### PR TITLE
[typescript-rxjs]: support reponseType blob

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -306,6 +306,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
             this.hasProduces = o.hasProduces;
             this.hasParams = o.hasParams;
             this.hasOptionalParams = o.hasOptionalParams;
+            this.hasRequiredParams = o.hasRequiredParams;
             this.returnTypeIsPrimitive = o.returnTypeIsPrimitive;
             this.returnSimpleType = o.returnSimpleType;
             this.subresourceOperation = o.subresourceOperation;
@@ -314,6 +315,7 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
             this.isMultipart = o.isMultipart;
             this.hasMore = o.hasMore;
             this.isResponseBinary = o.isResponseBinary;
+            this.isResponseFile = o.isResponseFile;
             this.hasReference = o.hasReference;
             this.isRestfulIndex = o.isRestfulIndex;
             this.isRestfulShow = o.isRestfulShow;
@@ -321,6 +323,8 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
             this.isRestfulUpdate = o.isRestfulUpdate;
             this.isRestfulDestroy = o.isRestfulDestroy;
             this.isRestful = o.isRestful;
+            this.isDeprecated = o.isDeprecated;
+            this.isCallbackRequest = o.isCallbackRequest;
             this.path = o.path;
             this.operationId = o.operationId;
             this.returnType = o.returnType;
@@ -335,6 +339,8 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
             this.discriminator = o.discriminator;
             this.consumes = o.consumes;
             this.produces = o.produces;
+            this.prioritizedContentTypes = o.prioritizedContentTypes;
+            this.servers = o.servers;
             this.bodyParam = o.bodyParam;
             this.allParams = o.allParams;
             this.bodyParams = o.bodyParams;
@@ -342,18 +348,23 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
             this.queryParams = o.queryParams;
             this.headerParams = o.headerParams;
             this.formParams = o.formParams;
+            this.cookieParams = o.cookieParams;
             this.requiredParams = o.requiredParams;
             this.optionalParams = o.optionalParams;
             this.authMethods = o.authMethods;
             this.tags = o.tags;
             this.responses = o.responses;
+            this.callbacks = o.callbacks;
             this.imports = o.imports;
             this.examples = o.examples;
+            this.requestBodyExamples = o.requestBodyExamples;
             this.externalDocs = o.externalDocs;
             this.vendorExtensions = o.vendorExtensions;
             this.nickname = o.nickname;
+            this.operationIdOriginal = o.operationIdOriginal;
             this.operationIdLowerCase = o.operationIdLowerCase;
             this.operationIdCamelCase = o.operationIdCamelCase;
+            this.operationIdSnakeCase = o.operationIdSnakeCase;
 
             // new fields
             this.hasHttpHeaders = o.getHasHeaderParams() || o.getHasBodyParam() || o.hasAuthMethods;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -42,10 +42,6 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
     public TypeScriptRxjsClientCodegen() {
         super();
 
-        // clear import mapping (from default generator) as TS does not use it
-        // at the moment
-        importMapping.clear();
-
         outputFolder = "generated-code/typescript-rxjs";
         embeddedTemplateDir = templateDir = "typescript-rxjs";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptRxjsClientCodegen.java
@@ -286,10 +286,10 @@ public class TypeScriptRxjsClientCodegen extends AbstractTypeScriptClientCodegen
         this.reservedWords.add("ModelPropertyNaming");
         this.reservedWords.add("RequestArgs");
         this.reservedWords.add("RequestOpts");
+        this.reservedWords.add("ResponseArgs");
         this.reservedWords.add("exists");
-        this.reservedWords.add("RequestContext");
-        this.reservedWords.add("ResponseContext");
         this.reservedWords.add("Middleware");
+        this.reservedWords.add("AjaxRequest");
         this.reservedWords.add("AjaxResponse");
     }
 

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/apis.mustache
@@ -171,6 +171,9 @@ export class {{classname}} extends BaseAPI {
             {{#hasFormParams}}
             body: formData,
             {{/hasFormParams}}
+{{#isResponseFile}}
+            responseType: 'blob'
+{{/isResponseFile}}
         });
     }
 

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -97,6 +97,7 @@ export class BaseAPI {
             method: requestOpts.method,
             headers: requestOpts.headers,
             body: requestOpts.body instanceof FormData ? requestOpts.body : JSON.stringify(requestOpts.body),
+            responseType: requestOpts.responseType || 'json'
         };
     }
 
@@ -149,6 +150,7 @@ export interface RequestOpts {
     headers?: HttpHeaders;
     query?: HttpQuery;
     body?: HttpBody;
+    responseType?: string;
 }
 
 export const encodeURI = (value: any) => encodeURIComponent(String(value))

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -150,7 +150,7 @@ export interface RequestOpts {
     headers?: HttpHeaders;
     query?: HttpQuery;
     body?: HttpBody;
-    responseType?: string;
+    responseType?: 'json' | 'blob' | 'arraybuffer' | 'text';
 }
 
 export const encodeURI = (value: any) => encodeURIComponent(String(value))

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -108,6 +108,7 @@ export class BaseAPI {
             method: requestOpts.method,
             headers: requestOpts.headers,
             body: requestOpts.body instanceof FormData ? requestOpts.body : JSON.stringify(requestOpts.body),
+            responseType: requestOpts.responseType || 'json'
         };
     }
 
@@ -160,6 +161,7 @@ export interface RequestOpts {
     headers?: HttpHeaders;
     query?: HttpQuery;
     body?: HttpBody;
+    responseType?: 'json' | 'blob' | 'arraybuffer' | 'text';
 }
 
 export const encodeURI = (value: any) => encodeURIComponent(String(value))

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -108,6 +108,7 @@ export class BaseAPI {
             method: requestOpts.method,
             headers: requestOpts.headers,
             body: requestOpts.body instanceof FormData ? requestOpts.body : JSON.stringify(requestOpts.body),
+            responseType: requestOpts.responseType || 'json'
         };
     }
 
@@ -160,6 +161,7 @@ export interface RequestOpts {
     headers?: HttpHeaders;
     query?: HttpQuery;
     body?: HttpBody;
+    responseType?: 'json' | 'blob' | 'arraybuffer' | 'text';
 }
 
 export const encodeURI = (value: any) => encodeURIComponent(String(value))

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
@@ -108,6 +108,7 @@ export class BaseAPI {
             method: requestOpts.method,
             headers: requestOpts.headers,
             body: requestOpts.body instanceof FormData ? requestOpts.body : JSON.stringify(requestOpts.body),
+            responseType: requestOpts.responseType || 'json'
         };
     }
 
@@ -160,6 +161,7 @@ export interface RequestOpts {
     headers?: HttpHeaders;
     query?: HttpQuery;
     body?: HttpBody;
+    responseType?: 'json' | 'blob' | 'arraybuffer' | 'text';
 }
 
 export const encodeURI = (value: any) => encodeURIComponent(String(value))

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -108,6 +108,7 @@ export class BaseAPI {
             method: requestOpts.method,
             headers: requestOpts.headers,
             body: requestOpts.body instanceof FormData ? requestOpts.body : JSON.stringify(requestOpts.body),
+            responseType: requestOpts.responseType || 'json'
         };
     }
 
@@ -160,6 +161,7 @@ export interface RequestOpts {
     headers?: HttpHeaders;
     query?: HttpQuery;
     body?: HttpBody;
+    responseType?: 'json' | 'blob' | 'arraybuffer' | 'text';
 }
 
 export const encodeURI = (value: any) => encodeURIComponent(String(value))


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The goal is to generate the correct `responseType` which is passed to `rxjs/ajax`. 
By default this is `json` as visible here: <https://github.com/ReactiveX/rxjs/blob/master/src/internal/observable/dom/AjaxObservable.ts#L167)> but it can be overriden.

I am not too sure about all the possible types but I found `json`, `text`, `blob` and `arraybuffer` to be supported by `rxjs/ajax` based on <https://github.com/Reactive-Extensions/RxJS-DOM/pull/121/files#diff-d3b897234759c07ed79441f35e56b67fR22>. Perhaps it's also possible to pass `document` and `ms-stream` as described there for completeness: <https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType>.

The one that I personally need for a project is `blob` in order to download an excel file.

The relevant lines for this in the `api.json` are:
```
"/api/export": {  
    "get": {
        "produces": ["*/*"],
        "responses": {
            "200": {
                "description": "OK",
                "schema": {  
                    "type": "string",
                    "format": "byte" // <–– here
                }
            }
        }
    }
}
```

However `AbstractTypeScriptClientCodegen` maps this to a string because of `typeMapping.put("ByteArray", "string");`.
I tried removing this via `this.typeMapping.remove("ByteArray");` in `TypeScriptRxjsClientCodegen` but then I end up with another import being generated for a model `ByteArray` which does not exist.

Here are the changes on the call:
```
-    exportUsingGET = (): Observable<object> => {
-        return this.request<object>({
+    exportUsingGET = (): Observable<ByteArray> => {
+        return this.request<ByteArray>({
             path: '/api/export',
             method: 'GET',
             responseType: 'blob' // <–– that's the one I need
         });
     }
```

In order to solve this I need some input on how to get there.
Or asked differently what's the reason for the mapping of `ByteArray` to `string`?
Or any how to figure out the appropriate `responseType`?


@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07)
