### PR TITLE
[Java] Fix numeric field names

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -585,6 +585,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             name = "_u";
         }
 
+        // numbers are not allowed at the beginning
+        if (name.matches("^\\d.*")) {
+            name = "_" + name;
+        }
+
         // if it's all uppper case, do nothing
         if (name.matches("^[A-Z0-9_]*$")) {
             return name;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -89,6 +89,11 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(fakeJavaCodegen.toVarName("USERname"), "usERname");
         Assert.assertEquals(fakeJavaCodegen.toVarName("USERNAME"), "USERNAME");
         Assert.assertEquals(fakeJavaCodegen.toVarName("USER123NAME"), "USER123NAME");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("1"), "_1");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("1a"), "_1a");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("1A"), "_1A");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("1AAAA"), "_1AAAA");
+        Assert.assertEquals(fakeJavaCodegen.toVarName("1AAaa"), "_1aAaa");
    }
 
    @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -94,15 +94,26 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(fakeJavaCodegen.toVarName("1A"), "_1A");
         Assert.assertEquals(fakeJavaCodegen.toVarName("1AAAA"), "_1AAAA");
         Assert.assertEquals(fakeJavaCodegen.toVarName("1AAaa"), "_1aAaa");
-   }
+    }
 
-   @Test
-   public void convertModelName() throws Exception {
+    @Test
+    public void convertModelName() throws Exception {
         Assert.assertEquals(fakeJavaCodegen.toModelName("name"), "Name");
         Assert.assertEquals(fakeJavaCodegen.toModelName("$name"), "Name");
         Assert.assertEquals(fakeJavaCodegen.toModelName("nam#e"), "Name");
         Assert.assertEquals(fakeJavaCodegen.toModelName("$another-fake?"), "AnotherFake");
-   }
+        Assert.assertEquals(fakeJavaCodegen.toModelName("1a"), "Model1a");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("1A"), "Model1A");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("AAAb"), "AAAb");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("aBB"), "ABB");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("AaBBa"), "AaBBa");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("A_B"), "AB");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("A-B"), "AB");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("Aa_Bb"), "AaBb");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("Aa-Bb"), "AaBb");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("Aa_bb"), "AaBb");
+        Assert.assertEquals(fakeJavaCodegen.toModelName("Aa-bb"), "AaBb");
+    }
 
     @Test
     public void testInitialConfigValues() throws Exception {
@@ -168,7 +179,7 @@ public class AbstractJavaCodegenTest {
     }
 
     @Test
-    public void toEnumValue(){
+    public void toEnumValue() {
         final AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
         Assert.assertEquals(codegen.toEnumValue("1", "Integer"), "1");
         Assert.assertEquals(codegen.toEnumValue("42", "Double"), "42");
@@ -218,7 +229,7 @@ public class AbstractJavaCodegenTest {
         codegen.setOutputDir("/User/open.api.tools");
         Assert.assertEquals(codegen.apiDocFileFolder(), "/User/open.api.tools/docs/".replace('/', File.separatorChar));
     }
-  
+
     @Test(description = "tests if API version specification is used if no version is provided in additional properties")
     public void openApiversionTest() {
         final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
@@ -315,6 +326,7 @@ public class AbstractJavaCodegenTest {
         /**
          * Gets artifact version.
          * Only for testing purposes.
+         *
          * @return version
          */
         public String getArtifactVersion() {


### PR DESCRIPTION
…nerators are escaped now.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Somehow the generator started somewhen to generate broken java code if the fields in the openapi spec are staring with a number. Numbers are not allowed at the start of a word in java so they need to be escaped. This bugfix escapes all varNames which start with a number with an underscore like it was sometime before

### Fixed Issues:
- fixes https://github.com/OpenAPITools/openapi-generator/issues/3293

### Technical Commitee for Java:
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)