### PR TITLE
2745 typescript date format

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -119,7 +119,7 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
                 {{^isDateTime}}
                 {{#isDate}}
                 localVarQueryParameter['{{baseName}}'] = ({{paramName}} as any instanceof Date) ?
-                    ({{paramName}} as any).toISOString().substr(0,10); :
+                    ({{paramName}} as any).toISOString().substr(0,10) :
                     {{paramName}};
                 {{/isDate}}
                 {{^isDate}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -118,7 +118,9 @@ export const {{classname}}AxiosParamCreator = function (configuration?: Configur
                 {{/isDateTime}}
                 {{^isDateTime}}
                 {{#isDate}}
-                localVarQueryParameter['{{baseName}}'] = ({{paramName}} as any).toISOString();
+                localVarQueryParameter['{{baseName}}'] = ({{paramName}} as any instanceof Date) ?
+                    ({{paramName}} as any).toISOString().substr(0,10); :
+                    {{paramName}};
                 {{/isDate}}
                 {{^isDate}}
                 localVarQueryParameter['{{baseName}}'] = {{paramName}};


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny 

Fair warning that I tested this out more thoroughly using swagger-codegen for this PR - https://github.com/swagger-api/swagger-codegen/pull/9594 - but it looks like the same exact issue.

Related to this [issue](https://github.com/OpenAPITools/openapi-generator/issues/2745). When using TypeScript Fetch and passing parameters to a "Date" field, they expect a type of "string", but then `toISOString()` is called on it, which causes the function to fail. 

Example json swagger:
```json
        "parameters": [
          {
            "name": "date",
            "in": "query",
            "type": "string",
            "format": "date"
          }
        ]
```

in In `AbstractTypeScriptClientCodegen.java the Typings map:
```
typeMapping.put("date", "string");
typeMapping.put("DateTime", "Date");
```

template issue:
```mustache
{{#isDate}}
queryParameters['{{baseName}}'] = (requestParameters.{{paramName}} as any).toISOString();
{{/isDate}}
```
`requestParameters.{{paramName}}` can never be a Date, since it has to be a string. 


fixes https://github.com/OpenAPITools/openapi-generator/issues/2745