### PR TITLE
[Java] add nullable annotation to pojo template for non-required fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -145,6 +145,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "com.sun.jersey:jersey-client:$jersey_version"
     compile "com.sun.jersey.contribs:jersey-multipart:$jersey_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -133,6 +133,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "io.github.openfeign:feign-core:$feign_version"
     compile "io.github.openfeign:feign-jackson:$feign_version"
     compile "io.github.openfeign:feign-slf4j:$feign_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -199,6 +199,13 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        
         <!-- HTTP client: Netflix Feign -->
         <dependency>
             <groupId>io.github.openfeign</groupId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -133,6 +133,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "com.google.api-client:google-api-client:${google_api_client_version}"
     compile "org.glassfish.jersey.core:jersey-common:${jersey_common_version}"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
@@ -219,6 +219,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <!-- HTTP client: google-api-client -->
         <dependency>
             <groupId>com.google.api-client</groupId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -137,6 +137,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.glassfish.jersey.core:jersey-client:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-multipart:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jersey_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -229,6 +229,13 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        
         <!-- HTTP client: jersey-client -->
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -127,6 +127,7 @@ if(hasProperty('target') && target == 'android') {
 
 dependencies {
     compile 'io.swagger:swagger-annotations:1.5.22'
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile 'com.squareup.okhttp3:okhttp:3.14.2'
     compile 'com.squareup.okhttp3:logging-interceptor:3.14.2'
     compile 'com.google.code.gson:gson:2.8.5'

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pom.mustache
@@ -207,6 +207,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -111,6 +111,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "io.rest-assured:scala-support:$rest_assured_version"
     compile "io.gsonfire:gson-fire:$gson_fire_version"
 {{#joda}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
@@ -206,6 +206,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -135,6 +135,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.jboss.resteasy:resteasy-client:$resteasy_version"
     compile "org.jboss.resteasy:resteasy-multipart-provider:$resteasy_version"
     compile "org.jboss.resteasy:resteasy-jackson2-provider:$resteasy_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -179,6 +179,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <!-- HTTP client: jersey-client -->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -132,6 +132,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.springframework:spring-web:$spring_web_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -219,6 +219,13 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
 
         <!-- HTTP client: Spring RestTemplate -->
         <dependency>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
@@ -120,6 +120,7 @@ ext {
 
 dependencies {
     compile "com.squareup.okhttp:okhttp:$okhttp_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "com.squareup.retrofit:retrofit:$retrofit_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
     compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/pom.mustache
@@ -219,6 +219,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.squareup.retrofit</groupId>
             <artifactId>retrofit</artifactId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -166,6 +166,7 @@ dependencies {
     compile "io.reactivex.rxjava2:rxjava:$rx_java_version"
     {{/useRxJava2}}
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile ("org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"){
         exclude group:'org.apache.oltu.oauth2' , module: 'org.apache.oltu.oauth2.common'
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -198,6 +198,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-gson</artifactId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/build.gradle.mustache
@@ -36,6 +36,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "io.vertx:vertx-web-client:$vertx_version"
     compile "io.vertx:vertx-rx-java:$vertx_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -208,6 +208,13 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        
         <!-- Vertx -->
         <dependency>
             <groupId>io.vertx</groupId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -72,6 +72,13 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
 
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -129,6 +129,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{/maximum}}
    * @return {{name}}
   **/
+{{^required}}  @javax.annotation.Nullable {{/required}}
 {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}

--- a/modules/openapi-generator/src/main/resources/Java/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pom.mustache
@@ -220,6 +220,14 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+
+
         <!-- HTTP client: jersey-client -->
         <dependency>
             <groupId>com.sun.jersey</groupId>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-cdi/pom.mustache
@@ -77,6 +77,13 @@
             <version>[1.5.3,1.5.16]</version>
         </dependency>
         
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        
 {{#useBeanValidation}}
        <!-- Bean Validation API support -->
        <dependency>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/resteasy/pom.mustache
@@ -71,6 +71,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
@@ -88,6 +88,12 @@
       <version>1.5.3</version>
     </dependency>
     {{/useSwaggerAnnotations}}
+    <!-- @Nullable annotation -->
+    <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -111,6 +111,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>1.5.14</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -47,6 +47,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-mvc/pom.mustache
@@ -177,6 +177,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>1.5.14</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>

--- a/modules/openapi-generator/src/main/resources/android/libraries/volley/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/android/libraries/volley/pom.mustache
@@ -11,6 +11,12 @@
       <artifactId>swagger-annotations</artifactId>
       <version>${swagger-annotations-version}</version>
     </dependency>
+    <!-- @Nullable annotation -->
+    <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.2</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>

--- a/modules/openapi-generator/src/main/resources/android/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/android/pom.mustache
@@ -131,6 +131,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/modules/openapi-generator/src/main/resources/java-undertow-server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-undertow-server/pom.mustache
@@ -108,6 +108,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${version.swagger}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom.mustache
@@ -105,6 +105,12 @@
             <version>1.5.21</version>
         </dependency>
         {{/swaggerAnnotations}}
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>

--- a/samples/client/petstore/android/httpclient/pom.xml
+++ b/samples/client/petstore/android/httpclient/pom.xml
@@ -131,6 +131,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -107,6 +107,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "io.github.openfeign:feign-core:$feign_version"
     compile "io.github.openfeign:feign-jackson:$feign_version"
     compile "io.github.openfeign:feign-slf4j:$feign_version"

--- a/samples/client/petstore/java/feign/pom.xml
+++ b/samples/client/petstore/java/feign/pom.xml
@@ -192,6 +192,13 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        
         <!-- HTTP client: Netflix Feign -->
         <dependency>
             <groupId>io.github.openfeign</groupId>

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -106,6 +107,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -158,6 +161,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -184,6 +188,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -210,6 +215,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -236,6 +242,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -262,6 +269,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -280,6 +288,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -298,6 +307,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -316,6 +326,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
@@ -49,6 +49,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -67,6 +68,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -55,6 +55,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -81,6 +82,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -107,6 +109,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,6 +53,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -71,6 +72,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -89,6 +91,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -107,6 +110,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -125,6 +129,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -143,6 +148,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -38,6 +38,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
@@ -41,6 +41,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -39,6 +39,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
@@ -38,6 +38,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -38,6 +38,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -113,6 +113,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -139,6 +140,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -195,6 +195,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -213,6 +214,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -231,6 +233,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -249,6 +252,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -267,6 +271,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -43,6 +43,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -69,6 +70,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -81,6 +81,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -101,6 +102,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -119,6 +121,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -139,6 +142,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -159,6 +163,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -179,6 +184,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -197,6 +203,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -215,6 +222,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -233,6 +241,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -251,6 +260,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -269,6 +279,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -287,6 +298,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -305,6 +317,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -36,6 +36,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -45,6 +46,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -119,6 +120,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -145,6 +147,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -171,6 +174,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -94,6 +96,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,6 +42,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -62,6 +63,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -80,6 +82,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -61,6 +62,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -75,6 +77,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -88,6 +91,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -39,6 +39,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -109,6 +110,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -127,6 +129,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -145,6 +148,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -163,6 +167,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -181,6 +186,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isComplete() {
     return complete;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -63,6 +64,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -81,6 +83,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
@@ -94,6 +94,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -112,6 +113,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -130,6 +132,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -153,6 +156,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -179,6 +183,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -197,6 +202,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -36,6 +36,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -38,6 +38,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -53,6 +53,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean isBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -53,6 +53,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean isBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
@@ -59,6 +59,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -77,6 +78,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -95,6 +97,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -113,6 +116,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -131,6 +135,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -149,6 +154,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -167,6 +173,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -185,6 +192,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -125,6 +125,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -143,6 +144,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -161,6 +163,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -179,6 +182,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
@@ -205,6 +209,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -223,6 +228,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -241,6 +247,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -259,6 +266,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -277,6 +285,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isNameBoolean() {
     return nameBoolean;
@@ -303,6 +312,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -329,6 +339,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -347,6 +358,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -365,6 +377,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -383,6 +396,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -401,6 +415,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
@@ -427,6 +442,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -453,6 +469,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -471,6 +488,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -489,6 +507,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -507,6 +526,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -525,6 +545,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
@@ -551,6 +572,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -577,6 +599,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -595,6 +618,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -613,6 +637,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -631,6 +656,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -649,6 +675,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -675,6 +702,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -701,6 +729,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/feign10x/build.gradle
+++ b/samples/client/petstore/java/feign10x/build.gradle
@@ -107,6 +107,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "io.github.openfeign:feign-core:$feign_version"
     compile "io.github.openfeign:feign-jackson:$feign_version"
     compile "io.github.openfeign:feign-slf4j:$feign_version"

--- a/samples/client/petstore/java/feign10x/pom.xml
+++ b/samples/client/petstore/java/feign10x/pom.xml
@@ -192,6 +192,13 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        
         <!-- HTTP client: Netflix Feign -->
         <dependency>
             <groupId>io.github.openfeign</groupId>

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -106,6 +107,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -158,6 +161,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -184,6 +188,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -210,6 +215,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -236,6 +242,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -262,6 +269,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -280,6 +288,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -298,6 +307,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -316,6 +326,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Animal.java
@@ -49,6 +49,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -67,6 +68,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -55,6 +55,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -81,6 +82,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -107,6 +109,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,6 +53,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -71,6 +72,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -89,6 +91,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -107,6 +110,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -125,6 +129,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -143,6 +148,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -38,6 +38,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Category.java
@@ -41,6 +41,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -39,6 +39,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Client.java
@@ -38,6 +38,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -38,6 +38,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -113,6 +113,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -139,6 +140,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -195,6 +195,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -213,6 +214,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -231,6 +233,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -249,6 +252,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -267,6 +271,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -43,6 +43,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -69,6 +70,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -81,6 +81,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -101,6 +102,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -119,6 +121,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -139,6 +142,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -159,6 +163,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -179,6 +184,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -197,6 +203,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -215,6 +222,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -233,6 +241,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -251,6 +260,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -269,6 +279,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -287,6 +298,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -305,6 +317,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -36,6 +36,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -45,6 +46,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -119,6 +120,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -145,6 +147,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -171,6 +174,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -94,6 +96,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,6 +42,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -62,6 +63,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -80,6 +82,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -61,6 +62,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -75,6 +77,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -88,6 +91,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -39,6 +39,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -109,6 +110,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -127,6 +129,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -145,6 +148,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -163,6 +167,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -181,6 +186,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isComplete() {
     return complete;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -63,6 +64,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -81,6 +83,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Pet.java
@@ -94,6 +94,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -112,6 +113,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -130,6 +132,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -153,6 +156,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -179,6 +183,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -197,6 +202,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -36,6 +36,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -38,6 +38,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -53,6 +53,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean isBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -53,6 +53,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean isBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/User.java
@@ -59,6 +59,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -77,6 +78,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -95,6 +97,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -113,6 +116,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -131,6 +135,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -149,6 +154,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -167,6 +173,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -185,6 +192,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -125,6 +125,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -143,6 +144,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -161,6 +163,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -179,6 +182,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
@@ -205,6 +209,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -223,6 +228,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -241,6 +247,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -259,6 +266,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -277,6 +285,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isNameBoolean() {
     return nameBoolean;
@@ -303,6 +312,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -329,6 +339,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -347,6 +358,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -365,6 +377,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -383,6 +396,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -401,6 +415,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
@@ -427,6 +442,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -453,6 +469,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -471,6 +488,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -489,6 +507,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -507,6 +526,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -525,6 +545,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
@@ -551,6 +572,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -577,6 +599,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -595,6 +618,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -613,6 +637,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -631,6 +656,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -649,6 +675,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -675,6 +702,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -701,6 +729,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/google-api-client/build.gradle
+++ b/samples/client/petstore/java/google-api-client/build.gradle
@@ -107,6 +107,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "com.google.api-client:google-api-client:${google_api_client_version}"
     compile "org.glassfish.jersey.core:jersey-common:${jersey_common_version}"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/samples/client/petstore/java/google-api-client/pom.xml
+++ b/samples/client/petstore/java/google-api-client/pom.xml
@@ -200,6 +200,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <!-- HTTP client: google-api-client -->
         <dependency>
             <groupId>com.google.api-client</groupId>

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -106,6 +107,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -158,6 +161,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -184,6 +188,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -210,6 +215,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -236,6 +242,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -262,6 +269,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -280,6 +288,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -298,6 +307,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -316,6 +326,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
@@ -49,6 +49,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -67,6 +68,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -55,6 +55,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -81,6 +82,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -107,6 +109,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,6 +53,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -71,6 +72,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -89,6 +91,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -107,6 +110,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -125,6 +129,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -143,6 +148,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -38,6 +38,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
@@ -41,6 +41,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -39,6 +39,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
@@ -38,6 +38,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -38,6 +38,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -113,6 +113,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -139,6 +140,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -195,6 +195,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -213,6 +214,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -231,6 +233,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -249,6 +252,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -267,6 +271,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -43,6 +43,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -69,6 +70,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -81,6 +81,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -101,6 +102,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -119,6 +121,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -139,6 +142,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -159,6 +163,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -179,6 +184,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -197,6 +203,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -215,6 +222,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -233,6 +241,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -251,6 +260,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -269,6 +279,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -287,6 +298,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -305,6 +317,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -36,6 +36,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -45,6 +46,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -119,6 +120,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -145,6 +147,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -171,6 +174,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -94,6 +96,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,6 +42,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -62,6 +63,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -80,6 +82,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -61,6 +62,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -75,6 +77,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -88,6 +91,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -39,6 +39,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -109,6 +110,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -127,6 +129,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -145,6 +148,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -163,6 +167,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -181,6 +186,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -63,6 +64,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -81,6 +83,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
@@ -94,6 +94,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -112,6 +113,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -130,6 +132,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -153,6 +156,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -179,6 +183,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -197,6 +202,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -36,6 +36,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -38,6 +38,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -53,6 +53,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -53,6 +53,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
@@ -59,6 +59,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -77,6 +78,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -95,6 +97,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -113,6 +116,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -131,6 +135,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -149,6 +154,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -167,6 +173,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -185,6 +192,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -125,6 +125,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -143,6 +144,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -161,6 +163,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -179,6 +182,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -205,6 +209,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -223,6 +228,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -241,6 +247,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -259,6 +266,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -277,6 +285,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -303,6 +312,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -329,6 +339,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -347,6 +358,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -365,6 +377,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -383,6 +396,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -401,6 +415,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -427,6 +442,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -453,6 +469,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -471,6 +488,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -489,6 +507,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -507,6 +526,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -525,6 +545,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -551,6 +572,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -577,6 +599,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -595,6 +618,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -613,6 +637,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -631,6 +656,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -649,6 +675,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -675,6 +702,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -701,6 +729,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/jersey1/build.gradle
+++ b/samples/client/petstore/java/jersey1/build.gradle
@@ -121,6 +121,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "com.sun.jersey:jersey-client:$jersey_version"
     compile "com.sun.jersey.contribs:jersey-multipart:$jersey_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/samples/client/petstore/java/jersey1/pom.xml
+++ b/samples/client/petstore/java/jersey1/pom.xml
@@ -201,6 +201,14 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+
+
         <!-- HTTP client: jersey-client -->
         <dependency>
             <groupId>com.sun.jersey</groupId>

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -106,6 +107,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -158,6 +161,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -184,6 +188,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -210,6 +215,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -236,6 +242,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -262,6 +269,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -280,6 +288,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -298,6 +307,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -316,6 +326,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
@@ -49,6 +49,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -67,6 +68,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -55,6 +55,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -81,6 +82,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -107,6 +109,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,6 +53,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -71,6 +72,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -89,6 +91,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -107,6 +110,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -125,6 +129,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -143,6 +148,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -38,6 +38,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
@@ -41,6 +41,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -39,6 +39,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
@@ -38,6 +38,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -38,6 +38,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -113,6 +113,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -139,6 +140,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -195,6 +195,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -213,6 +214,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -231,6 +233,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -249,6 +252,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -267,6 +271,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -43,6 +43,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -69,6 +70,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -81,6 +81,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -101,6 +102,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -119,6 +121,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -139,6 +142,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -159,6 +163,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -179,6 +184,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -197,6 +203,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -215,6 +222,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -233,6 +241,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -251,6 +260,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -269,6 +279,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -287,6 +298,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -305,6 +317,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -36,6 +36,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -45,6 +46,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -119,6 +120,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -145,6 +147,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -171,6 +174,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -94,6 +96,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,6 +42,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -62,6 +63,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -80,6 +82,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -61,6 +62,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -75,6 +77,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -88,6 +91,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -39,6 +39,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -109,6 +110,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -127,6 +129,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -145,6 +148,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -163,6 +167,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -181,6 +186,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -63,6 +64,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -81,6 +83,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
@@ -94,6 +94,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -112,6 +113,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -130,6 +132,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -153,6 +156,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -179,6 +183,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -197,6 +202,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -36,6 +36,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -38,6 +38,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -53,6 +53,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -53,6 +53,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
@@ -59,6 +59,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -77,6 +78,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -95,6 +97,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -113,6 +116,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -131,6 +135,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -149,6 +154,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -167,6 +173,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -185,6 +192,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -125,6 +125,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -143,6 +144,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -161,6 +163,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -179,6 +182,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -205,6 +209,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -223,6 +228,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -241,6 +247,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -259,6 +266,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -277,6 +285,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -303,6 +312,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -329,6 +339,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -347,6 +358,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -365,6 +377,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -383,6 +396,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -401,6 +415,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -427,6 +442,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -453,6 +469,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -471,6 +488,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -489,6 +507,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -507,6 +526,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -525,6 +545,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -551,6 +572,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -577,6 +599,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -595,6 +618,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -613,6 +637,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -631,6 +656,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -649,6 +675,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -675,6 +702,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -701,6 +729,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -39,6 +39,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -39,6 +39,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -79,6 +79,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -105,6 +106,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -131,6 +133,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -157,6 +160,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -183,6 +187,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -209,6 +214,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -235,6 +241,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -261,6 +268,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -279,6 +287,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -297,6 +306,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -315,6 +325,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -39,6 +39,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -39,6 +39,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -39,6 +39,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Animal.java
@@ -48,6 +48,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -66,6 +67,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -48,6 +48,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -48,6 +48,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -54,6 +54,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -80,6 +81,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -106,6 +108,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -52,6 +52,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -70,6 +71,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -88,6 +90,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -106,6 +109,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -124,6 +128,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -142,6 +147,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Cat.java
@@ -39,6 +39,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -37,6 +37,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Category.java
@@ -40,6 +40,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -58,6 +59,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -38,6 +38,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Client.java
@@ -37,6 +37,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Dog.java
@@ -39,6 +39,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -37,6 +37,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -112,6 +112,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -138,6 +139,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -194,6 +194,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -212,6 +213,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -230,6 +232,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -248,6 +251,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -266,6 +270,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -42,6 +42,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -68,6 +69,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -80,6 +80,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -100,6 +101,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -118,6 +120,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -138,6 +141,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -158,6 +162,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -178,6 +183,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -196,6 +202,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -214,6 +221,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -232,6 +240,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -250,6 +259,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -268,6 +278,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -286,6 +297,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -304,6 +316,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -35,6 +35,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -44,6 +45,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MapTest.java
@@ -92,6 +92,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -118,6 +119,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -144,6 +146,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -170,6 +173,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -49,6 +49,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -67,6 +68,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -93,6 +95,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -41,6 +41,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -59,6 +60,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -43,6 +43,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -61,6 +62,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -79,6 +81,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -38,6 +38,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Name.java
@@ -47,6 +47,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -74,6 +76,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -87,6 +90,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -38,6 +38,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Order.java
@@ -90,6 +90,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -108,6 +109,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -126,6 +128,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -144,6 +147,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -162,6 +166,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -180,6 +185,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isComplete() {
     return complete;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -44,6 +44,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -62,6 +63,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -80,6 +82,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Pet.java
@@ -93,6 +93,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -111,6 +112,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -129,6 +131,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -152,6 +155,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -178,6 +182,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -196,6 +201,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -35,6 +35,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -49,6 +50,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -37,6 +37,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Tag.java
@@ -40,6 +40,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -58,6 +59,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -52,6 +52,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -70,6 +71,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -88,6 +90,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -106,6 +109,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean isBoolItem() {
     return boolItem;
@@ -129,6 +133,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -52,6 +52,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -70,6 +71,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -88,6 +90,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -106,6 +109,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean isBoolItem() {
     return boolItem;
@@ -129,6 +133,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/User.java
@@ -58,6 +58,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -76,6 +77,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -94,6 +96,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -112,6 +115,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -130,6 +134,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -148,6 +153,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -166,6 +172,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -184,6 +191,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -124,6 +124,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -142,6 +143,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -160,6 +162,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -178,6 +181,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
@@ -204,6 +208,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -222,6 +227,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -240,6 +246,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -258,6 +265,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -276,6 +284,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isNameBoolean() {
     return nameBoolean;
@@ -302,6 +311,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -328,6 +338,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -346,6 +357,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -364,6 +376,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -382,6 +395,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -400,6 +414,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
@@ -426,6 +441,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -452,6 +468,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -470,6 +487,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -488,6 +506,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -506,6 +525,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -524,6 +544,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
@@ -550,6 +571,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -576,6 +598,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -594,6 +617,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -612,6 +636,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -630,6 +655,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -648,6 +674,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -674,6 +701,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -700,6 +728,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -103,6 +103,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.glassfish.jersey.core:jersey-client:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-multipart:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jersey_version"

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -106,6 +107,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -158,6 +161,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -184,6 +188,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -210,6 +215,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -236,6 +242,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -262,6 +269,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -280,6 +288,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -298,6 +307,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -316,6 +326,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -49,6 +49,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -67,6 +68,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -55,6 +55,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -81,6 +82,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -107,6 +109,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,6 +53,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -71,6 +72,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -89,6 +91,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -107,6 +110,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -125,6 +129,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -143,6 +148,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -38,6 +38,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
@@ -41,6 +41,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -39,6 +39,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
@@ -38,6 +38,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -38,6 +38,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -113,6 +113,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -139,6 +140,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -195,6 +195,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -213,6 +214,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -231,6 +233,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -249,6 +252,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -267,6 +271,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -43,6 +43,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -69,6 +70,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -81,6 +81,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -101,6 +102,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -119,6 +121,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -139,6 +142,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -159,6 +163,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -179,6 +184,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -197,6 +203,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -215,6 +222,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -233,6 +241,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -251,6 +260,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -269,6 +279,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -287,6 +298,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -305,6 +317,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -36,6 +36,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -45,6 +46,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -119,6 +120,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -145,6 +147,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -171,6 +174,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -94,6 +96,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,6 +42,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -62,6 +63,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -80,6 +82,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -61,6 +62,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -75,6 +77,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -88,6 +91,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -39,6 +39,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -109,6 +110,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -127,6 +129,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -145,6 +148,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -163,6 +167,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -181,6 +186,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -63,6 +64,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -81,6 +83,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
@@ -94,6 +94,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -112,6 +113,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -130,6 +132,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -153,6 +156,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -179,6 +183,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -197,6 +202,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -36,6 +36,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -38,6 +38,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -53,6 +53,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -53,6 +53,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
@@ -59,6 +59,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -77,6 +78,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -95,6 +97,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -113,6 +116,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -131,6 +135,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -149,6 +154,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -167,6 +173,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -185,6 +192,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -125,6 +125,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -143,6 +144,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -161,6 +163,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -179,6 +182,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -205,6 +209,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -223,6 +228,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -241,6 +247,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -259,6 +266,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -277,6 +285,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -303,6 +312,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -329,6 +339,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -347,6 +358,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -365,6 +377,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -383,6 +396,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -401,6 +415,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -427,6 +442,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -453,6 +469,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -471,6 +488,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -489,6 +507,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -507,6 +526,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -525,6 +545,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -551,6 +572,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -577,6 +599,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -595,6 +618,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -613,6 +637,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -631,6 +656,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -649,6 +675,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -675,6 +702,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -701,6 +729,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/jersey2/build.gradle
+++ b/samples/client/petstore/java/jersey2/build.gradle
@@ -104,6 +104,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.glassfish.jersey.core:jersey-client:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-multipart:$jersey_version"
     compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jersey_version"

--- a/samples/client/petstore/java/jersey2/pom.xml
+++ b/samples/client/petstore/java/jersey2/pom.xml
@@ -210,6 +210,13 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        
         <!-- HTTP client: jersey-client -->
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -106,6 +107,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -158,6 +161,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -184,6 +188,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -210,6 +215,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -236,6 +242,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -262,6 +269,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -280,6 +288,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -298,6 +307,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -316,6 +326,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Animal.java
@@ -49,6 +49,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -67,6 +68,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -55,6 +55,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -81,6 +82,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -107,6 +109,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,6 +53,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -71,6 +72,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -89,6 +91,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -107,6 +110,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -125,6 +129,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -143,6 +148,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -38,6 +38,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Category.java
@@ -41,6 +41,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -39,6 +39,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Client.java
@@ -38,6 +38,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -38,6 +38,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -113,6 +113,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -139,6 +140,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -195,6 +195,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -213,6 +214,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -231,6 +233,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -249,6 +252,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -267,6 +271,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -43,6 +43,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -69,6 +70,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -81,6 +81,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -101,6 +102,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -119,6 +121,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -139,6 +142,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -159,6 +163,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -179,6 +184,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -197,6 +203,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -215,6 +222,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -233,6 +241,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -251,6 +260,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -269,6 +279,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -287,6 +298,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -305,6 +317,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -36,6 +36,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -45,6 +46,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -119,6 +120,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -145,6 +147,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -171,6 +174,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -94,6 +96,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,6 +42,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -62,6 +63,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -80,6 +82,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -61,6 +62,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -75,6 +77,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -88,6 +91,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -39,6 +39,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -109,6 +110,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -127,6 +129,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -145,6 +148,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -163,6 +167,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -181,6 +186,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -63,6 +64,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -81,6 +83,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Pet.java
@@ -94,6 +94,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -112,6 +113,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -130,6 +132,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -153,6 +156,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -179,6 +183,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -197,6 +202,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -36,6 +36,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -38,6 +38,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -53,6 +53,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -53,6 +53,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/User.java
@@ -59,6 +59,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -77,6 +78,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -95,6 +97,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -113,6 +116,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -131,6 +135,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -149,6 +154,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -167,6 +173,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -185,6 +192,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -125,6 +125,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -143,6 +144,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -161,6 +163,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -179,6 +182,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -205,6 +209,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -223,6 +228,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -241,6 +247,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -259,6 +266,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -277,6 +285,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -303,6 +312,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -329,6 +339,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -347,6 +358,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -365,6 +377,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -383,6 +396,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -401,6 +415,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -427,6 +442,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -453,6 +469,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -471,6 +488,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -489,6 +507,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -507,6 +526,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -525,6 +545,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -551,6 +572,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -577,6 +599,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -595,6 +618,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -613,6 +637,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -631,6 +656,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -649,6 +675,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -675,6 +702,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -701,6 +729,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
@@ -99,6 +99,7 @@ if(hasProperty('target') && target == 'android') {
 
 dependencies {
     compile 'io.swagger:swagger-annotations:1.5.22'
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile 'com.squareup.okhttp3:okhttp:3.14.2'
     compile 'com.squareup.okhttp3:logging-interceptor:3.14.2'
     compile 'com.google.code.gson:gson:2.8.5'

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/pom.xml
@@ -200,6 +200,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -49,6 +49,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -50,6 +50,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -49,6 +49,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -98,6 +98,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -124,6 +125,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -150,6 +152,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -176,6 +179,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -202,6 +206,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -228,6 +233,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -254,6 +260,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -280,6 +287,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -298,6 +306,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -316,6 +325,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -334,6 +344,7 @@ public class AdditionalPropertiesClass implements Parcelable {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -49,6 +49,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -50,6 +50,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -49,6 +49,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -49,6 +49,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Animal.java
@@ -52,6 +52,7 @@ public class Animal implements Parcelable {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -70,6 +71,7 @@ public class Animal implements Parcelable {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -57,6 +57,7 @@ public class ArrayOfArrayOfNumberOnly implements Parcelable {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -57,6 +57,7 @@ public class ArrayOfNumberOnly implements Parcelable {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -65,6 +65,7 @@ public class ArrayTest implements Parcelable {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -91,6 +92,7 @@ public class ArrayTest implements Parcelable {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -117,6 +119,7 @@ public class ArrayTest implements Parcelable {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -66,6 +66,7 @@ public class Capitalization implements Parcelable {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -84,6 +85,7 @@ public class Capitalization implements Parcelable {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -102,6 +104,7 @@ public class Capitalization implements Parcelable {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -120,6 +123,7 @@ public class Capitalization implements Parcelable {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -138,6 +142,7 @@ public class Capitalization implements Parcelable {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -156,6 +161,7 @@ public class Capitalization implements Parcelable {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Cat.java
@@ -49,6 +49,7 @@ public class Cat extends Animal implements Parcelable {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -46,6 +46,7 @@ public class CatAllOf implements Parcelable {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Category.java
@@ -50,6 +50,7 @@ public class Category implements Parcelable {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -68,6 +69,7 @@ public class Category implements Parcelable {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -47,6 +47,7 @@ public class ClassModel implements Parcelable {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Client.java
@@ -46,6 +46,7 @@ public class Client implements Parcelable {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Dog.java
@@ -49,6 +49,7 @@ public class Dog extends Animal implements Parcelable {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -46,6 +46,7 @@ public class DogAllOf implements Parcelable {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -146,6 +146,7 @@ public class EnumArrays implements Parcelable {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -172,6 +173,7 @@ public class EnumArrays implements Parcelable {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -255,6 +255,7 @@ public class EnumTest implements Parcelable {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -273,6 +274,7 @@ public class EnumTest implements Parcelable {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -291,6 +293,7 @@ public class EnumTest implements Parcelable {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -309,6 +312,7 @@ public class EnumTest implements Parcelable {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -327,6 +331,7 @@ public class EnumTest implements Parcelable {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -52,6 +52,7 @@ public class FileSchemaTestClass implements Parcelable {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -78,6 +79,7 @@ public class FileSchemaTestClass implements Parcelable {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -101,6 +101,7 @@ public class FormatTest implements Parcelable {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -121,6 +122,7 @@ public class FormatTest implements Parcelable {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -139,6 +141,7 @@ public class FormatTest implements Parcelable {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -159,6 +162,7 @@ public class FormatTest implements Parcelable {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -179,6 +183,7 @@ public class FormatTest implements Parcelable {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -199,6 +204,7 @@ public class FormatTest implements Parcelable {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -217,6 +223,7 @@ public class FormatTest implements Parcelable {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -235,6 +242,7 @@ public class FormatTest implements Parcelable {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -253,6 +261,7 @@ public class FormatTest implements Parcelable {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -271,6 +280,7 @@ public class FormatTest implements Parcelable {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -289,6 +299,7 @@ public class FormatTest implements Parcelable {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -307,6 +318,7 @@ public class FormatTest implements Parcelable {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -325,6 +337,7 @@ public class FormatTest implements Parcelable {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly implements Parcelable {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -54,6 +55,7 @@ public class HasOnlyReadOnly implements Parcelable {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MapTest.java
@@ -116,6 +116,7 @@ public class MapTest implements Parcelable {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -142,6 +143,7 @@ public class MapTest implements Parcelable {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -168,6 +170,7 @@ public class MapTest implements Parcelable {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -194,6 +197,7 @@ public class MapTest implements Parcelable {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -60,6 +60,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass implements Parcelable {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -78,6 +79,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass implements Parcelable {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -104,6 +106,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass implements Parcelable {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -51,6 +51,7 @@ public class Model200Response implements Parcelable {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -69,6 +70,7 @@ public class Model200Response implements Parcelable {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -54,6 +54,7 @@ public class ModelApiResponse implements Parcelable {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -72,6 +73,7 @@ public class ModelApiResponse implements Parcelable {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -90,6 +92,7 @@ public class ModelApiResponse implements Parcelable {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -47,6 +47,7 @@ public class ModelReturn implements Parcelable {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Name.java
@@ -59,6 +59,7 @@ public class Name implements Parcelable {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -72,6 +73,7 @@ public class Name implements Parcelable {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -86,6 +88,7 @@ public class Name implements Parcelable {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -99,6 +102,7 @@ public class Name implements Parcelable {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -47,6 +47,7 @@ public class NumberOnly implements Parcelable {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
@@ -116,6 +116,7 @@ public class Order implements Parcelable {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -134,6 +135,7 @@ public class Order implements Parcelable {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -152,6 +154,7 @@ public class Order implements Parcelable {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -170,6 +173,7 @@ public class Order implements Parcelable {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -188,6 +192,7 @@ public class Order implements Parcelable {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -206,6 +211,7 @@ public class Order implements Parcelable {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -55,6 +55,7 @@ public class OuterComposite implements Parcelable {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -73,6 +74,7 @@ public class OuterComposite implements Parcelable {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -91,6 +93,7 @@ public class OuterComposite implements Parcelable {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Pet.java
@@ -119,6 +119,7 @@ public class Pet implements Parcelable {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -137,6 +138,7 @@ public class Pet implements Parcelable {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -155,6 +157,7 @@ public class Pet implements Parcelable {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -178,6 +181,7 @@ public class Pet implements Parcelable {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -204,6 +208,7 @@ public class Pet implements Parcelable {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -222,6 +227,7 @@ public class Pet implements Parcelable {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -45,6 +45,7 @@ public class ReadOnlyFirst implements Parcelable {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -59,6 +60,7 @@ public class ReadOnlyFirst implements Parcelable {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -46,6 +46,7 @@ public class SpecialModelName implements Parcelable {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Tag.java
@@ -50,6 +50,7 @@ public class Tag implements Parcelable {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -68,6 +69,7 @@ public class Tag implements Parcelable {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -65,6 +65,7 @@ public class TypeHolderDefault implements Parcelable {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -83,6 +84,7 @@ public class TypeHolderDefault implements Parcelable {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -101,6 +103,7 @@ public class TypeHolderDefault implements Parcelable {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -119,6 +122,7 @@ public class TypeHolderDefault implements Parcelable {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -142,6 +146,7 @@ public class TypeHolderDefault implements Parcelable {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -65,6 +65,7 @@ public class TypeHolderExample implements Parcelable {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -83,6 +84,7 @@ public class TypeHolderExample implements Parcelable {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -101,6 +103,7 @@ public class TypeHolderExample implements Parcelable {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -119,6 +122,7 @@ public class TypeHolderExample implements Parcelable {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -142,6 +146,7 @@ public class TypeHolderExample implements Parcelable {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/User.java
@@ -74,6 +74,7 @@ public class User implements Parcelable {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -92,6 +93,7 @@ public class User implements Parcelable {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -110,6 +112,7 @@ public class User implements Parcelable {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -128,6 +131,7 @@ public class User implements Parcelable {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -146,6 +150,7 @@ public class User implements Parcelable {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -164,6 +169,7 @@ public class User implements Parcelable {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -182,6 +188,7 @@ public class User implements Parcelable {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -200,6 +207,7 @@ public class User implements Parcelable {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -161,6 +161,7 @@ public class XmlItem implements Parcelable {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -179,6 +180,7 @@ public class XmlItem implements Parcelable {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -197,6 +199,7 @@ public class XmlItem implements Parcelable {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -215,6 +218,7 @@ public class XmlItem implements Parcelable {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -241,6 +245,7 @@ public class XmlItem implements Parcelable {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -259,6 +264,7 @@ public class XmlItem implements Parcelable {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -277,6 +283,7 @@ public class XmlItem implements Parcelable {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -295,6 +302,7 @@ public class XmlItem implements Parcelable {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -313,6 +321,7 @@ public class XmlItem implements Parcelable {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -339,6 +348,7 @@ public class XmlItem implements Parcelable {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -365,6 +375,7 @@ public class XmlItem implements Parcelable {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -383,6 +394,7 @@ public class XmlItem implements Parcelable {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -401,6 +413,7 @@ public class XmlItem implements Parcelable {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -419,6 +432,7 @@ public class XmlItem implements Parcelable {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -437,6 +451,7 @@ public class XmlItem implements Parcelable {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -463,6 +478,7 @@ public class XmlItem implements Parcelable {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -489,6 +505,7 @@ public class XmlItem implements Parcelable {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -507,6 +524,7 @@ public class XmlItem implements Parcelable {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -525,6 +543,7 @@ public class XmlItem implements Parcelable {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -543,6 +562,7 @@ public class XmlItem implements Parcelable {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -561,6 +581,7 @@ public class XmlItem implements Parcelable {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -587,6 +608,7 @@ public class XmlItem implements Parcelable {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -613,6 +635,7 @@ public class XmlItem implements Parcelable {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -631,6 +654,7 @@ public class XmlItem implements Parcelable {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -649,6 +673,7 @@ public class XmlItem implements Parcelable {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -667,6 +692,7 @@ public class XmlItem implements Parcelable {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -685,6 +711,7 @@ public class XmlItem implements Parcelable {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -711,6 +738,7 @@ public class XmlItem implements Parcelable {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -737,6 +765,7 @@ public class XmlItem implements Parcelable {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -99,6 +99,7 @@ if(hasProperty('target') && target == 'android') {
 
 dependencies {
     compile 'io.swagger:swagger-annotations:1.5.22'
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile 'com.squareup.okhttp3:okhttp:3.14.2'
     compile 'com.squareup.okhttp3:logging-interceptor:3.14.2'
     compile 'com.google.code.gson:gson:2.8.5'

--- a/samples/client/petstore/java/okhttp-gson/pom.xml
+++ b/samples/client/petstore/java/okhttp-gson/pom.xml
@@ -200,6 +200,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -94,6 +94,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -120,6 +121,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -146,6 +148,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -172,6 +175,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -198,6 +202,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -250,6 +256,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -276,6 +283,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -294,6 +302,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -312,6 +321,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -330,6 +340,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
@@ -50,6 +50,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -68,6 +69,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -61,6 +61,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -87,6 +88,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -113,6 +115,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -62,6 +62,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -80,6 +81,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -98,6 +100,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -116,6 +119,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -134,6 +138,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -152,6 +157,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,6 +44,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -42,6 +42,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
@@ -46,6 +46,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -43,6 +43,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
@@ -42,6 +42,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
@@ -44,6 +44,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -42,6 +42,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -142,6 +142,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -168,6 +169,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -251,6 +251,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -269,6 +270,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -287,6 +289,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -305,6 +308,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -323,6 +327,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -74,6 +75,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -97,6 +97,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -117,6 +118,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -135,6 +137,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -155,6 +158,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -175,6 +179,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -195,6 +200,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -213,6 +219,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -231,6 +238,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -249,6 +257,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -267,6 +276,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -285,6 +295,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -303,6 +314,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -321,6 +333,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -41,6 +41,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -112,6 +112,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -138,6 +139,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -164,6 +166,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -190,6 +193,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -56,6 +56,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -74,6 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -47,6 +47,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -65,6 +66,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -50,6 +50,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -68,6 +69,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -86,6 +88,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
@@ -55,6 +55,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -68,6 +69,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -82,6 +84,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -95,6 +98,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -43,6 +43,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
@@ -112,6 +112,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -130,6 +131,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -148,6 +150,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -166,6 +169,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -184,6 +188,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -202,6 +207,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -51,6 +51,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -69,6 +70,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -87,6 +89,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
@@ -115,6 +115,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -133,6 +134,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -151,6 +153,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -174,6 +177,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -200,6 +204,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -218,6 +223,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -41,6 +41,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -55,6 +56,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
@@ -46,6 +46,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -61,6 +61,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -61,6 +61,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
@@ -70,6 +70,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -88,6 +89,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -106,6 +108,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -124,6 +127,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -142,6 +146,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -160,6 +165,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -178,6 +184,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -196,6 +203,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -157,6 +157,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -175,6 +176,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -193,6 +195,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -211,6 +214,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -237,6 +241,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -255,6 +260,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -273,6 +279,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -291,6 +298,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -309,6 +317,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -335,6 +344,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -361,6 +371,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -379,6 +390,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -397,6 +409,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -415,6 +428,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -433,6 +447,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -459,6 +474,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -485,6 +501,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -503,6 +520,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -521,6 +539,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -539,6 +558,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -557,6 +577,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -583,6 +604,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -609,6 +631,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -627,6 +650,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -645,6 +669,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -663,6 +688,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -681,6 +707,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -707,6 +734,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -733,6 +761,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/rest-assured/build.gradle
+++ b/samples/client/petstore/java/rest-assured/build.gradle
@@ -106,6 +106,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "io.rest-assured:scala-support:$rest_assured_version"
     compile "io.gsonfire:gson-fire:$gson_fire_version"
     compile "org.threeten:threetenbp:$threetenbp_version"

--- a/samples/client/petstore/java/rest-assured/pom.xml
+++ b/samples/client/petstore/java/rest-assured/pom.xml
@@ -199,6 +199,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -94,6 +94,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -120,6 +121,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -146,6 +148,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -172,6 +175,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -198,6 +202,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -250,6 +256,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -276,6 +283,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -294,6 +302,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -312,6 +321,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -330,6 +340,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
@@ -50,6 +50,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -68,6 +69,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -61,6 +61,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -87,6 +88,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -113,6 +115,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -62,6 +62,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -80,6 +81,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -98,6 +100,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -116,6 +119,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -134,6 +138,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -152,6 +157,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,6 +44,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -42,6 +42,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
@@ -46,6 +46,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -43,6 +43,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
@@ -42,6 +42,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
@@ -44,6 +44,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -42,6 +42,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -142,6 +142,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -168,6 +169,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -251,6 +251,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -269,6 +270,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -287,6 +289,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -305,6 +308,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -323,6 +327,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -74,6 +75,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -97,6 +97,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -117,6 +118,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -135,6 +137,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -155,6 +158,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -175,6 +179,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -195,6 +200,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -213,6 +219,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -231,6 +238,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -249,6 +257,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -267,6 +276,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -285,6 +295,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -303,6 +314,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -321,6 +333,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -41,6 +41,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
@@ -112,6 +112,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -138,6 +139,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -164,6 +166,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -190,6 +193,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -56,6 +56,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -74,6 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -47,6 +47,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -65,6 +66,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -50,6 +50,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -68,6 +69,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -86,6 +88,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
@@ -55,6 +55,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -68,6 +69,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -82,6 +84,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -95,6 +98,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -43,6 +43,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
@@ -112,6 +112,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -130,6 +131,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -148,6 +150,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -166,6 +169,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -184,6 +188,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -202,6 +207,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isComplete() {
     return complete;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -51,6 +51,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -69,6 +70,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -87,6 +89,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean isMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
@@ -115,6 +115,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -133,6 +134,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -151,6 +153,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -174,6 +177,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -200,6 +204,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -218,6 +223,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -41,6 +41,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -55,6 +56,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
@@ -46,6 +46,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -61,6 +61,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean isBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -61,6 +61,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean isBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
@@ -70,6 +70,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -88,6 +89,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -106,6 +108,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -124,6 +127,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -142,6 +146,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -160,6 +165,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -178,6 +184,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -196,6 +203,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -157,6 +157,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -175,6 +176,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -193,6 +195,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -211,6 +214,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
@@ -237,6 +241,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -255,6 +260,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -273,6 +279,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -291,6 +298,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -309,6 +317,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isNameBoolean() {
     return nameBoolean;
@@ -335,6 +344,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -361,6 +371,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -379,6 +390,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -397,6 +409,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -415,6 +428,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -433,6 +447,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
@@ -459,6 +474,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -485,6 +501,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -503,6 +520,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -521,6 +539,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -539,6 +558,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -557,6 +577,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
@@ -583,6 +604,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -609,6 +631,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -627,6 +650,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -645,6 +669,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -663,6 +688,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -681,6 +707,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -707,6 +734,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -733,6 +761,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/resteasy/build.gradle
+++ b/samples/client/petstore/java/resteasy/build.gradle
@@ -105,6 +105,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.jboss.resteasy:resteasy-client:$resteasy_version"
     compile "org.jboss.resteasy:resteasy-multipart-provider:$resteasy_version"
     compile "org.jboss.resteasy:resteasy-jackson2-provider:$resteasy_version"

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -106,6 +107,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -158,6 +161,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -184,6 +188,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -210,6 +215,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -236,6 +242,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -262,6 +269,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -280,6 +288,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -298,6 +307,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -316,6 +326,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
@@ -49,6 +49,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -67,6 +68,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -55,6 +55,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -81,6 +82,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -107,6 +109,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,6 +53,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -71,6 +72,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -89,6 +91,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -107,6 +110,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -125,6 +129,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -143,6 +148,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -38,6 +38,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
@@ -41,6 +41,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -39,6 +39,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
@@ -38,6 +38,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -38,6 +38,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -113,6 +113,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -139,6 +140,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -195,6 +195,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -213,6 +214,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -231,6 +233,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -249,6 +252,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -267,6 +271,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -43,6 +43,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -69,6 +70,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -81,6 +81,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -101,6 +102,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -119,6 +121,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -139,6 +142,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -159,6 +163,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -179,6 +184,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -197,6 +203,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -215,6 +222,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -233,6 +241,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -251,6 +260,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -269,6 +279,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -287,6 +298,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -305,6 +317,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -36,6 +36,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -45,6 +46,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -119,6 +120,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -145,6 +147,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -171,6 +174,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -94,6 +96,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,6 +42,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -62,6 +63,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -80,6 +82,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -61,6 +62,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -75,6 +77,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -88,6 +91,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -39,6 +39,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -109,6 +110,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -127,6 +129,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -145,6 +148,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -163,6 +167,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -181,6 +186,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -63,6 +64,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -81,6 +83,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
@@ -94,6 +94,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -112,6 +113,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -130,6 +132,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -153,6 +156,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -179,6 +183,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -197,6 +202,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -36,6 +36,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -38,6 +38,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -53,6 +53,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -53,6 +53,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
@@ -59,6 +59,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -77,6 +78,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -95,6 +97,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -113,6 +116,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -131,6 +135,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -149,6 +154,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -167,6 +173,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -185,6 +192,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -125,6 +125,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -143,6 +144,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -161,6 +163,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -179,6 +182,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -205,6 +209,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -223,6 +228,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -241,6 +247,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -259,6 +266,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -277,6 +285,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -303,6 +312,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -329,6 +339,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -347,6 +358,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -365,6 +377,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -383,6 +396,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -401,6 +415,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -427,6 +442,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -453,6 +469,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -471,6 +488,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -489,6 +507,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -507,6 +526,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -525,6 +545,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -551,6 +572,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -577,6 +599,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -595,6 +618,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -613,6 +637,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -631,6 +656,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -649,6 +675,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -675,6 +702,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -701,6 +729,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -106,6 +106,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.springframework:spring-web:$spring_web_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -48,6 +48,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -123,6 +123,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -149,6 +150,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -175,6 +177,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -201,6 +204,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -227,6 +231,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -253,6 +258,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -279,6 +285,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -305,6 +312,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -323,6 +331,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -341,6 +350,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -359,6 +369,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -48,6 +48,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -47,6 +47,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
@@ -58,6 +58,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -76,6 +77,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -58,6 +58,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -58,6 +58,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -72,6 +72,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -98,6 +99,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -124,6 +126,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -70,6 +70,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -88,6 +89,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -106,6 +108,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -124,6 +127,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -142,6 +146,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -160,6 +165,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
@@ -47,6 +47,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -45,6 +45,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
@@ -50,6 +50,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -68,6 +69,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -46,6 +46,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
@@ -45,6 +45,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
@@ -47,6 +47,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -45,6 +45,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -124,6 +124,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -150,6 +151,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -210,6 +210,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -228,6 +229,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -246,6 +248,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -264,6 +267,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -282,6 +286,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -54,6 +54,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -80,6 +81,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -112,6 +112,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -132,6 +133,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -150,6 +152,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -170,6 +173,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -190,6 +194,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -210,6 +215,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -228,6 +234,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -246,6 +253,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -264,6 +272,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -282,6 +291,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -300,6 +310,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -318,6 +329,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -336,6 +348,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -45,6 +45,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -54,6 +55,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
@@ -114,6 +114,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -140,6 +141,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -166,6 +168,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -192,6 +195,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -63,6 +63,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -81,6 +82,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -107,6 +109,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -51,6 +51,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -69,6 +70,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -55,6 +55,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -73,6 +74,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -91,6 +93,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -46,6 +46,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
@@ -61,6 +61,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -74,6 +75,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -88,6 +90,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -101,6 +104,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -46,6 +46,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
@@ -108,6 +108,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -126,6 +127,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -144,6 +146,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -162,6 +165,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -180,6 +184,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -198,6 +203,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -56,6 +56,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -74,6 +75,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -92,6 +94,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
@@ -121,6 +121,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -139,6 +140,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -157,6 +159,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -180,6 +183,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -206,6 +210,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -224,6 +229,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -45,6 +45,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -59,6 +60,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -45,6 +45,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
@@ -50,6 +50,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -68,6 +69,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -70,6 +70,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -88,6 +89,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -106,6 +108,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -124,6 +127,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -147,6 +151,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -70,6 +70,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -88,6 +89,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -106,6 +108,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -124,6 +127,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -147,6 +151,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
@@ -80,6 +80,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -98,6 +99,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -116,6 +118,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -134,6 +137,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -152,6 +156,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -170,6 +175,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -188,6 +194,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -206,6 +213,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -221,6 +221,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -239,6 +240,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -257,6 +259,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -275,6 +278,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -301,6 +305,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -319,6 +324,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -337,6 +343,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -355,6 +362,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -373,6 +381,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -399,6 +408,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -425,6 +435,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -443,6 +454,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -461,6 +473,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -479,6 +492,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -497,6 +511,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -523,6 +538,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -549,6 +565,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -567,6 +584,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -585,6 +603,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -603,6 +622,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -621,6 +641,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -647,6 +668,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -673,6 +695,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -691,6 +714,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -709,6 +733,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -727,6 +752,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -745,6 +771,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -771,6 +798,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -797,6 +825,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -106,6 +106,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "org.springframework:spring-web:$spring_web_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -106,6 +107,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -158,6 +161,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -184,6 +188,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -210,6 +215,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -236,6 +242,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -262,6 +269,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -280,6 +288,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -298,6 +307,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -316,6 +326,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
@@ -49,6 +49,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -67,6 +68,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -55,6 +55,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -81,6 +82,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -107,6 +109,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,6 +53,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -71,6 +72,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -89,6 +91,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -107,6 +110,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -125,6 +129,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -143,6 +148,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -38,6 +38,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
@@ -41,6 +41,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -39,6 +39,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
@@ -38,6 +38,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -38,6 +38,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -113,6 +113,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -139,6 +140,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -195,6 +195,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -213,6 +214,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -231,6 +233,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -249,6 +252,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -267,6 +271,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -43,6 +43,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -69,6 +70,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -81,6 +81,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -101,6 +102,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -119,6 +121,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -139,6 +142,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -159,6 +163,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -179,6 +184,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -197,6 +203,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -215,6 +222,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -233,6 +241,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -251,6 +260,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -269,6 +279,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -287,6 +298,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -305,6 +317,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -36,6 +36,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -45,6 +46,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -119,6 +120,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -145,6 +147,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -171,6 +174,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -94,6 +96,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,6 +42,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -62,6 +63,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -80,6 +82,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -61,6 +62,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -75,6 +77,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -88,6 +91,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -39,6 +39,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -109,6 +110,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -127,6 +129,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -145,6 +148,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -163,6 +167,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -181,6 +186,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -63,6 +64,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -81,6 +83,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
@@ -94,6 +94,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -112,6 +113,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -130,6 +132,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -153,6 +156,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -179,6 +183,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -197,6 +202,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -36,6 +36,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -38,6 +38,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -53,6 +53,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -53,6 +53,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
@@ -59,6 +59,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -77,6 +78,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -95,6 +97,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -113,6 +116,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -131,6 +135,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -149,6 +154,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -167,6 +173,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -185,6 +192,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -125,6 +125,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -143,6 +144,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -161,6 +163,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -179,6 +182,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -205,6 +209,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -223,6 +228,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -241,6 +247,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -259,6 +266,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -277,6 +285,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -303,6 +312,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -329,6 +339,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -347,6 +358,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -365,6 +377,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -383,6 +396,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -401,6 +415,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -427,6 +442,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -453,6 +469,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -471,6 +488,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -489,6 +507,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -507,6 +526,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -525,6 +545,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -551,6 +572,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -577,6 +599,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -595,6 +618,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -613,6 +637,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -631,6 +656,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -649,6 +675,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -675,6 +702,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -701,6 +729,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit/build.gradle
+++ b/samples/client/petstore/java/retrofit/build.gradle
@@ -105,6 +105,7 @@ ext {
 
 dependencies {
     compile "com.squareup.okhttp:okhttp:$okhttp_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "com.squareup.retrofit:retrofit:$retrofit_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
     compile "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -94,6 +94,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -120,6 +121,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -146,6 +148,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -172,6 +175,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -198,6 +202,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -250,6 +256,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -276,6 +283,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -294,6 +302,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -312,6 +321,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -330,6 +340,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Animal.java
@@ -50,6 +50,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -68,6 +69,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -61,6 +61,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -87,6 +88,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -113,6 +115,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -62,6 +62,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -80,6 +81,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -98,6 +100,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -116,6 +119,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -134,6 +138,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -152,6 +157,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,6 +44,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -42,6 +42,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Category.java
@@ -46,6 +46,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -43,6 +43,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Client.java
@@ -42,6 +42,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Dog.java
@@ -44,6 +44,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -42,6 +42,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -142,6 +142,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -168,6 +169,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -251,6 +251,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -269,6 +270,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -287,6 +289,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -305,6 +308,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -323,6 +327,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -74,6 +75,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -97,6 +97,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -117,6 +118,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -135,6 +137,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -155,6 +158,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -175,6 +179,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -195,6 +200,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -213,6 +219,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -231,6 +238,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -249,6 +257,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -267,6 +276,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -285,6 +295,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public DateTime getDateTime() {
     return dateTime;
@@ -303,6 +314,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -321,6 +333,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -41,6 +41,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MapTest.java
@@ -112,6 +112,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -138,6 +139,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -164,6 +166,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -190,6 +193,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -56,6 +56,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -74,6 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public DateTime getDateTime() {
     return dateTime;
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -47,6 +47,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -65,6 +66,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -50,6 +50,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -68,6 +69,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -86,6 +88,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Name.java
@@ -55,6 +55,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -68,6 +69,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -82,6 +84,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -95,6 +98,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -43,6 +43,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Order.java
@@ -112,6 +112,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -130,6 +131,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -148,6 +150,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -166,6 +169,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public DateTime getShipDate() {
     return shipDate;
@@ -184,6 +188,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -202,6 +207,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -51,6 +51,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -69,6 +70,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -87,6 +89,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Pet.java
@@ -115,6 +115,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -133,6 +134,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -151,6 +153,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -174,6 +177,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -200,6 +204,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -218,6 +223,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -41,6 +41,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -55,6 +56,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Tag.java
@@ -46,6 +46,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -61,6 +61,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -61,6 +61,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/User.java
@@ -70,6 +70,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -88,6 +89,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -106,6 +108,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -124,6 +127,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -142,6 +146,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -160,6 +165,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -178,6 +184,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -196,6 +203,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -157,6 +157,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -175,6 +176,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -193,6 +195,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -211,6 +214,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -237,6 +241,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -255,6 +260,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -273,6 +279,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -291,6 +298,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -309,6 +317,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -335,6 +344,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -361,6 +371,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -379,6 +390,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -397,6 +409,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -415,6 +428,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -433,6 +447,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -459,6 +474,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -485,6 +501,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -503,6 +520,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -521,6 +539,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -539,6 +558,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -557,6 +577,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -583,6 +604,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -609,6 +631,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -627,6 +650,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -645,6 +669,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -663,6 +688,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -681,6 +707,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -707,6 +734,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -733,6 +761,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2-play24/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play24/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     compile "com.squareup.retrofit2:converter-scalars:$retrofit_version"
     compile "com.squareup.retrofit2:converter-gson:$retrofit_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile ("org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"){
         exclude group:'org.apache.oltu.oauth2' , module: 'org.apache.oltu.oauth2.common'
     }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -82,6 +82,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -108,6 +109,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
@@ -135,6 +137,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -161,6 +164,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -187,6 +191,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
@@ -214,6 +219,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
@@ -241,6 +247,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
@@ -268,6 +275,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
@@ -287,6 +295,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
@@ -306,6 +315,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
@@ -325,6 +335,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Object getAnytype3() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Animal.java
@@ -51,6 +51,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
@@ -70,6 +71,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -51,6 +51,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -51,6 +51,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -57,6 +57,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -83,6 +84,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
@@ -110,6 +112,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -55,6 +55,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -73,6 +74,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -91,6 +93,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -109,6 +112,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -127,6 +131,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -145,6 +150,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Cat.java
@@ -42,6 +42,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -40,6 +40,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -61,6 +62,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public String getName() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -41,6 +41,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Client.java
@@ -40,6 +40,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Dog.java
@@ -42,6 +42,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -40,6 +40,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -115,6 +115,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -141,6 +142,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -197,6 +197,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -215,6 +216,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
@@ -234,6 +236,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -252,6 +255,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -270,6 +274,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -45,6 +45,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
@@ -72,6 +73,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -83,6 +83,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
  @Min(10) @Max(100)  @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -103,6 +104,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
  @Min(20) @Max(200)  @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -121,6 +123,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -141,6 +144,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @NotNull
   @Valid
  @DecimalMin("32.1") @DecimalMax("543.2")  @ApiModelProperty(required = true, value = "")
@@ -163,6 +167,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
  @DecimalMin("54.3") @DecimalMax("987.6")  @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -183,6 +188,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
  @DecimalMin("67.8") @DecimalMax("123.4")  @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -201,6 +207,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
  @Pattern(regexp="/[a-z]/i")  @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -219,6 +226,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @NotNull
  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
@@ -238,6 +246,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public File getBinary() {
@@ -257,6 +266,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
@@ -277,6 +287,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
@@ -296,6 +307,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
@@ -315,6 +327,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @NotNull
  @Size(min=10,max=64)  @ApiModelProperty(required = true, value = "")
   public String getPassword() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -38,6 +38,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -47,6 +48,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MapTest.java
@@ -95,6 +95,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
@@ -122,6 +123,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -148,6 +150,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -174,6 +177,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -52,6 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public UUID getUuid() {
@@ -71,6 +72,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
@@ -98,6 +100,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -44,6 +44,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -62,6 +63,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -46,6 +46,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -64,6 +65,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -82,6 +84,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -41,6 +41,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Name.java
@@ -50,6 +50,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
@@ -64,6 +65,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -78,6 +80,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -91,6 +94,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -41,6 +41,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
@@ -93,6 +93,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -111,6 +112,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -129,6 +131,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -147,6 +150,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
@@ -166,6 +170,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -184,6 +189,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -47,6 +47,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
@@ -66,6 +67,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -84,6 +86,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Pet.java
@@ -96,6 +96,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -114,6 +115,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Category getCategory() {
@@ -133,6 +135,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @NotNull
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
@@ -157,6 +160,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
@@ -184,6 +188,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
@@ -203,6 +208,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -38,6 +38,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -52,6 +53,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -40,6 +40,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -61,6 +62,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -55,6 +55,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
@@ -74,6 +75,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
@@ -94,6 +96,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
@@ -113,6 +116,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
@@ -137,6 +141,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -55,6 +55,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
@@ -74,6 +75,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @NotNull
   @Valid
   @ApiModelProperty(example = "1.234", required = true, value = "")
@@ -94,6 +96,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
@@ -113,6 +116,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
@@ -137,6 +141,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/User.java
@@ -61,6 +61,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -79,6 +80,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -97,6 +99,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -115,6 +118,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -133,6 +137,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -151,6 +156,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -169,6 +175,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -187,6 +194,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -127,6 +127,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -145,6 +146,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
@@ -164,6 +166,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -182,6 +185,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -208,6 +212,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -226,6 +231,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -244,6 +250,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
@@ -263,6 +270,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -281,6 +289,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -307,6 +316,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -333,6 +343,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -351,6 +362,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -369,6 +381,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
@@ -388,6 +401,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -406,6 +420,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -432,6 +447,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -458,6 +474,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -476,6 +493,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -494,6 +512,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
@@ -513,6 +532,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -531,6 +551,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -557,6 +578,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -583,6 +605,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -601,6 +624,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -619,6 +643,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
@@ -638,6 +663,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -656,6 +682,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -682,6 +709,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -708,6 +736,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2-play25/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play25/build.gradle
@@ -110,6 +110,7 @@ dependencies {
     compile "com.squareup.retrofit2:converter-scalars:$retrofit_version"
     compile "com.squareup.retrofit2:converter-gson:$retrofit_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile ("org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"){
         exclude group:'org.apache.oltu.oauth2' , module: 'org.apache.oltu.oauth2.common'
     }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -82,6 +82,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -108,6 +109,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
@@ -135,6 +137,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -161,6 +164,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -187,6 +191,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
@@ -214,6 +219,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
@@ -241,6 +247,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
@@ -268,6 +275,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
@@ -287,6 +295,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
@@ -306,6 +315,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
@@ -325,6 +335,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Object getAnytype3() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Animal.java
@@ -51,6 +51,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
@@ -70,6 +71,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -51,6 +51,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -51,6 +51,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -57,6 +57,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -83,6 +84,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
@@ -110,6 +112,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -55,6 +55,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -73,6 +74,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -91,6 +93,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -109,6 +112,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -127,6 +131,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -145,6 +150,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Cat.java
@@ -42,6 +42,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -40,6 +40,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -61,6 +62,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public String getName() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -41,6 +41,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Client.java
@@ -40,6 +40,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Dog.java
@@ -42,6 +42,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -40,6 +40,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -115,6 +115,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -141,6 +142,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -197,6 +197,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -215,6 +216,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
@@ -234,6 +236,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -252,6 +255,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -270,6 +274,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -45,6 +45,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
@@ -72,6 +73,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -83,6 +83,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
  @Min(10) @Max(100)  @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -103,6 +104,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
  @Min(20) @Max(200)  @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -121,6 +123,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -141,6 +144,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @NotNull
   @Valid
  @DecimalMin("32.1") @DecimalMax("543.2")  @ApiModelProperty(required = true, value = "")
@@ -163,6 +167,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
  @DecimalMin("54.3") @DecimalMax("987.6")  @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -183,6 +188,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
  @DecimalMin("67.8") @DecimalMax("123.4")  @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -201,6 +207,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
  @Pattern(regexp="/[a-z]/i")  @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -219,6 +226,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @NotNull
  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
@@ -238,6 +246,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public File getBinary() {
@@ -257,6 +266,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
@@ -277,6 +287,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
@@ -296,6 +307,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
@@ -315,6 +327,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @NotNull
  @Size(min=10,max=64)  @ApiModelProperty(required = true, value = "")
   public String getPassword() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -38,6 +38,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -47,6 +48,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MapTest.java
@@ -95,6 +95,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
@@ -122,6 +123,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -148,6 +150,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -174,6 +177,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -52,6 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public UUID getUuid() {
@@ -71,6 +72,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
@@ -98,6 +100,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -44,6 +44,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -62,6 +63,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -46,6 +46,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -64,6 +65,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -82,6 +84,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -41,6 +41,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Name.java
@@ -50,6 +50,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
@@ -64,6 +65,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -78,6 +80,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -91,6 +94,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -41,6 +41,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
@@ -93,6 +93,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -111,6 +112,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -129,6 +131,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -147,6 +150,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
@@ -166,6 +170,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -184,6 +189,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -47,6 +47,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
@@ -66,6 +67,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -84,6 +86,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Pet.java
@@ -96,6 +96,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -114,6 +115,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Category getCategory() {
@@ -133,6 +135,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @NotNull
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
@@ -157,6 +160,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
@@ -184,6 +188,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
@@ -203,6 +208,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -38,6 +38,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -52,6 +53,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -40,6 +40,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -61,6 +62,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -55,6 +55,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
@@ -74,6 +75,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
@@ -94,6 +96,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
@@ -113,6 +116,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
@@ -137,6 +141,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -55,6 +55,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
@@ -74,6 +75,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @NotNull
   @Valid
   @ApiModelProperty(example = "1.234", required = true, value = "")
@@ -94,6 +96,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
@@ -113,6 +116,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
@@ -137,6 +141,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/User.java
@@ -61,6 +61,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -79,6 +80,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -97,6 +99,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -115,6 +118,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -133,6 +137,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -151,6 +156,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -169,6 +175,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -187,6 +194,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -127,6 +127,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -145,6 +146,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
@@ -164,6 +166,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -182,6 +185,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -208,6 +212,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -226,6 +231,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -244,6 +250,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
@@ -263,6 +270,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -281,6 +289,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -307,6 +316,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -333,6 +343,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -351,6 +362,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -369,6 +381,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
@@ -388,6 +401,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -406,6 +420,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -432,6 +447,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -458,6 +474,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -476,6 +493,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -494,6 +512,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
@@ -513,6 +532,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -531,6 +551,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -557,6 +578,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -583,6 +605,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -601,6 +624,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -619,6 +643,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
@@ -638,6 +663,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -656,6 +682,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -682,6 +709,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -708,6 +736,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2-play26/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play26/build.gradle
@@ -111,6 +111,7 @@ dependencies {
     compile "com.squareup.retrofit2:converter-scalars:$retrofit_version"
     compile "com.squareup.retrofit2:converter-gson:$retrofit_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile ("org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"){
         exclude group:'org.apache.oltu.oauth2' , module: 'org.apache.oltu.oauth2.common'
     }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -82,6 +82,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -108,6 +109,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
@@ -135,6 +137,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -161,6 +164,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -187,6 +191,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
@@ -214,6 +219,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
@@ -241,6 +247,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
@@ -268,6 +275,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
@@ -287,6 +295,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
@@ -306,6 +315,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
@@ -325,6 +335,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Object getAnytype3() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -43,6 +43,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -42,6 +42,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
@@ -51,6 +51,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
@@ -70,6 +71,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -51,6 +51,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -51,6 +51,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -57,6 +57,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -83,6 +84,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
@@ -110,6 +112,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -55,6 +55,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -73,6 +74,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -91,6 +93,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -109,6 +112,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -127,6 +131,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -145,6 +150,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
@@ -42,6 +42,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -40,6 +40,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
@@ -43,6 +43,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -61,6 +62,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public String getName() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -41,6 +41,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
@@ -40,6 +40,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
@@ -42,6 +42,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -40,6 +40,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -115,6 +115,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -141,6 +142,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -197,6 +197,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -215,6 +216,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
@@ -234,6 +236,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -252,6 +255,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -270,6 +274,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -45,6 +45,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
@@ -72,6 +73,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -83,6 +83,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
  @Min(10) @Max(100)  @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -103,6 +104,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
  @Min(20) @Max(200)  @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -121,6 +123,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -141,6 +144,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @NotNull
   @Valid
  @DecimalMin("32.1") @DecimalMax("543.2")  @ApiModelProperty(required = true, value = "")
@@ -163,6 +167,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
  @DecimalMin("54.3") @DecimalMax("987.6")  @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -183,6 +188,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
  @DecimalMin("67.8") @DecimalMax("123.4")  @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -201,6 +207,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
  @Pattern(regexp="/[a-z]/i")  @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -219,6 +226,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @NotNull
  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
@@ -238,6 +246,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public File getBinary() {
@@ -257,6 +266,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
@@ -277,6 +287,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
@@ -296,6 +307,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
@@ -315,6 +327,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @NotNull
  @Size(min=10,max=64)  @ApiModelProperty(required = true, value = "")
   public String getPassword() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -38,6 +38,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -47,6 +48,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
@@ -95,6 +95,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
@@ -122,6 +123,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -148,6 +150,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -174,6 +177,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -52,6 +52,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public UUID getUuid() {
@@ -71,6 +72,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
@@ -98,6 +100,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -44,6 +44,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -62,6 +63,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -46,6 +46,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -64,6 +65,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -82,6 +84,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -41,6 +41,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
@@ -50,6 +50,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
@@ -64,6 +65,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -78,6 +80,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -91,6 +94,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -41,6 +41,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
@@ -93,6 +93,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -111,6 +112,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -129,6 +131,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -147,6 +150,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
@@ -166,6 +170,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -184,6 +189,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -47,6 +47,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
@@ -66,6 +67,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -84,6 +86,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
@@ -96,6 +96,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -114,6 +115,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public Category getCategory() {
@@ -133,6 +135,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @NotNull
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
@@ -157,6 +160,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
@@ -184,6 +188,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
@@ -203,6 +208,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -38,6 +38,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -52,6 +53,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -40,6 +40,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
@@ -43,6 +43,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -61,6 +62,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -55,6 +55,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
@@ -74,6 +75,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
@@ -94,6 +96,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
@@ -113,6 +116,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
@@ -137,6 +141,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @NotNull
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -55,6 +55,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
@@ -74,6 +75,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @NotNull
   @Valid
   @ApiModelProperty(example = "1.234", required = true, value = "")
@@ -94,6 +96,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
@@ -113,6 +116,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
@@ -137,6 +141,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @NotNull
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
@@ -61,6 +61,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -79,6 +80,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -97,6 +99,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -115,6 +118,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -133,6 +137,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -151,6 +156,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -169,6 +175,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -187,6 +194,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -127,6 +127,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -145,6 +146,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
@@ -164,6 +166,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -182,6 +185,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -208,6 +212,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -226,6 +231,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -244,6 +250,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
@@ -263,6 +270,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -281,6 +289,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -307,6 +316,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -333,6 +343,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -351,6 +362,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -369,6 +381,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
@@ -388,6 +401,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -406,6 +420,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -432,6 +447,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -458,6 +474,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -476,6 +493,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -494,6 +512,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
@@ -513,6 +532,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -531,6 +551,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -557,6 +578,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -583,6 +605,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -601,6 +624,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -619,6 +643,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
@@ -638,6 +663,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -656,6 +682,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -682,6 +709,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -708,6 +736,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2/build.gradle
+++ b/samples/client/petstore/java/retrofit2/build.gradle
@@ -108,6 +108,7 @@ dependencies {
     compile "com.squareup.retrofit2:converter-scalars:$retrofit_version"
     compile "com.squareup.retrofit2:converter-gson:$retrofit_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile ("org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"){
         exclude group:'org.apache.oltu.oauth2' , module: 'org.apache.oltu.oauth2.common'
     }

--- a/samples/client/petstore/java/retrofit2/pom.xml
+++ b/samples/client/petstore/java/retrofit2/pom.xml
@@ -191,6 +191,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-gson</artifactId>

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -94,6 +94,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -120,6 +121,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -146,6 +148,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -172,6 +175,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -198,6 +202,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -250,6 +256,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -276,6 +283,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -294,6 +302,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -312,6 +321,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -330,6 +340,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Animal.java
@@ -50,6 +50,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -68,6 +69,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -61,6 +61,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -87,6 +88,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -113,6 +115,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -62,6 +62,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -80,6 +81,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -98,6 +100,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -116,6 +119,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -134,6 +138,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -152,6 +157,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,6 +44,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -42,6 +42,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Category.java
@@ -46,6 +46,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -43,6 +43,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Client.java
@@ -42,6 +42,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Dog.java
@@ -44,6 +44,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -42,6 +42,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -142,6 +142,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -168,6 +169,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -251,6 +251,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -269,6 +270,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -287,6 +289,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -305,6 +308,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -323,6 +327,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -74,6 +75,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -97,6 +97,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -117,6 +118,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -135,6 +137,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -155,6 +158,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -175,6 +179,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -195,6 +200,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -213,6 +219,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -231,6 +238,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -249,6 +257,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -267,6 +276,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -285,6 +295,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -303,6 +314,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -321,6 +333,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -41,6 +41,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -112,6 +112,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -138,6 +139,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -164,6 +166,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -190,6 +193,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -56,6 +56,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -74,6 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -47,6 +47,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -65,6 +66,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -50,6 +50,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -68,6 +69,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -86,6 +88,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Name.java
@@ -55,6 +55,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -68,6 +69,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -82,6 +84,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -95,6 +98,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -43,6 +43,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
@@ -112,6 +112,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -130,6 +131,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -148,6 +150,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -166,6 +169,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -184,6 +188,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -202,6 +207,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -51,6 +51,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -69,6 +70,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -87,6 +89,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Pet.java
@@ -115,6 +115,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -133,6 +134,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -151,6 +153,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -174,6 +177,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -200,6 +204,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -218,6 +223,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -41,6 +41,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -55,6 +56,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Tag.java
@@ -46,6 +46,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -61,6 +61,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -61,6 +61,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/User.java
@@ -70,6 +70,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -88,6 +89,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -106,6 +108,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -124,6 +127,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -142,6 +146,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -160,6 +165,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -178,6 +184,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -196,6 +203,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -157,6 +157,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -175,6 +176,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -193,6 +195,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -211,6 +214,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -237,6 +241,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -255,6 +260,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -273,6 +279,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -291,6 +298,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -309,6 +317,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -335,6 +344,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -361,6 +371,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -379,6 +390,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -397,6 +409,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -415,6 +428,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -433,6 +447,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -459,6 +474,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -485,6 +501,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -503,6 +520,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -521,6 +539,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -539,6 +558,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -557,6 +577,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -583,6 +604,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -609,6 +631,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -627,6 +650,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -645,6 +669,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -663,6 +688,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -681,6 +707,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -707,6 +734,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -733,6 +761,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2rx/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx/build.gradle
@@ -111,6 +111,7 @@ dependencies {
     compile "com.squareup.retrofit2:adapter-rxjava:$retrofit_version"
     compile "io.reactivex:rxjava:$rx_java_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile ("org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"){
         exclude group:'org.apache.oltu.oauth2' , module: 'org.apache.oltu.oauth2.common'
     }

--- a/samples/client/petstore/java/retrofit2rx/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx/pom.xml
@@ -191,6 +191,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-gson</artifactId>

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -94,6 +94,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -120,6 +121,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -146,6 +148,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -172,6 +175,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -198,6 +202,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -250,6 +256,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -276,6 +283,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -294,6 +302,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -312,6 +321,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -330,6 +340,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Animal.java
@@ -50,6 +50,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -68,6 +69,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -61,6 +61,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -87,6 +88,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -113,6 +115,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -62,6 +62,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -80,6 +81,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -98,6 +100,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -116,6 +119,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -134,6 +138,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -152,6 +157,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,6 +44,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -42,6 +42,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Category.java
@@ -46,6 +46,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -43,6 +43,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Client.java
@@ -42,6 +42,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Dog.java
@@ -44,6 +44,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -42,6 +42,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -142,6 +142,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -168,6 +169,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -251,6 +251,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -269,6 +270,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -287,6 +289,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -305,6 +308,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -323,6 +327,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -74,6 +75,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -97,6 +97,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -117,6 +118,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -135,6 +137,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -155,6 +158,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -175,6 +179,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -195,6 +200,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -213,6 +219,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -231,6 +238,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -249,6 +257,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -267,6 +276,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -285,6 +295,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -303,6 +314,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -321,6 +333,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -41,6 +41,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -112,6 +112,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -138,6 +139,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -164,6 +166,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -190,6 +193,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -56,6 +56,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -74,6 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -47,6 +47,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -65,6 +66,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -50,6 +50,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -68,6 +69,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -86,6 +88,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Name.java
@@ -55,6 +55,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -68,6 +69,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -82,6 +84,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -95,6 +98,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -43,6 +43,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Order.java
@@ -112,6 +112,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -130,6 +131,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -148,6 +150,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -166,6 +169,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -184,6 +188,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -202,6 +207,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -51,6 +51,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -69,6 +70,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -87,6 +89,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Pet.java
@@ -115,6 +115,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -133,6 +134,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -151,6 +153,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -174,6 +177,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -200,6 +204,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -218,6 +223,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -41,6 +41,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -55,6 +56,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Tag.java
@@ -46,6 +46,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -61,6 +61,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -61,6 +61,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/User.java
@@ -70,6 +70,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -88,6 +89,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -106,6 +108,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -124,6 +127,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -142,6 +146,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -160,6 +165,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -178,6 +184,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -196,6 +203,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -157,6 +157,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -175,6 +176,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -193,6 +195,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -211,6 +214,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -237,6 +241,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -255,6 +260,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -273,6 +279,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -291,6 +298,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -309,6 +317,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -335,6 +344,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -361,6 +371,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -379,6 +390,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -397,6 +409,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -415,6 +428,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -433,6 +447,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -459,6 +474,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -485,6 +501,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -503,6 +520,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -521,6 +539,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -539,6 +558,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -557,6 +577,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -583,6 +604,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -609,6 +631,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -627,6 +650,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -645,6 +669,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -663,6 +688,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -681,6 +707,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -707,6 +734,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -733,6 +761,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2rx2/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx2/build.gradle
@@ -111,6 +111,7 @@ dependencies {
     compile 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
     compile "io.reactivex.rxjava2:rxjava:$rx_java_version"
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile ("org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:$oltu_version"){
         exclude group:'org.apache.oltu.oauth2' , module: 'org.apache.oltu.oauth2.common'
     }

--- a/samples/client/petstore/java/retrofit2rx2/pom.xml
+++ b/samples/client/petstore/java/retrofit2rx2/pom.xml
@@ -191,6 +191,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-annotations-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-gson</artifactId>

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -94,6 +94,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -120,6 +121,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -146,6 +148,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -172,6 +175,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -198,6 +202,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -224,6 +229,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -250,6 +256,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -276,6 +283,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -294,6 +302,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -312,6 +321,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -330,6 +340,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -45,6 +45,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -44,6 +44,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Animal.java
@@ -50,6 +50,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -68,6 +69,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -53,6 +53,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -61,6 +61,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -87,6 +88,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -113,6 +115,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -62,6 +62,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -80,6 +81,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -98,6 +100,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -116,6 +119,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -134,6 +138,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -152,6 +157,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Cat.java
@@ -44,6 +44,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -42,6 +42,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Category.java
@@ -46,6 +46,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -43,6 +43,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Client.java
@@ -42,6 +42,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Dog.java
@@ -44,6 +44,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -42,6 +42,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -142,6 +142,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -168,6 +169,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -251,6 +251,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -269,6 +270,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -287,6 +289,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -305,6 +308,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -323,6 +327,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -48,6 +48,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -74,6 +75,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -97,6 +97,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -117,6 +118,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -135,6 +137,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -155,6 +158,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -175,6 +179,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -195,6 +200,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -213,6 +219,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -231,6 +238,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -249,6 +257,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -267,6 +276,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -285,6 +295,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -303,6 +314,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -321,6 +333,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -41,6 +41,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -112,6 +112,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -138,6 +139,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -164,6 +166,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -190,6 +193,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -56,6 +56,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -74,6 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -100,6 +102,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -47,6 +47,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -65,6 +66,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -50,6 +50,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -68,6 +69,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -86,6 +88,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -43,6 +43,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Name.java
@@ -55,6 +55,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -68,6 +69,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -82,6 +84,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -95,6 +98,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -43,6 +43,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
@@ -112,6 +112,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -130,6 +131,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -148,6 +150,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -166,6 +169,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -184,6 +188,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -202,6 +207,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -51,6 +51,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -69,6 +70,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -87,6 +89,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Pet.java
@@ -115,6 +115,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -133,6 +134,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -151,6 +153,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -174,6 +177,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -200,6 +204,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -218,6 +223,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -41,6 +41,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -55,6 +56,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -42,6 +42,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Tag.java
@@ -46,6 +46,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -64,6 +65,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -61,6 +61,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -61,6 +61,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -79,6 +80,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -97,6 +99,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -115,6 +118,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -138,6 +142,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/User.java
@@ -70,6 +70,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -88,6 +89,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -106,6 +108,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -124,6 +127,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -142,6 +146,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -160,6 +165,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -178,6 +184,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -196,6 +203,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -157,6 +157,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -175,6 +176,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -193,6 +195,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -211,6 +214,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -237,6 +241,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -255,6 +260,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -273,6 +279,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -291,6 +298,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -309,6 +317,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -335,6 +344,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -361,6 +371,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -379,6 +390,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -397,6 +409,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -415,6 +428,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -433,6 +447,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -459,6 +474,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -485,6 +501,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -503,6 +520,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -521,6 +539,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -539,6 +558,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -557,6 +577,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -583,6 +604,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -609,6 +631,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -627,6 +650,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -645,6 +669,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -663,6 +688,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -681,6 +707,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -707,6 +734,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -733,6 +761,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/vertx/build.gradle
+++ b/samples/client/petstore/java/vertx/build.gradle
@@ -36,6 +36,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "io.vertx:vertx-web-client:$vertx_version"
     compile "io.vertx:vertx-rx-java:$vertx_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/samples/client/petstore/java/vertx/pom.xml
+++ b/samples/client/petstore/java/vertx/pom.xml
@@ -201,6 +201,13 @@
             <version>${swagger-annotations-version}</version>
         </dependency>
 
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        
         <!-- Vertx -->
         <dependency>
             <groupId>io.vertx</groupId>

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -106,6 +107,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -158,6 +161,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -184,6 +188,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -210,6 +215,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -236,6 +242,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -262,6 +269,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -280,6 +288,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -298,6 +307,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -316,6 +326,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
@@ -49,6 +49,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -67,6 +68,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -55,6 +55,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -81,6 +82,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -107,6 +109,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,6 +53,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -71,6 +72,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -89,6 +91,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -107,6 +110,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -125,6 +129,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -143,6 +148,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -38,6 +38,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
@@ -41,6 +41,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -39,6 +39,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
@@ -38,6 +38,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -38,6 +38,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -113,6 +113,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -139,6 +140,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -195,6 +195,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -213,6 +214,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -231,6 +233,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -249,6 +252,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -267,6 +271,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -43,6 +43,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -69,6 +70,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -81,6 +81,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -101,6 +102,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -119,6 +121,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -139,6 +142,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -159,6 +163,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -179,6 +184,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -197,6 +203,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -215,6 +222,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -233,6 +241,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public AsyncFile getBinary() {
     return binary;
@@ -251,6 +260,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -269,6 +279,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -287,6 +298,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -305,6 +317,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -36,6 +36,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -45,6 +46,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -119,6 +120,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -145,6 +147,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -171,6 +174,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -94,6 +96,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,6 +42,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -62,6 +63,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -80,6 +82,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -61,6 +62,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -75,6 +77,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -88,6 +91,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -39,6 +39,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -109,6 +110,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -127,6 +129,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -145,6 +148,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -163,6 +167,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -181,6 +186,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -63,6 +64,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -81,6 +83,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
@@ -94,6 +94,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -112,6 +113,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -130,6 +132,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -153,6 +156,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -179,6 +183,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -197,6 +202,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -36,6 +36,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -38,6 +38,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -53,6 +53,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -53,6 +53,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
@@ -59,6 +59,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -77,6 +78,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -95,6 +97,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -113,6 +116,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -131,6 +135,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -149,6 +154,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -167,6 +173,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -185,6 +192,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -125,6 +125,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -143,6 +144,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -161,6 +163,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -179,6 +182,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -205,6 +209,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -223,6 +228,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -241,6 +247,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -259,6 +266,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -277,6 +285,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -303,6 +312,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -329,6 +339,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -347,6 +358,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -365,6 +377,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -383,6 +396,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -401,6 +415,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -427,6 +442,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -453,6 +469,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -471,6 +488,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -489,6 +507,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -507,6 +526,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -525,6 +545,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -551,6 +572,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -577,6 +599,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -595,6 +618,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -613,6 +637,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -631,6 +656,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -649,6 +675,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -675,6 +702,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -701,6 +729,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -121,6 +121,7 @@ ext {
 
 dependencies {
     compile "io.swagger:swagger-annotations:$swagger_annotations_version"
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile "com.sun.jersey:jersey-client:$jersey_version"
     compile "com.sun.jersey.contribs:jersey-multipart:$jersey_version"
     compile "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -80,6 +80,7 @@ public class AdditionalPropertiesClass {
    * Get mapString
    * @return mapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, String> getMapString() {
     return mapString;
@@ -106,6 +107,7 @@ public class AdditionalPropertiesClass {
    * Get mapNumber
    * @return mapNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
@@ -132,6 +134,7 @@ public class AdditionalPropertiesClass {
    * Get mapInteger
    * @return mapInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
@@ -158,6 +161,7 @@ public class AdditionalPropertiesClass {
    * Get mapBoolean
    * @return mapBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
@@ -184,6 +188,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayInteger
    * @return mapArrayInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
@@ -210,6 +215,7 @@ public class AdditionalPropertiesClass {
    * Get mapArrayAnytype
    * @return mapArrayAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
@@ -236,6 +242,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapString
    * @return mapMapString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
@@ -262,6 +269,7 @@ public class AdditionalPropertiesClass {
    * Get mapMapAnytype
    * @return mapMapAnytype
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
@@ -280,6 +288,7 @@ public class AdditionalPropertiesClass {
    * Get anytype1
    * @return anytype1
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype1() {
     return anytype1;
@@ -298,6 +307,7 @@ public class AdditionalPropertiesClass {
    * Get anytype2
    * @return anytype2
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype2() {
     return anytype2;
@@ -316,6 +326,7 @@ public class AdditionalPropertiesClass {
    * Get anytype3
    * @return anytype3
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Object getAnytype3() {
     return anytype3;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,6 +41,7 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,6 +40,7 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
@@ -49,6 +49,7 @@ public class Animal {
    * Get className
    * @return className
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getClassName() {
     return className;
@@ -67,6 +68,7 @@ public class Animal {
    * Get color
    * @return color
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getColor() {
     return color;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfArrayOfNumberOnly {
    * Get arrayArrayNumber
    * @return arrayArrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -49,6 +49,7 @@ public class ArrayOfNumberOnly {
    * Get arrayNumber
    * @return arrayNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -55,6 +55,7 @@ public class ArrayTest {
    * Get arrayOfString
    * @return arrayOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<String> getArrayOfString() {
     return arrayOfString;
@@ -81,6 +82,7 @@ public class ArrayTest {
    * Get arrayArrayOfInteger
    * @return arrayArrayOfInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
@@ -107,6 +109,7 @@ public class ArrayTest {
    * Get arrayArrayOfModel
    * @return arrayArrayOfModel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,6 +53,7 @@ public class Capitalization {
    * Get smallCamel
    * @return smallCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallCamel() {
     return smallCamel;
@@ -71,6 +72,7 @@ public class Capitalization {
    * Get capitalCamel
    * @return capitalCamel
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalCamel() {
     return capitalCamel;
@@ -89,6 +91,7 @@ public class Capitalization {
    * Get smallSnake
    * @return smallSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getSmallSnake() {
     return smallSnake;
@@ -107,6 +110,7 @@ public class Capitalization {
    * Get capitalSnake
    * @return capitalSnake
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getCapitalSnake() {
     return capitalSnake;
@@ -125,6 +129,7 @@ public class Capitalization {
    * Get scAETHFlowPoints
    * @return scAETHFlowPoints
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
@@ -143,6 +148,7 @@ public class Capitalization {
    * Name of the pet 
    * @return ATT_NAME
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Name of the pet ")
   public String getATTNAME() {
     return ATT_NAME;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,6 +40,7 @@ public class Cat extends Animal {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -38,6 +38,7 @@ public class CatAllOf {
    * Get declawed
    * @return declawed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getDeclawed() {
     return declawed;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
@@ -41,6 +41,7 @@ public class Category {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Category {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -39,6 +39,7 @@ public class ClassModel {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
@@ -38,6 +38,7 @@ public class Client {
    * Get client
    * @return client
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getClient() {
     return client;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,6 +40,7 @@ public class Dog extends Animal {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -38,6 +38,7 @@ public class DogAllOf {
    * Get breed
    * @return breed
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBreed() {
     return breed;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -113,6 +113,7 @@ public class EnumArrays {
    * Get justSymbol
    * @return justSymbol
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
@@ -139,6 +140,7 @@ public class EnumArrays {
    * Get arrayEnum
    * @return arrayEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -195,6 +195,7 @@ public class EnumTest {
    * Get enumString
    * @return enumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumStringEnum getEnumString() {
     return enumString;
@@ -213,6 +214,7 @@ public class EnumTest {
    * Get enumStringRequired
    * @return enumStringRequired
   **/
+
   @ApiModelProperty(required = true, value = "")
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
@@ -231,6 +233,7 @@ public class EnumTest {
    * Get enumInteger
    * @return enumInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
@@ -249,6 +252,7 @@ public class EnumTest {
    * Get enumNumber
    * @return enumNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
@@ -267,6 +271,7 @@ public class EnumTest {
    * Get outerEnum
    * @return outerEnum
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OuterEnum getOuterEnum() {
     return outerEnum;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -43,6 +43,7 @@ public class FileSchemaTestClass {
    * Get file
    * @return file
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public java.io.File getFile() {
     return file;
@@ -69,6 +70,7 @@ public class FileSchemaTestClass {
    * Get files
    * @return files
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<java.io.File> getFiles() {
     return files;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -81,6 +81,7 @@ public class FormatTest {
    * maximum: 100
    * @return integer
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInteger() {
     return integer;
@@ -101,6 +102,7 @@ public class FormatTest {
    * maximum: 200
    * @return int32
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getInt32() {
     return int32;
@@ -119,6 +121,7 @@ public class FormatTest {
    * Get int64
    * @return int64
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getInt64() {
     return int64;
@@ -139,6 +142,7 @@ public class FormatTest {
    * maximum: 543.2
    * @return number
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumber() {
     return number;
@@ -159,6 +163,7 @@ public class FormatTest {
    * maximum: 987.6
    * @return _float
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Float getFloat() {
     return _float;
@@ -179,6 +184,7 @@ public class FormatTest {
    * maximum: 123.4
    * @return _double
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Double getDouble() {
     return _double;
@@ -197,6 +203,7 @@ public class FormatTest {
    * Get string
    * @return string
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getString() {
     return string;
@@ -215,6 +222,7 @@ public class FormatTest {
    * Get _byte
    * @return _byte
   **/
+
   @ApiModelProperty(required = true, value = "")
   public byte[] getByte() {
     return _byte;
@@ -233,6 +241,7 @@ public class FormatTest {
    * Get binary
    * @return binary
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public File getBinary() {
     return binary;
@@ -251,6 +260,7 @@ public class FormatTest {
    * Get date
    * @return date
   **/
+
   @ApiModelProperty(required = true, value = "")
   public LocalDate getDate() {
     return date;
@@ -269,6 +279,7 @@ public class FormatTest {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -287,6 +298,7 @@ public class FormatTest {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   public UUID getUuid() {
     return uuid;
@@ -305,6 +317,7 @@ public class FormatTest {
    * Get password
    * @return password
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getPassword() {
     return password;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -36,6 +36,7 @@ public class HasOnlyReadOnly {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -45,6 +46,7 @@ public class HasOnlyReadOnly {
    * Get foo
    * @return foo
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFoo() {
     return foo;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
@@ -93,6 +93,7 @@ public class MapTest {
    * Get mapMapOfString
    * @return mapMapOfString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
@@ -119,6 +120,7 @@ public class MapTest {
    * Get mapOfEnumString
    * @return mapOfEnumString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
@@ -145,6 +147,7 @@ public class MapTest {
    * Get directMap
    * @return directMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getDirectMap() {
     return directMap;
@@ -171,6 +174,7 @@ public class MapTest {
    * Get indirectMap
    * @return indirectMap
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -50,6 +50,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get uuid
    * @return uuid
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public UUID getUuid() {
     return uuid;
@@ -68,6 +69,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get dateTime
    * @return dateTime
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getDateTime() {
     return dateTime;
@@ -94,6 +96,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
    * Get map
    * @return map
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Map<String, Animal> getMap() {
     return map;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,6 +42,7 @@ public class Model200Response {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getName() {
     return name;
@@ -60,6 +61,7 @@ public class Model200Response {
    * Get propertyClass
    * @return propertyClass
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPropertyClass() {
     return propertyClass;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -44,6 +44,7 @@ public class ModelApiResponse {
    * Get code
    * @return code
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getCode() {
     return code;
@@ -62,6 +63,7 @@ public class ModelApiResponse {
    * Get type
    * @return type
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getType() {
     return type;
@@ -80,6 +82,7 @@ public class ModelApiResponse {
    * Get message
    * @return message
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMessage() {
     return message;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -39,6 +39,7 @@ public class ModelReturn {
    * Get _return
    * @return _return
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getReturn() {
     return _return;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,7 @@ public class Name {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getName() {
     return name;
@@ -61,6 +62,7 @@ public class Name {
    * Get snakeCase
    * @return snakeCase
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getSnakeCase() {
     return snakeCase;
@@ -75,6 +77,7 @@ public class Name {
    * Get property
    * @return property
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getProperty() {
     return property;
@@ -88,6 +91,7 @@ public class Name {
    * Get _123number
    * @return _123number
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer get123number() {
     return _123number;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -39,6 +39,7 @@ public class NumberOnly {
    * Get justNumber
    * @return justNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getJustNumber() {
     return justNumber;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
@@ -91,6 +91,7 @@ public class Order {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -109,6 +110,7 @@ public class Order {
    * Get petId
    * @return petId
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getPetId() {
     return petId;
@@ -127,6 +129,7 @@ public class Order {
    * Get quantity
    * @return quantity
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Integer getQuantity() {
     return quantity;
@@ -145,6 +148,7 @@ public class Order {
    * Get shipDate
    * @return shipDate
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public OffsetDateTime getShipDate() {
     return shipDate;
@@ -163,6 +167,7 @@ public class Order {
    * Order Status
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "Order Status")
   public StatusEnum getStatus() {
     return status;
@@ -181,6 +186,7 @@ public class Order {
    * Get complete
    * @return complete
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getComplete() {
     return complete;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -45,6 +45,7 @@ public class OuterComposite {
    * Get myNumber
    * @return myNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public BigDecimal getMyNumber() {
     return myNumber;
@@ -63,6 +64,7 @@ public class OuterComposite {
    * Get myString
    * @return myString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getMyString() {
     return myString;
@@ -81,6 +83,7 @@ public class OuterComposite {
    * Get myBoolean
    * @return myBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Boolean getMyBoolean() {
     return myBoolean;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
@@ -94,6 +94,7 @@ public class Pet {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -112,6 +113,7 @@ public class Pet {
    * Get category
    * @return category
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Category getCategory() {
     return category;
@@ -130,6 +132,7 @@ public class Pet {
    * Get name
    * @return name
   **/
+
   @ApiModelProperty(example = "doggie", required = true, value = "")
   public String getName() {
     return name;
@@ -153,6 +156,7 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<String> getPhotoUrls() {
     return photoUrls;
@@ -179,6 +183,7 @@ public class Pet {
    * Get tags
    * @return tags
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Tag> getTags() {
     return tags;
@@ -197,6 +202,7 @@ public class Pet {
    * pet status in the store
    * @return status
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "pet status in the store")
   public StatusEnum getStatus() {
     return status;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -36,6 +36,7 @@ public class ReadOnlyFirst {
    * Get bar
    * @return bar
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBar() {
     return bar;
@@ -50,6 +51,7 @@ public class ReadOnlyFirst {
    * Get baz
    * @return baz
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getBaz() {
     return baz;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -38,6 +38,7 @@ public class SpecialModelName {
    * Get $specialPropertyName
    * @return $specialPropertyName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -59,6 +60,7 @@ public class Tag {
    * Get name
    * @return name
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getName() {
     return name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -53,6 +53,7 @@ public class TypeHolderDefault {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderDefault {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderDefault {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderDefault {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderDefault {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -53,6 +53,7 @@ public class TypeHolderExample {
    * Get stringItem
    * @return stringItem
   **/
+
   @ApiModelProperty(example = "what", required = true, value = "")
   public String getStringItem() {
     return stringItem;
@@ -71,6 +72,7 @@ public class TypeHolderExample {
    * Get numberItem
    * @return numberItem
   **/
+
   @ApiModelProperty(example = "1.234", required = true, value = "")
   public BigDecimal getNumberItem() {
     return numberItem;
@@ -89,6 +91,7 @@ public class TypeHolderExample {
    * Get integerItem
    * @return integerItem
   **/
+
   @ApiModelProperty(example = "-2", required = true, value = "")
   public Integer getIntegerItem() {
     return integerItem;
@@ -107,6 +110,7 @@ public class TypeHolderExample {
    * Get boolItem
    * @return boolItem
   **/
+
   @ApiModelProperty(example = "true", required = true, value = "")
   public Boolean getBoolItem() {
     return boolItem;
@@ -130,6 +134,7 @@ public class TypeHolderExample {
    * Get arrayItem
    * @return arrayItem
   **/
+
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   public List<Integer> getArrayItem() {
     return arrayItem;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
@@ -59,6 +59,7 @@ public class User {
    * Get id
    * @return id
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public Long getId() {
     return id;
@@ -77,6 +78,7 @@ public class User {
    * Get username
    * @return username
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getUsername() {
     return username;
@@ -95,6 +97,7 @@ public class User {
    * Get firstName
    * @return firstName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getFirstName() {
     return firstName;
@@ -113,6 +116,7 @@ public class User {
    * Get lastName
    * @return lastName
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getLastName() {
     return lastName;
@@ -131,6 +135,7 @@ public class User {
    * Get email
    * @return email
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getEmail() {
     return email;
@@ -149,6 +154,7 @@ public class User {
    * Get password
    * @return password
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPassword() {
     return password;
@@ -167,6 +173,7 @@ public class User {
    * Get phone
    * @return phone
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public String getPhone() {
     return phone;
@@ -185,6 +192,7 @@ public class User {
    * User Status
    * @return userStatus
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "User Status")
   public Integer getUserStatus() {
     return userStatus;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -125,6 +125,7 @@ public class XmlItem {
    * Get attributeString
    * @return attributeString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getAttributeString() {
     return attributeString;
@@ -143,6 +144,7 @@ public class XmlItem {
    * Get attributeNumber
    * @return attributeNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
@@ -161,6 +163,7 @@ public class XmlItem {
    * Get attributeInteger
    * @return attributeInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getAttributeInteger() {
     return attributeInteger;
@@ -179,6 +182,7 @@ public class XmlItem {
    * Get attributeBoolean
    * @return attributeBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
@@ -205,6 +209,7 @@ public class XmlItem {
    * Get wrappedArray
    * @return wrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getWrappedArray() {
     return wrappedArray;
@@ -223,6 +228,7 @@ public class XmlItem {
    * Get nameString
    * @return nameString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNameString() {
     return nameString;
@@ -241,6 +247,7 @@ public class XmlItem {
    * Get nameNumber
    * @return nameNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNameNumber() {
     return nameNumber;
@@ -259,6 +266,7 @@ public class XmlItem {
    * Get nameInteger
    * @return nameInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNameInteger() {
     return nameInteger;
@@ -277,6 +285,7 @@ public class XmlItem {
    * Get nameBoolean
    * @return nameBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNameBoolean() {
     return nameBoolean;
@@ -303,6 +312,7 @@ public class XmlItem {
    * Get nameArray
    * @return nameArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameArray() {
     return nameArray;
@@ -329,6 +339,7 @@ public class XmlItem {
    * Get nameWrappedArray
    * @return nameWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
@@ -347,6 +358,7 @@ public class XmlItem {
    * Get prefixString
    * @return prefixString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixString() {
     return prefixString;
@@ -365,6 +377,7 @@ public class XmlItem {
    * Get prefixNumber
    * @return prefixNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
@@ -383,6 +396,7 @@ public class XmlItem {
    * Get prefixInteger
    * @return prefixInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixInteger() {
     return prefixInteger;
@@ -401,6 +415,7 @@ public class XmlItem {
    * Get prefixBoolean
    * @return prefixBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
@@ -427,6 +442,7 @@ public class XmlItem {
    * Get prefixArray
    * @return prefixArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixArray() {
     return prefixArray;
@@ -453,6 +469,7 @@ public class XmlItem {
    * Get prefixWrappedArray
    * @return prefixWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
@@ -471,6 +488,7 @@ public class XmlItem {
    * Get namespaceString
    * @return namespaceString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getNamespaceString() {
     return namespaceString;
@@ -489,6 +507,7 @@ public class XmlItem {
    * Get namespaceNumber
    * @return namespaceNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
@@ -507,6 +526,7 @@ public class XmlItem {
    * Get namespaceInteger
    * @return namespaceInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getNamespaceInteger() {
     return namespaceInteger;
@@ -525,6 +545,7 @@ public class XmlItem {
    * Get namespaceBoolean
    * @return namespaceBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
@@ -551,6 +572,7 @@ public class XmlItem {
    * Get namespaceArray
    * @return namespaceArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
@@ -577,6 +599,7 @@ public class XmlItem {
    * Get namespaceWrappedArray
    * @return namespaceWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
@@ -595,6 +618,7 @@ public class XmlItem {
    * Get prefixNsString
    * @return prefixNsString
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "string", value = "")
   public String getPrefixNsString() {
     return prefixNsString;
@@ -613,6 +637,7 @@ public class XmlItem {
    * Get prefixNsNumber
    * @return prefixNsNumber
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "1.234", value = "")
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
@@ -631,6 +656,7 @@ public class XmlItem {
    * Get prefixNsInteger
    * @return prefixNsInteger
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "-2", value = "")
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
@@ -649,6 +675,7 @@ public class XmlItem {
    * Get prefixNsBoolean
    * @return prefixNsBoolean
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(example = "true", value = "")
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
@@ -675,6 +702,7 @@ public class XmlItem {
    * Get prefixNsArray
    * @return prefixNsArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
@@ -701,6 +729,7 @@ public class XmlItem {
    * Get prefixNsWrappedArray
    * @return prefixNsWrappedArray
   **/
+  @javax.annotation.Nullable 
   @ApiModelProperty(value = "")
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;

--- a/samples/client/petstore/spring-cloud/pom.xml
+++ b/samples/client/petstore/spring-cloud/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>

--- a/samples/server/petstore/springboot-reactive/pom.xml
+++ b/samples/server/petstore/springboot-reactive/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>swagger-annotations</artifactId>
             <version>1.5.14</version>
         </dependency>
+        <!-- @Nullable annotation -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


@bbdouglas
@sreeshas
@jfiala
@lukoyanov
@cbornet
@jeff9finger
@karismann
@Zomzog

### Description of the PR

fixes https://github.com/OpenAPITools/openapi-generator/issues/3264

adds `@javax.annotation.Nullable` to non-required fields, to enhance IDE feedback and Kotlin-interop

this requires the `com.google.code.findbugs:jsr305:3.0.2` dependency for the annotation - I'm not sure where I should adjust the ~sample dependencies (I adjusted the pom.xml / build.gradle in the sample but the integration test still fails)~ documentation to inform people this

existing tests are working fine, I don't think additional ones are necessary