### PR TITLE
Feature/mustache lambda tests

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -240,13 +240,10 @@ public class DefaultCodegen implements CodegenConfig {
         }
 
         if (additionalProperties.containsKey("lambda")) {
-            LOGGER.warn("A property named 'lambda' already exists. Mustache lambdas renamed from 'lambda' to '_lambda'. " +
-                    "You'll likely need to use a custom template, " +
-                    "see https://github.com/OpenAPITools/openapi-generator/blob/master/docs/templating.md. ");
-            additionalProperties.put("_lambda", lambdas);
-        } else {
-            additionalProperties.put("lambda", lambdas);
+            LOGGER.error("A property called 'lambda' already exists in additionalProperties");
+            throw new RuntimeException("A property called 'lambda' already exists in additionalProperties");
         }
+        additionalProperties.put("lambda", lambdas);
     }
 
     // override with any special post-processing for all models

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -18,6 +18,8 @@
 package org.openapitools.codegen;
 
 import com.google.common.collect.Sets;
+import com.samskivert.mustache.Mustache.Lambda;
+
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -30,14 +32,19 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.parser.core.models.ParseOptions;
-import org.openapitools.codegen.languages.features.CXFServerFeatures;
+
+import org.openapitools.codegen.templating.mustache.CamelCaseLambda;
+import org.openapitools.codegen.templating.mustache.IndentedLambda;
+import org.openapitools.codegen.templating.mustache.LowercaseLambda;
+import org.openapitools.codegen.templating.mustache.TitlecaseLambda;
+import org.openapitools.codegen.templating.mustache.UppercaseLambda;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -888,6 +895,7 @@ public class DefaultCodegenTest {
 
         Assert.assertEquals(codegenModel.vars.size(), 1);
     }
+
     @Test
     public void modelWithSuffixDoNotContainInheritedVars() {
         DefaultCodegen codegen = new DefaultCodegen();
@@ -901,6 +909,27 @@ public class DefaultCodegenTest {
         CodegenModel codegenModel = codegen.fromModel("Dog", openAPI.getComponents().getSchemas().get("Dog"));
 
         Assert.assertEquals(codegenModel.vars.size(), 1);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void commonLambdasRegistrationTest() {
+
+        DefaultCodegen codegen = new DefaultCodegen();
+        Object lambdasObj = codegen.additionalProperties.get("lambda");
+
+        assertNotNull(lambdasObj, "Expecting lambda in additionalProperties");
+
+        Map<String, Lambda> lambdas = (Map<String, Lambda>) lambdasObj;
+
+        assertTrue(lambdas.get("lowercase") instanceof LowercaseLambda, "Expecting LowercaseLambda class");
+        assertTrue(lambdas.get("uppercase") instanceof UppercaseLambda, "Expecting UppercaseLambda class");
+        assertTrue(lambdas.get("titlecase") instanceof TitlecaseLambda, "Expecting TitlecaseLambda class");
+        assertTrue(lambdas.get("camelcase") instanceof CamelCaseLambda, "Expecting CamelCaseLambda class");
+        assertTrue(lambdas.get("indented") instanceof IndentedLambda, "Expecting IndentedLambda class");
+        assertTrue(lambdas.get("indented_8") instanceof IndentedLambda, "Expecting IndentedLambda class");
+        assertTrue(lambdas.get("indented_12") instanceof IndentedLambda, "Expecting IndentedLambda class");
+        assertTrue(lambdas.get("indented_16") instanceof IndentedLambda, "Expecting IndentedLambda class");
     }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/CamelCaseLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/CamelCaseLambdaTest.java
@@ -1,0 +1,63 @@
+package org.openapitools.codegen.templating.mustache;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.openapitools.codegen.CodegenConfig;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class CamelCaseLambdaTest extends LambdaTest {
+
+    @Mock
+    CodegenConfig generator;
+
+    @BeforeMethod
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void camelCaseTest() {
+        // Given
+        Map<String, Object> ctx = context("camelcase", new CamelCaseLambda());
+
+        // When & Then
+        test("inputText", "{{#camelcase}}Input-text{{/camelcase}}", ctx);
+    }
+
+    @Test
+    public void camelCaseReservedWordTest() {
+        // Given
+        Map<String, Object> ctx = context("camelcase", new CamelCaseLambda().generator(generator));
+
+        when(generator.sanitizeName(anyString())).then(returnsFirstArg());
+        when(generator.reservedWords()).thenReturn(new HashSet<String>(Arrays.asList("reservedWord")));
+        when(generator.escapeReservedWord("reservedWord")).thenReturn("escapedReservedWord");
+
+        // When & Then
+        test("escapedReservedWord", "{{#camelcase}}reserved-word{{/camelcase}}", ctx);
+    }
+
+    @Test
+    public void camelCaseEscapeParamTest() {
+        // Given
+        Map<String, Object> ctx = context("camelcase", new CamelCaseLambda()
+                .generator(generator).escapeAsParamName(true));
+
+        when(generator.sanitizeName(anyString())).then(returnsFirstArg());
+        when(generator.reservedWords()).thenReturn(new HashSet<String>());
+        when(generator.toParamName("inputText")).thenReturn("inputTextAsParam");
+
+        // When & Then
+        test("inputTextAsParam", "{{#camelcase}}Input_text{{/camelcase}}", ctx);
+    }
+
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/IndentedLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/IndentedLambdaTest.java
@@ -1,0 +1,35 @@
+package org.openapitools.codegen.templating.mustache;
+
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+public class IndentedLambdaTest extends LambdaTest {
+
+    String lineSeparator = System.lineSeparator();
+
+    @Test
+    public void defaultIndentTest() {
+        // Given
+        Map<String, Object> ctx = context("indented", new IndentedLambda());
+        String lineSeparator = System.lineSeparator();
+
+        // When & Then
+        // IndentedLambda applies indentation from second line on of a template.
+        test("first line" + lineSeparator + "    second line",
+                "{{#indented}}first line" + lineSeparator +"second line{{/indented}}", ctx);
+    }
+
+    @Test
+    public void indentedCountTest() {
+        // Given
+        Map<String, Object> ctx = context("indented", new IndentedLambda(8, " "));
+
+        // When & Then
+        // IndentedLambda applies indentation from second line on of a template.
+        test("first line" + lineSeparator + "        second line",
+                "{{#indented}}first line" + lineSeparator +"second line{{/indented}}", ctx);
+    }
+
+
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/LambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/LambdaTest.java
@@ -1,0 +1,44 @@
+package org.openapitools.codegen.templating.mustache;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.samskivert.mustache.Mustache;
+
+/**
+ * Simple framework to test Mustache Lambdas. It avoids
+ * <pre>compiler->compile->execute->assert</pre>
+ * boilerplate code.
+ *
+ * Inspired by <a href="https://github.com/samskivert/jmustache/blob/master/src/test/java/com/samskivert/mustache/SharedTests.java">Jmustache SharedTests.java</a>
+ *
+ */
+public abstract class LambdaTest {
+
+    protected String execute(String template, Object ctx) {
+        return execute(Mustache.compiler(), template, ctx);
+    }
+
+    protected String execute(Mustache.Compiler compiler, String template, Object ctx) {
+        return compiler.compile(template).execute(ctx);
+    }
+
+    protected void test(String expected, String template, Map<String, Object> ctx) {
+        test(Mustache.compiler(), expected, template, ctx);
+    }
+
+    protected void test(Mustache.Compiler compiler, String expected,String template, Map<String, Object> ctx) {
+        assertEquals(execute(compiler, template, ctx), expected);
+    }
+
+    protected static Map<String, Object> context(Object... data) {
+        Map<String, Object> ctx = new HashMap<String, Object>();
+        for (int ii = 0; ii < data.length; ii += 2) {
+            ctx.put(data[ii].toString(), data[ii + 1]);
+        }
+        return ctx;
+    }
+
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/LowercaseLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/LowercaseLambdaTest.java
@@ -1,0 +1,49 @@
+package org.openapitools.codegen.templating.mustache;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.openapitools.codegen.CodegenConfig;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class LowercaseLambdaTest extends LambdaTest {
+
+    @Mock
+    CodegenConfig generator;
+
+    @BeforeMethod
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void lowercaseTest() {
+        // Given
+        Map<String, Object> ctx = context("lowercase", new LowercaseLambda());
+
+        // When & Then
+        test("input text", "{{#lowercase}}InPut Text{{/lowercase}}", ctx);
+    }
+
+    @Test
+    public void lowercaseReservedWordTest() {
+        // Given
+        Map<String, Object> ctx = context("lowercase", new LowercaseLambda().generator(generator));
+
+        when(generator.sanitizeName(anyString())).then(returnsFirstArg());
+        when(generator.reservedWords()).thenReturn(new HashSet<String>(Arrays.asList("reserved")));
+        when(generator.escapeReservedWord("reserved")).thenReturn("escaped-reserved");
+
+        // When & Then
+        test("escaped-reserved", "{{#lowercase}}rEservEd{{/lowercase}}", ctx);
+    }
+
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/OnChangeLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/OnChangeLambdaTest.java
@@ -1,0 +1,42 @@
+package org.openapitools.codegen.templating.mustache;
+
+import java.util.Map;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class OnChangeLambdaTest extends LambdaTest {
+
+    private Map<String, Object> ctx;
+
+    // OnChangeLambda holds internal state it is important that context is
+    // reinitialize before each test.
+    @BeforeMethod
+    public void setup() {
+        ctx = context("onchange", new OnChangeLambda());
+    }
+
+    @Test
+    public void firstValueIsReturnedTest() {
+        // Given
+
+        // When & Then
+        test("first", "{{#onchange}}first{{/onchange}}", ctx);
+    }
+
+    @Test
+    public void repeatingValueReturnedOnFirstOccurrenceTest() {
+        // Given
+
+        // When & Then
+        test("First", "{{#onchange}}First{{/onchange}}", ctx);
+        test("", "{{#onchange}}First{{/onchange}}", ctx);
+
+        test("Another", "{{#onchange}}Another{{/onchange}}", ctx);
+        test("", "{{#onchange}}Another{{/onchange}}", ctx);
+        test("", "{{#onchange}}Another{{/onchange}}", ctx);
+
+        test("First", "{{#onchange}}First{{/onchange}}", ctx);
+    }
+
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/TitlecaseLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/TitlecaseLambdaTest.java
@@ -1,0 +1,28 @@
+package org.openapitools.codegen.templating.mustache;
+
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+public class TitlecaseLambdaTest extends LambdaTest {
+
+    @Test
+    public void titlecaseTest() {
+        // Given
+        Map<String, Object> ctx = context("titlecase", new TitlecaseLambda());
+
+        // When & Then
+        test("Once Upon A Time", "{{#titlecase}}once upon a time{{/titlecase}}", ctx);
+    }
+
+    @Test
+    public void titlecaseWithDelimiterTest() {
+        // Given
+        Map<String, Object> ctx = context("titlecase", new TitlecaseLambda("-"));
+
+        // When & Then
+        test("Once-Upon-A-Time", "{{#titlecase}}once-upon-a-time{{/titlecase}}", ctx);
+    }
+
+
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/UppercaseLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/UppercaseLambdaTest.java
@@ -1,0 +1,18 @@
+package org.openapitools.codegen.templating.mustache;
+
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+public class UppercaseLambdaTest extends LambdaTest {
+
+    @Test
+    public void uppercaseTest() {
+        // Given
+        Map<String, Object> ctx = context("uppercase", new UppercaseLambda());
+
+        // When & Then
+        test("INPUT TEXT", "{{#uppercase}}InPut Text{{/uppercase}}", ctx);
+    }
+
+}


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Follow up PR to #3368.

1. In registering common Mustache lambdas, do not fallback to `_lambda` key when `lambda` is already take in additionalProperties. It is possible only if `lambda` key was taken by `DefaultCodegen` itself.
2. Unit tests of common Mustache lambdas.
