### PR TITLE
[rust] Stop deriving Eq for models

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/model.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model.mustache
@@ -20,7 +20,7 @@ pub enum {{classname}} {
 
 {{!-- for non-enum schemas --}}
 {{^isEnum}}
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct {{{classname}}} {
 {{#vars}}
     {{#description}}
@@ -49,7 +49,7 @@ impl {{{classname}}} {
 {{#vars}}
 {{#isEnum}}
 /// {{{description}}}
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum {{enumName}} {
 {{#allowableValues}}
 {{#enumVars}}

--- a/samples/client/petstore/rust-reqwest/src/models/api_response.rs
+++ b/samples/client/petstore/rust-reqwest/src/models/api_response.rs
@@ -11,7 +11,7 @@
 /// ApiResponse : Describes the result of uploading an image resource
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ApiResponse {
     #[serde(rename = "code", skip_serializing_if = "Option::is_none")]
     pub code: Option<i32>,

--- a/samples/client/petstore/rust-reqwest/src/models/category.rs
+++ b/samples/client/petstore/rust-reqwest/src/models/category.rs
@@ -11,7 +11,7 @@
 /// Category : A category for a pet
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Category {
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<i64>,

--- a/samples/client/petstore/rust-reqwest/src/models/order.rs
+++ b/samples/client/petstore/rust-reqwest/src/models/order.rs
@@ -11,7 +11,7 @@
 /// Order : An order for a pets from the pet store
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Order {
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<i64>,
@@ -43,7 +43,7 @@ impl Order {
 }
 
 /// Order Status
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum Status {
     #[serde(rename = "placed")]
     Placed,

--- a/samples/client/petstore/rust-reqwest/src/models/pet.rs
+++ b/samples/client/petstore/rust-reqwest/src/models/pet.rs
@@ -11,7 +11,7 @@
 /// Pet : A pet for sale in the pet store
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Pet {
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<i64>,
@@ -43,7 +43,7 @@ impl Pet {
 }
 
 /// pet status in the store
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum Status {
     #[serde(rename = "available")]
     Available,

--- a/samples/client/petstore/rust-reqwest/src/models/tag.rs
+++ b/samples/client/petstore/rust-reqwest/src/models/tag.rs
@@ -11,7 +11,7 @@
 /// Tag : A tag for a pet
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<i64>,

--- a/samples/client/petstore/rust-reqwest/src/models/user.rs
+++ b/samples/client/petstore/rust-reqwest/src/models/user.rs
@@ -11,7 +11,7 @@
 /// User : A User who is purchasing from the pet store
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct User {
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<i64>,

--- a/samples/client/petstore/rust/src/models/api_response.rs
+++ b/samples/client/petstore/rust/src/models/api_response.rs
@@ -11,7 +11,7 @@
 /// ApiResponse : Describes the result of uploading an image resource
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ApiResponse {
     #[serde(rename = "code", skip_serializing_if = "Option::is_none")]
     pub code: Option<i32>,

--- a/samples/client/petstore/rust/src/models/category.rs
+++ b/samples/client/petstore/rust/src/models/category.rs
@@ -11,7 +11,7 @@
 /// Category : A category for a pet
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Category {
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<i64>,

--- a/samples/client/petstore/rust/src/models/order.rs
+++ b/samples/client/petstore/rust/src/models/order.rs
@@ -11,7 +11,7 @@
 /// Order : An order for a pets from the pet store
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Order {
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<i64>,
@@ -43,7 +43,7 @@ impl Order {
 }
 
 /// Order Status
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum Status {
     #[serde(rename = "placed")]
     Placed,

--- a/samples/client/petstore/rust/src/models/pet.rs
+++ b/samples/client/petstore/rust/src/models/pet.rs
@@ -11,7 +11,7 @@
 /// Pet : A pet for sale in the pet store
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Pet {
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<i64>,
@@ -43,7 +43,7 @@ impl Pet {
 }
 
 /// pet status in the store
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum Status {
     #[serde(rename = "available")]
     Available,

--- a/samples/client/petstore/rust/src/models/tag.rs
+++ b/samples/client/petstore/rust/src/models/tag.rs
@@ -11,7 +11,7 @@
 /// Tag : A tag for a pet
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<i64>,

--- a/samples/client/petstore/rust/src/models/user.rs
+++ b/samples/client/petstore/rust/src/models/user.rs
@@ -11,7 +11,7 @@
 /// User : A User who is purchasing from the pet store
 
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct User {
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<i64>,


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @frol @farcaller 

### Description of the PR

It fails if the model contains a float, which don't implement Eq.

Fix for bug introduced in https://github.com/OpenAPITools/openapi-generator/pull/3309. 

We really need to improve the testing of the rust generator to catch this sort of mistake in future. I don't have time to do this now, though.

