### PR TITLE
#3388 requestbody parameter type fix in case of additionalProperties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4741,10 +4741,22 @@ public class DefaultCodegen implements CodegenConfig {
             codegenParameter.paramName = toParamName(codegenParameter.baseName);
             codegenParameter.items = codegenProperty.items;
             codegenParameter.mostInnerItems = codegenProperty.mostInnerItems;
-            codegenParameter.dataType = getTypeDeclaration(schema);
-            codegenParameter.baseType = getSchemaType(inner);
             codegenParameter.isContainer = Boolean.TRUE;
             codegenParameter.isMapContainer = Boolean.TRUE;
+
+            CodegenModel codegenModel = null;
+            if (name != null) {
+                codegenModel = fromModel(name, schema);
+            }
+
+            if (codegenModel != null) {
+                codegenParameter.baseType = codegenModel.classname;
+                codegenParameter.dataType = getTypeDeclaration(codegenModel.classname);
+                imports.add(codegenParameter.baseType);
+            } else {
+                codegenParameter.dataType = getTypeDeclaration(schema);
+                codegenParameter.baseType = getSchemaType(inner);
+            }
 
             setParameterBooleanFlagWithCodegenProperty(codegenParameter, codegenProperty);
 


### PR DESCRIPTION
### Description of the PR

Solution for issue #3388. I have checked and return values or properties of models are generated well, meaning the real model class is used and not a Map in case additionalProperties is true on a model class.

Therefore, this fix generates the model class (if available) as type of the requestBody parameter in all languages.