### PR TITLE
[REQ][JAVA] Add JsonIgnoreProperties to model

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -51,6 +51,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public static final String WITH_XML = "withXml";
     public static final String SUPPORT_JAVA6 = "supportJava6";
     public static final String DISABLE_HTML_ESCAPING = "disableHtmlEscaping";
+    public static final String DISABLE_ADDITIONAL_FIELDS_ANNOTATION = "disableAdditionalFieldsAnnotation";
     public static final String BOOLEAN_GETTER_PREFIX = "booleanGetterPrefix";
     public static final String USE_NULL_FOR_UNKNOWN_ENUM_VALUE = "useNullForUnknownEnumValue";
 
@@ -85,6 +86,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     protected String modelDocPath = "docs/";
     protected boolean supportJava6 = false;
     protected boolean disableHtmlEscaping = false;
+    protected boolean disableAdditionalFieldsAnnotation = false;
     protected String booleanGetterPrefix = "get";
     protected boolean useNullForUnknownEnumValue = false;
     protected String parentGroupId = "";
@@ -183,6 +185,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         cliOptions.add(java8Mode);
 
         cliOptions.add(CliOption.newBoolean(DISABLE_HTML_ESCAPING, "Disable HTML escaping of JSON strings when using gson (needed to avoid problems with byte[] fields)", disableHtmlEscaping));
+        cliOptions.add(CliOption.newBoolean(DISABLE_ADDITIONAL_FIELDS_ANNOTATION, "Disables the @JsonIgnoreProperties(ignoreUnknown = true) annotation.", disableAdditionalFieldsAnnotation));
         cliOptions.add(CliOption.newString(BOOLEAN_GETTER_PREFIX, "Set booleanGetterPrefix").defaultValue(this.getBooleanGetterPrefix()));
 
         cliOptions.add(CliOption.newString(CodegenConstants.PARENT_GROUP_ID, CodegenConstants.PARENT_GROUP_ID_DESC));
@@ -215,6 +218,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             this.setDisableHtmlEscaping(Boolean.valueOf(additionalProperties.get(DISABLE_HTML_ESCAPING).toString()));
         }
         additionalProperties.put(DISABLE_HTML_ESCAPING, disableHtmlEscaping);
+
+        if (additionalProperties.containsKey(DISABLE_ADDITIONAL_FIELDS_ANNOTATION)) {
+            this.setDisableAdditionalFieldsAnnotation(Boolean.valueOf(additionalProperties.get(DISABLE_ADDITIONAL_FIELDS_ANNOTATION).toString()));
+        }
+        additionalProperties.put(DISABLE_ADDITIONAL_FIELDS_ANNOTATION, disableAdditionalFieldsAnnotation);
 
         if (additionalProperties.containsKey(BOOLEAN_GETTER_PREFIX)) {
             this.setBooleanGetterPrefix(additionalProperties.get(BOOLEAN_GETTER_PREFIX).toString());
@@ -1383,6 +1391,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     public void setDisableHtmlEscaping(boolean disabled) {
         this.disableHtmlEscaping = disabled;
+    }
+
+    public void setDisableAdditionalFieldsAnnotation(boolean disabled) {
+        this.disableAdditionalFieldsAnnotation = disabled;
     }
 
     public String getBooleanGetterPrefix() {

--- a/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/model.mustache
@@ -1,7 +1,8 @@
 package {{package}};
 
 import java.util.Objects;
-{{#imports}}import {{import}};
+{{^disableAdditionalFieldsAnnotation}}import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+{{/disableAdditionalFieldsAnnotation}}{{#imports}}import {{import}};
 {{/imports}}
 import org.openapitools.jackson.nullable.JsonNullable;
 {{#serializableModel}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -3,7 +3,8 @@
  */{{#description}}
 @ApiModel(description = "{{{description}}}"){{/description}}
 {{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
-public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}{{#hateoas}}extends ResourceSupport {{/hateoas}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
+{{^disableAdditionalFieldsAnnotation}}@JsonIgnoreProperties(ignoreUnknown = true)
+{{/disableAdditionalFieldsAnnotation}}public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}{{#hateoas}}extends ResourceSupport {{/hateoas}}{{/parent}} {{#serializableModel}}implements Serializable{{/serializableModel}} {
 {{#serializableModel}}
   private static final long serialVersionUID = 1L;
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSCXFExtServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSCXFExtServerCodegenTest.java
@@ -43,6 +43,10 @@ public class JavaJAXRSCXFExtServerCodegenTest extends JavaJaxrsBaseTest {
         public boolean isDisableHtmlEscaping() {
             return disableHtmlEscaping;
         }
+        // AbstractJavaCodegen.DISABLE_ADDITIONAL_FIELD_ANNOTATION
+        public boolean isDisableAdditionalFieldsAnnotation() {
+            return disableAdditionalFieldsAnnotation;
+        }
 
         // AbstractJavaCodegen.FULL_JAVA_UTIL
         public boolean isFullJavaUtil() {
@@ -249,6 +253,7 @@ public class JavaJAXRSCXFExtServerCodegenTest extends JavaJaxrsBaseTest {
         additionalProperties.put(AbstractJavaCodegen.BOOLEAN_GETTER_PREFIX, "isIt");
         additionalProperties.put(AbstractJavaCodegen.DATE_LIBRARY, "MyDateLibrary");
         additionalProperties.put(AbstractJavaCodegen.DISABLE_HTML_ESCAPING, "true");
+        additionalProperties.put(AbstractJavaCodegen.DISABLE_ADDITIONAL_FIELDS_ANNOTATION, "true");
         additionalProperties.put(AbstractJavaCodegen.FULL_JAVA_UTIL, "true");
         additionalProperties.put(AbstractJavaCodegen.JAVA8_MODE, "true");
         additionalProperties.put(AbstractJavaCodegen.SUPPORT_ASYNC, "true");
@@ -325,6 +330,7 @@ public class JavaJAXRSCXFExtServerCodegenTest extends JavaJaxrsBaseTest {
         assertEquals(testerCodegen.getBooleanGetterPrefix(), "isIt");
         assertEquals(testerCodegen.getDateLibrary(), "MyDateLibrary");
         assertEquals(testerCodegen.isDisableHtmlEscaping(), true);
+        assertEquals(testerCodegen.isDisableAdditionalFieldsAnnotation(), true);
         assertEquals(testerCodegen.isFullJavaUtil(), true);
         assertEquals(testerCodegen.isJava8Mode(), true);
         assertEquals(testerCodegen.isSupportAsync(), true);


### PR DESCRIPTION
Work in progress. I only did the Pojo class so far. Enums and other specialities have to be checked, too.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Added the annotation 
```java
import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@JsonIgnoreProperties(ignoreUnknown = true)
```
to every generated Pojo. This feature can be turned off via the flag `disableAdditionalFieldsAnnotation`.
This makes the generated code more independend from the attached default json parser.


### Fixed Issues:
- fixes https://github.com/OpenAPITools/openapi-generator/issues/3438

### Technical Commitee for Java:
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)