### PR TITLE
fix(typescript-angular): improve small template issues

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -333,7 +333,6 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         boolean hasSomeFormParams = false;
         for (CodegenOperation op : ops) {
             if (op.getHasFormParams()) {
-                System.out.println(op);
                 hasSomeFormParams = true;
             }
             if ((boolean) additionalProperties.get("useHttpClient")) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -330,7 +330,12 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         objs.put("apiFilename", getApiFilenameFromClassname(objs.get("classname").toString()));
 
         List<CodegenOperation> ops = (List<CodegenOperation>) objs.get("operation");
+        boolean hasSomeFormParams = false;
         for (CodegenOperation op : ops) {
+            if (op.getHasFormParams()) {
+                System.out.println(op);
+                hasSomeFormParams = true;
+            }
             if ((boolean) additionalProperties.get("useHttpClient")) {
                 op.httpMethod = op.httpMethod.toLowerCase(Locale.ENGLISH);
             } else {
@@ -405,6 +410,8 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
             // Overwrite path to TypeScript template string, after applying everything we just did.
             op.path = pathBuffer.toString();
         }
+
+        operations.put("hasSomeFormParams", hasSomeFormParams);
 
         // Add additional filename information for model imports in the services
         List<Map<String, Object>> imports = (List<Map<String, Object>>) operations.get("imports");

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -82,7 +82,7 @@ export class {{classname}} {
 {{/useHttpClient}}
     }
 
-{{#hasFormParams}}
+{{#hasSomeFormParams}}
     /**
      * @param consumes string[] mime-types
      * @return true: consumes contains 'multipart/form-data', false: otherwise
@@ -96,7 +96,7 @@ export class {{classname}} {
         }
         return false;
     }
-{{/hasFormParams}}
+{{/hasSomeFormParams}}
 
 {{^useHttpClient}}
 {{! Before HttpClient implementation or method overloading we relied on 2 functions, 1 to return the straight body as json

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -82,6 +82,7 @@ export class {{classname}} {
 {{/useHttpClient}}
     }
 
+{{#hasFormParams}}
     /**
      * @param consumes string[] mime-types
      * @return true: consumes contains 'multipart/form-data', false: otherwise
@@ -95,6 +96,7 @@ export class {{classname}} {
         }
         return false;
     }
+{{/hasFormParams}}
 
 {{^useHttpClient}}
 {{! Before HttpClient implementation or method overloading we relied on 2 functions, 1 to return the straight body as json
@@ -129,8 +131,12 @@ export class {{classname}} {
 
 {{#operation}}
     /**
+{{#summary}}
      * {{summary}}
+{{/summary}}
+{{#notes}}
      * {{notes}}
+{{/notes}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}{{#useHttpClient}}* @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.{{/useHttpClient}}
@@ -256,12 +262,25 @@ export class {{classname}} {
 {{/useHttpClient}}
         }
 
+{{#bodyParam}}
+{{- duplicated below, don't forget to change}}
         // to determine the Content-Type header
         const consumes: string[] = [
             {{#consumes}}
             '{{{mediaType}}}'{{#hasMore}},{{/hasMore}}
             {{/consumes}}
         ];
+{{/bodyParam}}
+{{#hasFormParams}}
+{{^bodyParam}}
+        // to determine the Content-Type header
+        const consumes: string[] = [
+            {{#consumes}}
+            '{{{mediaType}}}'{{#hasMore}},{{/hasMore}}
+            {{/consumes}}
+        ];
+{{/bodyParam}}
+{{/hasFormParams}}
 {{#bodyParam}}
         const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
         if (httpContentTypeSelected !== undefined) {

--- a/modules/openapi-generator/src/main/resources/typescript-angular/encoder.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/encoder.mustache
@@ -7,9 +7,9 @@ import { QueryEncoder } from '@angular/http';
 
 {{#useHttpClient}}
 /**
-* Custom HttpParameterCodec
-* Workaround for https://github.com/angular/angular/issues/18261
-*/
+ * Custom HttpParameterCodec
+ * Workaround for https://github.com/angular/angular/issues/18261
+ */
 export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
         return encodeURIComponent(k);
@@ -27,10 +27,10 @@ export class CustomHttpParameterCodec implements HttpParameterCodec {
 {{/useHttpClient}}
 {{^useHttpClient}}
 /**
-* Custom QueryEncoder
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
-*/
+ * Custom QueryEncoder
+ * Fix plus sign (+) not encoding, so sent as blank space
+ * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+ */
 export class CustomQueryEncoderHelper extends QueryEncoder {
     encodeKey(k: string): string {
         k = super.encodeKey(k);

--- a/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
@@ -46,6 +46,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * 

--- a/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/pet.service.ts
@@ -46,19 +46,6 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * 
@@ -196,7 +183,6 @@ export class PetService {
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      
      */
@@ -222,6 +208,7 @@ export class PetService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -249,7 +236,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      
@@ -280,9 +266,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -333,9 +316,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -387,9 +367,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -433,9 +410,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -452,7 +426,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      
      */
@@ -478,6 +451,7 @@ export class PetService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -505,7 +479,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -577,7 +550,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/store.service.ts
@@ -45,19 +45,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -144,9 +131,6 @@ export class StoreService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -184,9 +168,6 @@ export class StoreService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -224,9 +205,6 @@ export class StoreService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -243,7 +221,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      
      */
@@ -263,6 +240,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/api/user.service.ts
@@ -45,19 +45,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * This can only be done by the logged in user.
@@ -210,6 +197,7 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -234,7 +222,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      
      */
@@ -252,6 +239,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -277,7 +265,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      
      */
@@ -295,6 +282,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -339,9 +327,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -358,7 +343,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      
      */
@@ -379,9 +363,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -398,7 +379,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      
@@ -431,9 +411,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -451,7 +428,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
@@ -466,9 +442,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -507,6 +480,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v2/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/default/encoder.ts
@@ -1,10 +1,10 @@
 import { QueryEncoder } from '@angular/http';
 
 /**
-* Custom QueryEncoder
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
-*/
+ * Custom QueryEncoder
+ * Fix plus sign (+) not encoding, so sent as blank space
+ * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+ */
 export class CustomQueryEncoderHelper extends QueryEncoder {
     encodeKey(k: string): string {
         k = super.encodeKey(k);

--- a/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
@@ -46,6 +46,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * 

--- a/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/pet.service.ts
@@ -46,19 +46,6 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * 
@@ -196,7 +183,6 @@ export class PetService {
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      
      */
@@ -222,6 +208,7 @@ export class PetService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -249,7 +236,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      
@@ -280,9 +266,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -333,9 +316,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -387,9 +367,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -433,9 +410,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -452,7 +426,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      
      */
@@ -478,6 +451,7 @@ export class PetService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -505,7 +479,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -577,7 +550,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/store.service.ts
@@ -45,19 +45,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -144,9 +131,6 @@ export class StoreService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -184,9 +168,6 @@ export class StoreService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -224,9 +205,6 @@ export class StoreService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -243,7 +221,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      
      */
@@ -263,6 +240,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/api/user.service.ts
@@ -45,19 +45,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * This can only be done by the logged in user.
@@ -210,6 +197,7 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -234,7 +222,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      
      */
@@ -252,6 +239,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -277,7 +265,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      
      */
@@ -295,6 +282,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -339,9 +327,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -358,7 +343,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      
      */
@@ -379,9 +363,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -398,7 +379,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      
@@ -431,9 +411,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -451,7 +428,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
@@ -466,9 +442,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -507,6 +480,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v2/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/npm/encoder.ts
@@ -1,10 +1,10 @@
 import { QueryEncoder } from '@angular/http';
 
 /**
-* Custom QueryEncoder
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
-*/
+ * Custom QueryEncoder
+ * Fix plus sign (+) not encoding, so sent as blank space
+ * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+ */
 export class CustomQueryEncoderHelper extends QueryEncoder {
     encodeKey(k: string): string {
         k = super.encodeKey(k);

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
@@ -47,6 +47,19 @@ export class PetService implements PetServiceInterface {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * 

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/pet.service.ts
@@ -47,19 +47,6 @@ export class PetService implements PetServiceInterface {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * 
@@ -197,7 +184,6 @@ export class PetService implements PetServiceInterface {
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      
      */
@@ -223,6 +209,7 @@ export class PetService implements PetServiceInterface {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -250,7 +237,6 @@ export class PetService implements PetServiceInterface {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      
@@ -281,9 +267,6 @@ export class PetService implements PetServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -334,9 +317,6 @@ export class PetService implements PetServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -388,9 +368,6 @@ export class PetService implements PetServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -434,9 +411,6 @@ export class PetService implements PetServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -453,7 +427,6 @@ export class PetService implements PetServiceInterface {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      
      */
@@ -479,6 +452,7 @@ export class PetService implements PetServiceInterface {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -506,7 +480,6 @@ export class PetService implements PetServiceInterface {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -578,7 +551,6 @@ export class PetService implements PetServiceInterface {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/store.service.ts
@@ -46,19 +46,6 @@ export class StoreService implements StoreServiceInterface {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -145,9 +132,6 @@ export class StoreService implements StoreServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -185,9 +169,6 @@ export class StoreService implements StoreServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -225,9 +206,6 @@ export class StoreService implements StoreServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -244,7 +222,6 @@ export class StoreService implements StoreServiceInterface {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      
      */
@@ -264,6 +241,7 @@ export class StoreService implements StoreServiceInterface {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/api/user.service.ts
@@ -46,19 +46,6 @@ export class UserService implements UserServiceInterface {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * This can only be done by the logged in user.
@@ -211,6 +198,7 @@ export class UserService implements UserServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -235,7 +223,6 @@ export class UserService implements UserServiceInterface {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      
      */
@@ -253,6 +240,7 @@ export class UserService implements UserServiceInterface {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -278,7 +266,6 @@ export class UserService implements UserServiceInterface {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      
      */
@@ -296,6 +283,7 @@ export class UserService implements UserServiceInterface {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -340,9 +328,6 @@ export class UserService implements UserServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -359,7 +344,6 @@ export class UserService implements UserServiceInterface {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      
      */
@@ -380,9 +364,6 @@ export class UserService implements UserServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -399,7 +380,6 @@ export class UserService implements UserServiceInterface {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      
@@ -432,9 +412,6 @@ export class UserService implements UserServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -452,7 +429,6 @@ export class UserService implements UserServiceInterface {
 
     /**
      * Logs out current logged in user session
-     * 
      
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
@@ -467,9 +443,6 @@ export class UserService implements UserServiceInterface {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -508,6 +481,7 @@ export class UserService implements UserServiceInterface {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v2/with-interfaces/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v2/with-interfaces/encoder.ts
@@ -1,10 +1,10 @@
 import { QueryEncoder } from '@angular/http';
 
 /**
-* Custom QueryEncoder
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
-*/
+ * Custom QueryEncoder
+ * Fix plus sign (+) not encoding, so sent as blank space
+ * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+ */
 export class CustomQueryEncoderHelper extends QueryEncoder {
     encodeKey(k: string): string {
         k = super.encodeKey(k);

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
@@ -44,24 +44,10 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -92,6 +78,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -115,7 +102,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -150,9 +136,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -204,9 +187,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
             {
@@ -259,9 +239,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
             {
@@ -306,9 +283,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -322,7 +296,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -353,6 +326,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -376,7 +350,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -445,7 +418,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/pet.service.ts
@@ -44,6 +44,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 
     /**

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/store.service.ts
@@ -43,19 +43,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -83,9 +70,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -124,9 +108,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
             {
@@ -165,9 +146,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -181,7 +159,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -205,6 +182,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/api/user.service.ts
@@ -43,19 +43,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -83,6 +70,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -104,7 +92,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -127,6 +114,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -148,7 +136,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -170,6 +157,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -215,9 +203,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -231,7 +216,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -256,9 +240,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -272,7 +253,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -309,9 +289,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
             {
@@ -326,7 +303,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -345,9 +321,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
             {
@@ -387,6 +360,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v4.3/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v4.3/npm/encoder.ts
@@ -1,9 +1,9 @@
 import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* Custom HttpParameterCodec
-* Workaround for https://github.com/angular/angular/issues/18261
-*/
+ * Custom HttpParameterCodec
+ * Workaround for https://github.com/angular/angular/issues/18261
+ */
 export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
         return encodeURIComponent(k);

--- a/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
@@ -46,6 +46,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * 

--- a/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/pet.service.ts
@@ -46,19 +46,6 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * 
@@ -196,7 +183,6 @@ export class PetService {
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      
      */
@@ -222,6 +208,7 @@ export class PetService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -249,7 +236,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      
@@ -280,9 +266,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -333,9 +316,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -387,9 +367,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -433,9 +410,6 @@ export class PetService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -452,7 +426,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      
      */
@@ -478,6 +451,7 @@ export class PetService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -505,7 +479,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -577,7 +550,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/store.service.ts
@@ -45,19 +45,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -144,9 +131,6 @@ export class StoreService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -184,9 +168,6 @@ export class StoreService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -224,9 +205,6 @@ export class StoreService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -243,7 +221,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      
      */
@@ -263,6 +240,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/api/user.service.ts
@@ -45,19 +45,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomQueryEncoderHelper();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     /**
      * This can only be done by the logged in user.
@@ -210,6 +197,7 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -234,7 +222,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      
      */
@@ -252,6 +239,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -277,7 +265,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      
      */
@@ -295,6 +282,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -339,9 +327,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Delete,
@@ -358,7 +343,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      
      */
@@ -379,9 +363,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -398,7 +379,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      
@@ -431,9 +411,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -451,7 +428,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      
      */
     public logoutUserWithHttpInfo(extraHttpRequestParams?: RequestOptionsArgs): Observable<Response> {
@@ -466,9 +442,6 @@ export class UserService {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         let requestOptions: RequestOptionsArgs = new RequestOptions({
             method: RequestMethod.Get,
@@ -507,6 +480,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v4/npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v4/npm/encoder.ts
@@ -1,10 +1,10 @@
 import { QueryEncoder } from '@angular/http';
 
 /**
-* Custom QueryEncoder
-* Fix plus sign (+) not encoding, so sent as blank space
-* See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
-*/
+ * Custom QueryEncoder
+ * Fix plus sign (+) not encoding, so sent as blank space
+ * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
+ */
 export class CustomQueryEncoderHelper extends QueryEncoder {
     encodeKey(k: string): string {
         k = super.encodeKey(k);

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -44,24 +44,10 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -92,6 +78,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -115,7 +102,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -150,9 +136,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -204,9 +187,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
             {
@@ -259,9 +239,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
             {
@@ -306,9 +283,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -322,7 +296,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -353,6 +326,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -376,7 +350,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -445,7 +418,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/pet.service.ts
@@ -44,6 +44,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/store.service.ts
@@ -43,19 +43,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -83,9 +70,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -124,9 +108,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
             {
@@ -165,9 +146,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -181,7 +159,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -205,6 +182,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/api/user.service.ts
@@ -43,19 +43,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -83,6 +70,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -104,7 +92,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -127,6 +114,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -148,7 +136,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -170,6 +157,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -215,9 +203,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -231,7 +216,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -256,9 +240,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -272,7 +253,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -309,9 +289,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
             {
@@ -326,7 +303,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -345,9 +321,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
             {
@@ -387,6 +360,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/default/encoder.ts
@@ -1,9 +1,9 @@
 import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* Custom HttpParameterCodec
-* Workaround for https://github.com/angular/angular/issues/18261
-*/
+ * Custom HttpParameterCodec
+ * Workaround for https://github.com/angular/angular/issues/18261
+ */
 export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
         return encodeURIComponent(k);

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -44,24 +44,10 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -92,6 +78,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -115,7 +102,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -150,9 +136,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -204,9 +187,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
             {
@@ -259,9 +239,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
             {
@@ -306,9 +283,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -322,7 +296,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -353,6 +326,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -376,7 +350,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -445,7 +418,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -44,6 +44,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -43,19 +43,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -83,9 +70,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -124,9 +108,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
             {
@@ -165,9 +146,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -181,7 +159,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -205,6 +182,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -43,19 +43,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -83,6 +70,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -104,7 +92,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -127,6 +114,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -148,7 +136,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -170,6 +157,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -215,9 +203,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -231,7 +216,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -256,9 +240,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -272,7 +253,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -309,9 +289,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
             {
@@ -326,7 +303,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -345,9 +321,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
             {
@@ -387,6 +360,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-not-provided-in-root/builds/with-npm/encoder.ts
@@ -1,9 +1,9 @@
 import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* Custom HttpParameterCodec
-* Workaround for https://github.com/angular/angular/issues/18261
-*/
+ * Custom HttpParameterCodec
+ * Workaround for https://github.com/angular/angular/issues/18261
+ */
 export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
         return encodeURIComponent(k);

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -46,6 +46,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -46,24 +46,10 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -94,6 +80,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -117,7 +104,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -152,9 +138,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -206,9 +189,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
             {
@@ -261,9 +241,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
             {
@@ -308,9 +285,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -324,7 +298,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -355,6 +328,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -378,7 +352,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -447,7 +420,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/store.service.ts
@@ -45,19 +45,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -85,9 +72,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -126,9 +110,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
             {
@@ -167,9 +148,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -183,7 +161,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -207,6 +184,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api/user.service.ts
@@ -45,19 +45,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -85,6 +72,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -106,7 +94,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -129,6 +116,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -150,7 +138,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -172,6 +159,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -217,9 +205,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -233,7 +218,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -258,9 +242,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -274,7 +255,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -311,9 +291,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
             {
@@ -328,7 +305,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -347,9 +323,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
             {
@@ -389,6 +362,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/encoder.ts
@@ -1,9 +1,9 @@
 import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* Custom HttpParameterCodec
-* Workaround for https://github.com/angular/angular/issues/18261
-*/
+ * Custom HttpParameterCodec
+ * Workaround for https://github.com/angular/angular/issues/18261
+ */
 export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
         return encodeURIComponent(k);

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -46,6 +46,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 
     /**

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -46,24 +46,10 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -94,6 +80,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -117,7 +104,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -152,9 +138,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -206,9 +189,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
             {
@@ -261,9 +241,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
             {
@@ -308,9 +285,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -324,7 +298,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -355,6 +328,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -378,7 +352,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -447,7 +420,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/store.service.ts
@@ -45,19 +45,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -85,9 +72,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -126,9 +110,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
             {
@@ -167,9 +148,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -183,7 +161,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -207,6 +184,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api/user.service.ts
@@ -45,19 +45,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -85,6 +72,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -106,7 +94,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -129,6 +116,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -150,7 +138,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -172,6 +159,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -217,9 +205,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -233,7 +218,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -258,9 +242,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -274,7 +255,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -311,9 +291,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
             {
@@ -328,7 +305,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -347,9 +323,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
             {
@@ -389,6 +362,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/encoder.ts
@@ -1,9 +1,9 @@
 import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* Custom HttpParameterCodec
-* Workaround for https://github.com/angular/angular/issues/18261
-*/
+ * Custom HttpParameterCodec
+ * Workaround for https://github.com/angular/angular/issues/18261
+ */
 export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
         return encodeURIComponent(k);

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -44,24 +44,10 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -92,6 +78,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -115,7 +102,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -150,9 +136,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -204,9 +187,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
             {
@@ -259,9 +239,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
             {
@@ -306,9 +283,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -322,7 +296,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -353,6 +326,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -376,7 +350,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -445,7 +418,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/pet.service.ts
@@ -44,6 +44,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/store.service.ts
@@ -43,19 +43,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -83,9 +70,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -124,9 +108,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
             {
@@ -165,9 +146,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -181,7 +159,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -205,6 +182,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/api/user.service.ts
@@ -43,19 +43,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -83,6 +70,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -104,7 +92,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -127,6 +114,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -148,7 +136,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -170,6 +157,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -215,9 +203,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -231,7 +216,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -256,9 +240,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -272,7 +253,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -309,9 +289,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
             {
@@ -326,7 +303,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -345,9 +321,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
             {
@@ -387,6 +360,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/default/encoder.ts
@@ -1,9 +1,9 @@
 import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* Custom HttpParameterCodec
-* Workaround for https://github.com/angular/angular/issues/18261
-*/
+ * Custom HttpParameterCodec
+ * Workaround for https://github.com/angular/angular/issues/18261
+ */
 export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
         return encodeURIComponent(k);

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -44,24 +44,10 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -92,6 +78,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -115,7 +102,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -150,9 +136,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -204,9 +187,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
             {
@@ -259,9 +239,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
             {
@@ -306,9 +283,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -322,7 +296,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -353,6 +326,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -376,7 +350,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -445,7 +418,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -44,6 +44,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/store.service.ts
@@ -43,19 +43,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -83,9 +70,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -124,9 +108,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
             {
@@ -165,9 +146,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -181,7 +159,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -205,6 +182,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/api/user.service.ts
@@ -43,19 +43,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -83,6 +70,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -104,7 +92,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -127,6 +114,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -148,7 +136,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -170,6 +157,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -215,9 +203,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -231,7 +216,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -256,9 +240,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -272,7 +253,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -309,9 +289,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
             {
@@ -326,7 +303,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -345,9 +321,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
             {
@@ -387,6 +360,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-not-provided-in-root/builds/with-npm/encoder.ts
@@ -1,9 +1,9 @@
 import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* Custom HttpParameterCodec
-* Workaround for https://github.com/angular/angular/issues/18261
-*/
+ * Custom HttpParameterCodec
+ * Workaround for https://github.com/angular/angular/issues/18261
+ */
 export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
         return encodeURIComponent(k);

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -46,6 +46,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/pet.service.ts
@@ -46,24 +46,10 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -94,6 +80,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -117,7 +104,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -152,9 +138,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -206,9 +189,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
             {
@@ -261,9 +241,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
             {
@@ -308,9 +285,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -324,7 +298,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -355,6 +328,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -378,7 +352,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -447,7 +420,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/store.service.ts
@@ -45,19 +45,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -85,9 +72,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -126,9 +110,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
             {
@@ -167,9 +148,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -183,7 +161,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -207,6 +184,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api/user.service.ts
@@ -45,19 +45,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -85,6 +72,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -106,7 +94,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -129,6 +116,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -150,7 +138,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -172,6 +159,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -217,9 +205,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -233,7 +218,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -258,9 +242,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -274,7 +255,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -311,9 +291,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
             {
@@ -328,7 +305,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -347,9 +323,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
             {
@@ -389,6 +362,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/encoder.ts
@@ -1,9 +1,9 @@
 import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* Custom HttpParameterCodec
-* Workaround for https://github.com/angular/angular/issues/18261
-*/
+ * Custom HttpParameterCodec
+ * Workaround for https://github.com/angular/angular/issues/18261
+ */
 export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
         return encodeURIComponent(k);

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -46,6 +46,19 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
+    /**
+     * @param consumes string[] mime-types
+     * @return true: consumes contains 'multipart/form-data', false: otherwise
+     */
+    private canConsumeForm(consumes: string[]): boolean {
+        const form = 'multipart/form-data';
+        for (const consume of consumes) {
+            if (form === consume) {
+                return true;
+            }
+        }
+        return false;
+    }
 
 
     /**

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/pet.service.ts
@@ -46,24 +46,10 @@ export class PetService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
      * Add a new pet to the store
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -94,6 +80,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -117,7 +104,6 @@ export class PetService {
 
     /**
      * Deletes a pet
-     * 
      * @param petId Pet id to delete
      * @param apiKey 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -152,9 +138,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -206,9 +189,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByStatus`,
             {
@@ -261,9 +241,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Array<Pet>>(`${this.configuration.basePath}/pet/findByTags`,
             {
@@ -308,9 +285,6 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Pet>(`${this.configuration.basePath}/pet/${encodeURIComponent(String(petId))}`,
             {
@@ -324,7 +298,6 @@ export class PetService {
 
     /**
      * Update an existing pet
-     * 
      * @param body Pet object that needs to be added to the store
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -355,6 +328,7 @@ export class PetService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
             'application/json',
@@ -378,7 +352,6 @@ export class PetService {
 
     /**
      * Updates a pet in the store with form data
-     * 
      * @param petId ID of pet that needs to be updated
      * @param name Updated name of the pet
      * @param status Updated status of the pet
@@ -447,7 +420,6 @@ export class PetService {
 
     /**
      * uploads an image
-     * 
      * @param petId ID of pet to update
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/store.service.ts
@@ -45,19 +45,6 @@ export class StoreService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -85,9 +72,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -126,9 +110,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<{ [key: string]: number; }>(`${this.configuration.basePath}/store/inventory`,
             {
@@ -167,9 +148,6 @@ export class StoreService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<Order>(`${this.configuration.basePath}/store/order/${encodeURIComponent(String(orderId))}`,
             {
@@ -183,7 +161,6 @@ export class StoreService {
 
     /**
      * Place an order for a pet
-     * 
      * @param body order placed for purchasing the pet
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -207,6 +184,7 @@ export class StoreService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api/user.service.ts
@@ -45,19 +45,6 @@ export class UserService {
         this.encoder = this.configuration.encoder || new CustomHttpParameterCodec();
     }
 
-    /**
-     * @param consumes string[] mime-types
-     * @return true: consumes contains 'multipart/form-data', false: otherwise
-     */
-    private canConsumeForm(consumes: string[]): boolean {
-        const form = 'multipart/form-data';
-        for (const consume of consumes) {
-            if (form === consume) {
-                return true;
-            }
-        }
-        return false;
-    }
 
 
     /**
@@ -85,6 +72,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -106,7 +94,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -129,6 +116,7 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
+
         // to determine the Content-Type header
         const consumes: string[] = [
         ];
@@ -150,7 +138,6 @@ export class UserService {
 
     /**
      * Creates list of users with given input array
-     * 
      * @param body List of user object
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -172,6 +159,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [
@@ -217,9 +205,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.delete<any>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -233,7 +218,6 @@ export class UserService {
 
     /**
      * Get user by user name
-     * 
      * @param username The name that needs to be fetched. Use user1 for testing.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -258,9 +242,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<User>(`${this.configuration.basePath}/user/${encodeURIComponent(String(username))}`,
             {
@@ -274,7 +255,6 @@ export class UserService {
 
     /**
      * Logs user into the system
-     * 
      * @param username The user name for login
      * @param password The password for login in clear text
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
@@ -311,9 +291,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<string>(`${this.configuration.basePath}/user/login`,
             {
@@ -328,7 +305,6 @@ export class UserService {
 
     /**
      * Logs out current logged in user session
-     * 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -347,9 +323,6 @@ export class UserService {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
 
-        // to determine the Content-Type header
-        const consumes: string[] = [
-        ];
 
         return this.httpClient.get<any>(`${this.configuration.basePath}/user/logout`,
             {
@@ -389,6 +362,7 @@ export class UserService {
         if (httpHeaderAcceptSelected !== undefined) {
             headers = headers.set('Accept', httpHeaderAcceptSelected);
         }
+
 
         // to determine the Content-Type header
         const consumes: string[] = [

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/encoder.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/encoder.ts
@@ -1,9 +1,9 @@
 import { HttpParameterCodec } from '@angular/common/http';
 
 /**
-* Custom HttpParameterCodec
-* Workaround for https://github.com/angular/angular/issues/18261
-*/
+ * Custom HttpParameterCodec
+ * Workaround for https://github.com/angular/angular/issues/18261
+ */
 export class CustomHttpParameterCodec implements HttpParameterCodec {
     encodeKey(k: string): string {
         return encodeURIComponent(k);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes several minor issues in the templates for typescript-angular

- `canConsumeForm` is only included in the service if the method is actually needed. Reduces code size and helps with compiling the project where no unused locals cause compile errors
- no summary or no notes for an operation don't cause the jsdoc to start with an empty line
- only render consumes property when it is actually used. Also helpful when compiling the project with no unused locals
- fix formatting of doc block for encoder.ts

Anyone knows of a better solution to fix the consumes rather than having this "or" which needs the code to be duplicated? I didn't want to add another property to the CodegenOperation since it's only used for 1 generator. Maybe this is also acceptable since it'll be refactored soon anyways. Please advise :) 

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07)