### PR TITLE
1792 fix remote spec handling and hash calculation

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -32,6 +32,15 @@ import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyRese
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -422,7 +431,7 @@ public class CodeGenMojo extends AbstractMojo {
                 if (inputSpecFile.exists()) {
                     File storedInputSpecHashFile = getHashFile(inputSpecFile);
                     if(storedInputSpecHashFile.exists()) {
-                        String inputSpecHash = Files.asByteSource(inputSpecFile).hash(Hashing.sha256()).toString();
+                        String inputSpecHash = calculateInputSpecHash(inputSpecFile);
                         String storedInputSpecHash = Files.asCharSource(storedInputSpecHashFile, Charsets.UTF_8).read();
                         if (inputSpecHash.equals(storedInputSpecHash)) {
                             getLog().info(
@@ -697,12 +706,7 @@ public class CodeGenMojo extends AbstractMojo {
 
             // Store a checksum of the input spec
             File storedInputSpecHashFile = getHashFile(inputSpecFile);
-            ByteSource inputSpecByteSource =
-                inputSpecFile.exists()
-                    ? Files.asByteSource(inputSpecFile)
-                    : CharSource.wrap(ClasspathHelper.loadFileFromClasspath(inputSpecFile.toString().replaceAll("\\\\","/")))
-                        .asByteSource(Charsets.UTF_8);
-            String  inputSpecHash =inputSpecByteSource.hash(Hashing.sha256()).toString();
+            String inputSpecHash = calculateInputSpecHash(inputSpecFile);
 
             if (storedInputSpecHashFile.getParent() != null && !new File(storedInputSpecHashFile.getParent()).exists()) {
                 File parent = new File(storedInputSpecHashFile.getParent());
@@ -723,8 +727,70 @@ public class CodeGenMojo extends AbstractMojo {
         }
     }
 
+    /**
+     * Calculate openapi specification file hash. If specification is hosted on remote resource it is downloaded first
+     *
+     * @param inputSpecFile - Openapi specification input file to calculate it's hash.
+     *                        Does not taken into account if input spec is hosted on remote resource
+     * @return openapi specification file hash
+     * @throws IOException
+     */
+    private String calculateInputSpecHash(File inputSpecFile) throws IOException {
+
+        URL inputSpecRemoteUrl = inputSpecRemoteUrl();
+
+        File inputSpecTempFile = inputSpecFile;
+
+        if (inputSpecRemoteUrl != null) {
+            inputSpecTempFile = File.createTempFile("openapi-spec", ".tmp");
+
+            ReadableByteChannel readableByteChannel = Channels.newChannel(inputSpecRemoteUrl.openStream());
+
+            FileOutputStream fileOutputStream = new FileOutputStream(inputSpecTempFile);
+            FileChannel fileChannel = fileOutputStream.getChannel();
+
+            fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+        }
+
+        ByteSource inputSpecByteSource =
+                inputSpecTempFile.exists()
+                        ? Files.asByteSource(inputSpecTempFile)
+                        : CharSource.wrap(ClasspathHelper.loadFileFromClasspath(inputSpecTempFile.toString().replaceAll("\\\\","/")))
+                        .asByteSource(Charsets.UTF_8);
+
+        return inputSpecByteSource.hash(Hashing.sha256()).toString();
+    }
+
+    /**
+     * Try to parse inputSpec setting string into URL
+     * @return A valid URL or null if inputSpec is not a valid URL
+     */
+    private URL inputSpecRemoteUrl(){
+        try {
+            return new URI(inputSpec).toURL();
+        } catch (URISyntaxException e) {
+            return null;
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Get specification hash file
+     * @param inputSpecFile - Openapi specification input file to calculate it's hash.
+     *                        Does not taken into account if input spec is hosted on remote resource
+     * @return a file with previously calculated hash
+     */
     private File getHashFile(File inputSpecFile) {
-        return new File(output.getPath() + File.separator + ".openapi-generator" + File.separator + inputSpecFile.getName() + ".sha256");
+        String name = inputSpecFile.getName();
+
+        URL url = inputSpecRemoteUrl();
+        if (url != null) {
+            String[] segments = url.getPath().split("/");
+            name = Files.getNameWithoutExtension(segments[segments.length - 1]);
+        }
+
+        return new File(output.getPath() + File.separator + ".openapi-generator" + File.separator + name + ".sha256");
     }
 
     private String getCompileSourceRoot() {
@@ -734,8 +800,7 @@ public class CodeGenMojo extends AbstractMojo {
         final String sourceFolder =
                 sourceFolderObject == null ? "src/main/java" : sourceFolderObject.toString();
 
-        String sourceJavaFolder = output.toString() + "/" + sourceFolder;
-        return sourceJavaFolder;
+        return output.toString() + "/" + sourceFolder;
     }
 
     private void addCompileSourceRootIfConfigured() {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Current implementataion of maven plugin has the feature of skipping generation if no changes was detected in schema file. While the skipping itself is applied only when the **skipIfSpecIsUnchanged** option is present in the configuration file - hash calculation is calculated every time:

```
File storedInputSpecHashFile = getHashFile(inputSpecFile);
ByteSource inputSpecByteSource =
    inputSpecFile.exists()
        ? Files.asByteSource(inputSpecFile)
        : CharSource.wrap(ClasspathHelper.loadFileFromClasspath(inputSpecFile.toString().replaceAll("\\\\","/")))
                        .asByteSource(Charsets.UTF_8);
String  inputSpecHash =inputSpecByteSource.hash(Hashing.sha256()).toString();
```

This makes impossible to use remote spec files in pom configuration. FileNotFoundException is thrown at the end of generation phase despite that all classes generated fine. Generator itself are working great with remote specs.

My proposition in this PR is to fix this issue and allow the generator to work with remote spec files:

```
URL inputSpecRemoteUrl = inputSpecRemoteUrl();
File inputSpecTempFile = inputSpecFile;
if (inputSpecRemoteUrl != null) {
    inputSpecTempFile = File.createTempFile("openapi-spec", ".tmp");
    ReadableByteChannel readableByteChannel = Channels.newChannel(inputSpecRemoteUrl.openStream());
    
    FileOutputStream fileOutputStream = new FileOutputStream(inputSpecTempFile);
    FileChannel fileChannel = fileOutputStream.getChannel();

    fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
}

ByteSource inputSpecByteSource =
    inputSpecTempFile.exists()
        ? Files.asByteSource(inputSpecTempFile)
        : CharSource.wrap(ClasspathHelper.loadFileFromClasspath(inputSpecTempFile.toString().replaceAll("\\\\","/"))).asByteSource(Charsets.UTF_8);

return inputSpecByteSource.hash(Hashing.sha256()).toString();
``` 

To fix #1792