### PR TITLE
add modelNamePrefix option for qt5

### DIFF
--- a/docs/generators/cpp-qt5-client.md
+++ b/docs/generators/cpp-qt5-client.md
@@ -12,4 +12,5 @@ sidebar_label: cpp-qt5-client
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |cppNamespace|C++ namespace (convention: name::space::for::api).| |OpenAPI|
+|modelNamePrefix|Prefix that will be prepended to all model names.| |OAI|
 |optionalProjectFile|Generate client.pri.| |true|

--- a/docs/generators/cpp-qt5-client.md
+++ b/docs/generators/cpp-qt5-client.md
@@ -12,5 +12,4 @@ sidebar_label: cpp-qt5-client
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |cppNamespace|C++ namespace (convention: name::space::for::api).| |OpenAPI|
-|cppNamespace|C++ namespace (convention: name::space::for::api).| |OpenAPI|
 |optionalProjectFile|Generate client.pri.| |true|

--- a/docs/generators/cpp-qt5-qhttpengine-server.md
+++ b/docs/generators/cpp-qt5-qhttpengine-server.md
@@ -12,3 +12,4 @@ sidebar_label: cpp-qt5-qhttpengine-server
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |cppNamespace|C++ namespace (convention: name::space::for::api).| |OpenAPI|
+|modelNamePrefix|Prefix that will be prepended to all model names.| |OAI|

--- a/docs/generators/cpp-qt5-qhttpengine-server.md
+++ b/docs/generators/cpp-qt5-qhttpengine-server.md
@@ -12,4 +12,3 @@ sidebar_label: cpp-qt5-qhttpengine-server
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
 |cppNamespace|C++ namespace (convention: name::space::for::api).| |OpenAPI|
-|cppNamespace|C++ namespace (convention: name::space::for::api).| |OpenAPI|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -203,10 +203,10 @@ public class CodegenConstants {
     public static final String ENUM_PROPERTY_NAMING_DESC = "Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'";
 
     public static final String MODEL_NAME_PREFIX = "modelNamePrefix";
-    public static final String MODEL_NAME_PREFIX_DESC = "Prefix that will be prepended to all model names. Default is the empty string.";
+    public static final String MODEL_NAME_PREFIX_DESC = "Prefix that will be prepended to all model names.";
 
     public static final String MODEL_NAME_SUFFIX = "modelNameSuffix";
-    public static final String MODEL_NAME_SUFFIX_DESC = "Suffix that will be appended to all model names. Default is the empty string.";
+    public static final String MODEL_NAME_SUFFIX_DESC = "Suffix that will be appended to all model names.";
 
     public static final String GIT_USER_ID = "gitUserId";
     public static final String GIT_USER_ID_DESC = "Git user ID, e.g. openapitools.";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenConfig;
+import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenParameter;
@@ -34,6 +35,7 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
         }
         // CLI options
         addOption(CPP_NAMESPACE, CPP_NAMESPACE_DESC, this.cppNamespace);
+        addOption(CodegenConstants.MODEL_NAME_PREFIX, CodegenConstants.MODEL_NAME_PREFIX_DESC, this.modelNamePrefix);
 
         /*
          * Additional Properties.  These values can be passed to the templates and
@@ -110,7 +112,9 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
         }
 
         additionalProperties.put("cppNamespaceDeclarations", cppNamespace.split("\\::"));
+
         if (additionalProperties.containsKey("modelNamePrefix")) {
+            modelNamePrefix = (String) additionalProperties.get("modelNamePrefix");
             typeMapping.put("object", modelNamePrefix + "Object");
             additionalProperties().put("prefix", modelNamePrefix);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
@@ -45,9 +45,7 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
         // Write defaults namespace in properties so that it can be accessible in templates.
         // At this point command line has not been parsed so if value is given
         // in command line it will supersede this content
-        additionalProperties.put("cppNamespace", cppNamespace);   
-        // CLI options
-        addOption(CPP_NAMESPACE, CPP_NAMESPACE_DESC, this.cppNamespace);
+        additionalProperties.put("cppNamespace", cppNamespace);
         /*
          * Language Specific Primitives.  These types will not trigger imports by
          * the client generator


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR add the `modelNamePrefix` additional property to the Qt5 generator.

It also fix the double `cppNamespace` entry when running `openapi-generator config-help -g cpp-qt5-client`.

@ravinikam @stkrwork @etherealjoy