### PR TITLE
[Rust][Client] Correct the Rust client generated documentation

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/api_doc.mustache
@@ -14,27 +14,19 @@ Method | HTTP request | Description
 
 ## {{{operationId}}}
 
-> {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationId}}}({{#authMethods}}ctx, {{/authMethods}}{{#allParams}}{{#required}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}optional{{/hasOptionalParams}})
+> {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
 {{{summary}}}{{#notes}}
 
 {{{notes}}}{{/notes}}
 
-### Required Parameters
+### Parameters
 
 {{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------{{#authMethods}}
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication{{/authMethods}}{{/-last}}{{/allParams}}{{#allParams}}{{#required}}
-  **{{{paramName}}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{{baseType}}}.md){{/isPrimitiveType}}| {{{description}}} | {{#defaultValue}}[default to {{{defaultValue}}}]{{/defaultValue}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a map[string]interface{}.
-{{#allParams}}{{#-last}}
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}{{#allParams}}
- **{{{paramName}}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{{baseType}}}.md){{/isPrimitiveType}}| {{{description}}} | {{#defaultValue}}[default to {{{defaultValue}}}]{{/defaultValue}}{{/allParams}}{{/hasOptionalParams}}
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}
+{{#allParams}}
+**{{{paramName}}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{{baseType}}}.md){{/isPrimitiveType}} | {{{description}}} | {{#required}}Required{{/required}} | {{#defaultValue}}[default to {{{defaultValue}}}]{{/defaultValue}}
+{{/allParams}}
 
 ### Return type
 

--- a/samples/client/petstore/rust-reqwest/docs/PetApi.md
+++ b/samples/client/petstore/rust-reqwest/docs/PetApi.md
@@ -17,16 +17,15 @@ Method | HTTP request | Description
 
 ## add_pet
 
-> add_pet(ctx, body)
+> add_pet(body)
 Add a new pet to the store
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**Pet**](Pet.md) | Pet object that needs to be added to the store | Required | 
 
 ### Return type
 
@@ -46,26 +45,16 @@ Name | Type | Description  | Notes
 
 ## delete_pet
 
-> delete_pet(ctx, pet_id, optional)
+> delete_pet(pet_id, api_key)
 Deletes a pet
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **pet_id** | **i64**| Pet id to delete | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a map[string]interface{}.
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **i64**| Pet id to delete | 
- **api_key** | **String**|  | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**pet_id** | **i64** | Pet id to delete | Required | 
+**api_key** | **String** |  |  | 
 
 ### Return type
 
@@ -85,18 +74,17 @@ Name | Type | Description  | Notes
 
 ## find_pets_by_status
 
-> Vec<crate::models::Pet> find_pets_by_status(ctx, status)
+> Vec<crate::models::Pet> find_pets_by_status(status)
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **status** | [**Vec<String>**](String.md)| Status values that need to be considered for filter | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**status** | [**Vec<String>**](String.md) | Status values that need to be considered for filter | Required | 
 
 ### Return type
 
@@ -116,18 +104,17 @@ Name | Type | Description  | Notes
 
 ## find_pets_by_tags
 
-> Vec<crate::models::Pet> find_pets_by_tags(ctx, tags)
+> Vec<crate::models::Pet> find_pets_by_tags(tags)
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **tags** | [**Vec<String>**](String.md)| Tags to filter by | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**tags** | [**Vec<String>**](String.md) | Tags to filter by | Required | 
 
 ### Return type
 
@@ -147,18 +134,17 @@ Name | Type | Description  | Notes
 
 ## get_pet_by_id
 
-> crate::models::Pet get_pet_by_id(ctx, pet_id)
+> crate::models::Pet get_pet_by_id(pet_id)
 Find pet by ID
 
 Returns a single pet
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **pet_id** | **i64**| ID of pet to return | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**pet_id** | **i64** | ID of pet to return | Required | 
 
 ### Return type
 
@@ -178,16 +164,15 @@ Name | Type | Description  | Notes
 
 ## update_pet
 
-> update_pet(ctx, body)
+> update_pet(body)
 Update an existing pet
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**Pet**](Pet.md) | Pet object that needs to be added to the store | Required | 
 
 ### Return type
 
@@ -207,27 +192,17 @@ Name | Type | Description  | Notes
 
 ## update_pet_with_form
 
-> update_pet_with_form(ctx, pet_id, optional)
+> update_pet_with_form(pet_id, name, status)
 Updates a pet in the store with form data
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **pet_id** | **i64**| ID of pet that needs to be updated | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a map[string]interface{}.
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **i64**| ID of pet that needs to be updated | 
- **name** | **String**| Updated name of the pet | 
- **status** | **String**| Updated status of the pet | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**pet_id** | **i64** | ID of pet that needs to be updated | Required | 
+**name** | **String** | Updated name of the pet |  | 
+**status** | **String** | Updated status of the pet |  | 
 
 ### Return type
 
@@ -247,27 +222,17 @@ Name | Type | Description  | Notes
 
 ## upload_file
 
-> crate::models::ApiResponse upload_file(ctx, pet_id, optional)
+> crate::models::ApiResponse upload_file(pet_id, additional_metadata, file)
 uploads an image
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **pet_id** | **i64**| ID of pet to update | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a map[string]interface{}.
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **i64**| ID of pet to update | 
- **additional_metadata** | **String**| Additional data to pass to server | 
- **file** | **std::path::PathBuf**| file to upload | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**pet_id** | **i64** | ID of pet to update | Required | 
+**additional_metadata** | **String** | Additional data to pass to server |  | 
+**file** | **std::path::PathBuf** | file to upload |  | 
 
 ### Return type
 

--- a/samples/client/petstore/rust-reqwest/docs/StoreApi.md
+++ b/samples/client/petstore/rust-reqwest/docs/StoreApi.md
@@ -18,12 +18,12 @@ Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **order_id** | **String**| ID of the order that needs to be deleted | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**order_id** | **String** | ID of the order that needs to be deleted | Required | 
 
 ### Return type
 
@@ -43,12 +43,12 @@ No authorization required
 
 ## get_inventory
 
-> ::std::collections::HashMap<String, i32> get_inventory(ctx, )
+> ::std::collections::HashMap<String, i32> get_inventory()
 Returns pet inventories by status
 
 Returns a map of status codes to quantities
 
-### Required Parameters
+### Parameters
 
 This endpoint does not need any parameter.
 
@@ -75,12 +75,12 @@ Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **order_id** | **i64**| ID of pet that needs to be fetched | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**order_id** | **i64** | ID of pet that needs to be fetched | Required | 
 
 ### Return type
 
@@ -103,12 +103,12 @@ No authorization required
 > crate::models::Order place_order(body)
 Place an order for a pet
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **body** | [**Order**](Order.md)| order placed for purchasing the pet | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**Order**](Order.md) | order placed for purchasing the pet | Required | 
 
 ### Return type
 

--- a/samples/client/petstore/rust-reqwest/docs/UserApi.md
+++ b/samples/client/petstore/rust-reqwest/docs/UserApi.md
@@ -22,12 +22,12 @@ Create user
 
 This can only be done by the logged in user.
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **body** | [**User**](User.md)| Created user object | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**User**](User.md) | Created user object | Required | 
 
 ### Return type
 
@@ -50,12 +50,12 @@ No authorization required
 > create_users_with_array_input(body)
 Creates list of users with given input array
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **body** | [**Vec<crate::models::User>**](User.md)| List of user object | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**Vec<crate::models::User>**](User.md) | List of user object | Required | 
 
 ### Return type
 
@@ -78,12 +78,12 @@ No authorization required
 > create_users_with_list_input(body)
 Creates list of users with given input array
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **body** | [**Vec<crate::models::User>**](User.md)| List of user object | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**Vec<crate::models::User>**](User.md) | List of user object | Required | 
 
 ### Return type
 
@@ -108,12 +108,12 @@ Delete user
 
 This can only be done by the logged in user.
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **username** | **String**| The name that needs to be deleted | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**username** | **String** | The name that needs to be deleted | Required | 
 
 ### Return type
 
@@ -136,12 +136,12 @@ No authorization required
 > crate::models::User get_user_by_name(username)
 Get user by user name
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **username** | **String**| The name that needs to be fetched. Use user1 for testing. | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**username** | **String** | The name that needs to be fetched. Use user1 for testing. | Required | 
 
 ### Return type
 
@@ -164,13 +164,13 @@ No authorization required
 > String login_user(username, password)
 Logs user into the system
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **username** | **String**| The user name for login | 
-  **password** | **String**| The password for login in clear text | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**username** | **String** | The user name for login | Required | 
+**password** | **String** | The password for login in clear text | Required | 
 
 ### Return type
 
@@ -193,7 +193,7 @@ No authorization required
 > logout_user()
 Logs out current logged in user session
 
-### Required Parameters
+### Parameters
 
 This endpoint does not need any parameter.
 
@@ -220,13 +220,13 @@ Updated user
 
 This can only be done by the logged in user.
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **username** | **String**| name that need to be deleted | 
-  **body** | [**User**](User.md)| Updated user object | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**username** | **String** | name that need to be deleted | Required | 
+**body** | [**User**](User.md) | Updated user object | Required | 
 
 ### Return type
 

--- a/samples/client/petstore/rust/docs/PetApi.md
+++ b/samples/client/petstore/rust/docs/PetApi.md
@@ -17,16 +17,15 @@ Method | HTTP request | Description
 
 ## add_pet
 
-> add_pet(ctx, body)
+> add_pet(body)
 Add a new pet to the store
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**Pet**](Pet.md) | Pet object that needs to be added to the store | Required | 
 
 ### Return type
 
@@ -46,26 +45,16 @@ Name | Type | Description  | Notes
 
 ## delete_pet
 
-> delete_pet(ctx, pet_id, optional)
+> delete_pet(pet_id, api_key)
 Deletes a pet
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **pet_id** | **i64**| Pet id to delete | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a map[string]interface{}.
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **i64**| Pet id to delete | 
- **api_key** | **String**|  | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**pet_id** | **i64** | Pet id to delete | Required | 
+**api_key** | **String** |  |  | 
 
 ### Return type
 
@@ -85,18 +74,17 @@ Name | Type | Description  | Notes
 
 ## find_pets_by_status
 
-> Vec<crate::models::Pet> find_pets_by_status(ctx, status)
+> Vec<crate::models::Pet> find_pets_by_status(status)
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **status** | [**Vec<String>**](String.md)| Status values that need to be considered for filter | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**status** | [**Vec<String>**](String.md) | Status values that need to be considered for filter | Required | 
 
 ### Return type
 
@@ -116,18 +104,17 @@ Name | Type | Description  | Notes
 
 ## find_pets_by_tags
 
-> Vec<crate::models::Pet> find_pets_by_tags(ctx, tags)
+> Vec<crate::models::Pet> find_pets_by_tags(tags)
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **tags** | [**Vec<String>**](String.md)| Tags to filter by | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**tags** | [**Vec<String>**](String.md) | Tags to filter by | Required | 
 
 ### Return type
 
@@ -147,18 +134,17 @@ Name | Type | Description  | Notes
 
 ## get_pet_by_id
 
-> crate::models::Pet get_pet_by_id(ctx, pet_id)
+> crate::models::Pet get_pet_by_id(pet_id)
 Find pet by ID
 
 Returns a single pet
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **pet_id** | **i64**| ID of pet to return | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**pet_id** | **i64** | ID of pet to return | Required | 
 
 ### Return type
 
@@ -178,16 +164,15 @@ Name | Type | Description  | Notes
 
 ## update_pet
 
-> update_pet(ctx, body)
+> update_pet(body)
 Update an existing pet
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**Pet**](Pet.md) | Pet object that needs to be added to the store | Required | 
 
 ### Return type
 
@@ -207,27 +192,17 @@ Name | Type | Description  | Notes
 
 ## update_pet_with_form
 
-> update_pet_with_form(ctx, pet_id, optional)
+> update_pet_with_form(pet_id, name, status)
 Updates a pet in the store with form data
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **pet_id** | **i64**| ID of pet that needs to be updated | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a map[string]interface{}.
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **i64**| ID of pet that needs to be updated | 
- **name** | **String**| Updated name of the pet | 
- **status** | **String**| Updated status of the pet | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**pet_id** | **i64** | ID of pet that needs to be updated | Required | 
+**name** | **String** | Updated name of the pet |  | 
+**status** | **String** | Updated status of the pet |  | 
 
 ### Return type
 
@@ -247,27 +222,17 @@ Name | Type | Description  | Notes
 
 ## upload_file
 
-> crate::models::ApiResponse upload_file(ctx, pet_id, optional)
+> crate::models::ApiResponse upload_file(pet_id, additional_metadata, file)
 uploads an image
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **ctx** | **context.Context** | context containing the authentication | nil if no authentication
-  **pet_id** | **i64**| ID of pet to update | 
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a map[string]interface{}.
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **pet_id** | **i64**| ID of pet to update | 
- **additional_metadata** | **String**| Additional data to pass to server | 
- **file** | **std::path::PathBuf**| file to upload | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**pet_id** | **i64** | ID of pet to update | Required | 
+**additional_metadata** | **String** | Additional data to pass to server |  | 
+**file** | **std::path::PathBuf** | file to upload |  | 
 
 ### Return type
 

--- a/samples/client/petstore/rust/docs/StoreApi.md
+++ b/samples/client/petstore/rust/docs/StoreApi.md
@@ -18,12 +18,12 @@ Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **order_id** | **String**| ID of the order that needs to be deleted | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**order_id** | **String** | ID of the order that needs to be deleted | Required | 
 
 ### Return type
 
@@ -43,12 +43,12 @@ No authorization required
 
 ## get_inventory
 
-> ::std::collections::HashMap<String, i32> get_inventory(ctx, )
+> ::std::collections::HashMap<String, i32> get_inventory()
 Returns pet inventories by status
 
 Returns a map of status codes to quantities
 
-### Required Parameters
+### Parameters
 
 This endpoint does not need any parameter.
 
@@ -75,12 +75,12 @@ Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **order_id** | **i64**| ID of pet that needs to be fetched | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**order_id** | **i64** | ID of pet that needs to be fetched | Required | 
 
 ### Return type
 
@@ -103,12 +103,12 @@ No authorization required
 > crate::models::Order place_order(body)
 Place an order for a pet
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **body** | [**Order**](Order.md)| order placed for purchasing the pet | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**Order**](Order.md) | order placed for purchasing the pet | Required | 
 
 ### Return type
 

--- a/samples/client/petstore/rust/docs/UserApi.md
+++ b/samples/client/petstore/rust/docs/UserApi.md
@@ -22,12 +22,12 @@ Create user
 
 This can only be done by the logged in user.
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **body** | [**User**](User.md)| Created user object | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**User**](User.md) | Created user object | Required | 
 
 ### Return type
 
@@ -50,12 +50,12 @@ No authorization required
 > create_users_with_array_input(body)
 Creates list of users with given input array
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **body** | [**Vec<crate::models::User>**](User.md)| List of user object | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**Vec<crate::models::User>**](User.md) | List of user object | Required | 
 
 ### Return type
 
@@ -78,12 +78,12 @@ No authorization required
 > create_users_with_list_input(body)
 Creates list of users with given input array
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **body** | [**Vec<crate::models::User>**](User.md)| List of user object | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**body** | [**Vec<crate::models::User>**](User.md) | List of user object | Required | 
 
 ### Return type
 
@@ -108,12 +108,12 @@ Delete user
 
 This can only be done by the logged in user.
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **username** | **String**| The name that needs to be deleted | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**username** | **String** | The name that needs to be deleted | Required | 
 
 ### Return type
 
@@ -136,12 +136,12 @@ No authorization required
 > crate::models::User get_user_by_name(username)
 Get user by user name
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **username** | **String**| The name that needs to be fetched. Use user1 for testing. | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**username** | **String** | The name that needs to be fetched. Use user1 for testing. | Required | 
 
 ### Return type
 
@@ -164,13 +164,13 @@ No authorization required
 > String login_user(username, password)
 Logs user into the system
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **username** | **String**| The user name for login | 
-  **password** | **String**| The password for login in clear text | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**username** | **String** | The user name for login | Required | 
+**password** | **String** | The password for login in clear text | Required | 
 
 ### Return type
 
@@ -193,7 +193,7 @@ No authorization required
 > logout_user()
 Logs out current logged in user session
 
-### Required Parameters
+### Parameters
 
 This endpoint does not need any parameter.
 
@@ -220,13 +220,13 @@ Updated user
 
 This can only be done by the logged in user.
 
-### Required Parameters
+### Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-  **username** | **String**| name that need to be deleted | 
-  **body** | [**User**](User.md)| Updated user object | 
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**username** | **String** | name that need to be deleted | Required | 
+**body** | [**User**](User.md) | Updated user object | Required | 
 
 ### Return type
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

/cc @frol @farcaller @bjgill 

### Description of the PR

Fixes #3418. Only generated API markdown files are impacted.
