### PR TITLE
Support importMapping definitions for TypeScriptNodeClientCodegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -18,7 +18,6 @@
 package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
@@ -33,6 +32,7 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
     private static final Logger LOGGER = LoggerFactory.getLogger(TypeScriptNodeClientCodegen.class);
 
     public static final String NPM_REPOSITORY = "npmRepository";
+    private static final String DEFAULT_IMPORT_PREFIX = "./";
 
     protected String npmRepository = null;
     protected String apiSuffix = "Api";
@@ -106,7 +106,11 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
 
     @Override
     public String toModelFilename(String name) {
-        return camelize(toModelName(name), true);
+        if (importMapping.containsKey(name)) {
+            return importMapping.get(name);
+        }
+
+        return DEFAULT_IMPORT_PREFIX + camelize(toModelName(name), true);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -96,11 +96,18 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
         if (name.length() == 0) {
             return "default" + apiSuffix;
         }
+        if (importMapping.containsKey(name)) {
+            return importMapping.get(name);
+        }
         return camelize(name, true) + apiSuffix;
     }
 
     @Override
     public String toApiImport(String name) {
+        if (importMapping.containsKey(name)) {
+            return importMapping.get(name);
+        }
+
         return apiPackage() + "/" + toApiFilename(name);
     }
 
@@ -115,7 +122,11 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
 
     @Override
     public String toModelImport(String name) {
-        return modelPackage() + "/" + toModelFilename(name);
+        if (importMapping.containsKey(name)) {
+            return importMapping.get(name);
+        }
+
+        return modelPackage() + "/" + camelize(toModelName(name), true);
     }
     
     @Override

--- a/modules/openapi-generator/src/main/resources/typescript-node/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/model.mustache
@@ -2,7 +2,7 @@
 {{#models}}
 {{#model}}
 {{#tsImports}}
-import { {{classname}} } from './{{filename}}';
+import { {{classname}} } from '{{filename}}';
 {{/tsImports}}
 
 {{#description}}

--- a/modules/openapi-generator/src/main/resources/typescript-node/models.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/models.mustache
@@ -1,6 +1,6 @@
 {{#models}}
 {{#model}}
-export * from './{{{ classFilename }}}';
+export * from '{{{ classFilename }}}';
 {{/model}}
 {{/models}}
 
@@ -8,7 +8,7 @@ import localVarRequest = require('request');
 
 {{#models}}
 {{#model}}
-import { {{classname}} } from './{{{ classFilename }}}';
+import { {{classname}} } from '{{{ classFilename }}}';
 {{/model}}
 {{/models}}
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeClientCodegenTest.java
@@ -4,68 +4,131 @@ import io.swagger.v3.oas.models.OpenAPI;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.TypeScriptNodeClientCodegen;
 import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class TypeScriptNodeClientCodegenTest {
 
+    private TypeScriptNodeClientCodegen codegen;
+
+    @BeforeMethod
+    public void setUp() {
+        codegen = new TypeScriptNodeClientCodegen();
+    }
+
     @Test
     public void convertVarName() throws Exception {
-       TypeScriptNodeClientCodegen codegen = new TypeScriptNodeClientCodegen();
-       Assert.assertEquals(codegen.toVarName("name"), "name");
-       Assert.assertEquals(codegen.toVarName("$name"), "$name");
-       Assert.assertEquals(codegen.toVarName("nam$$e"), "nam$$e");
-       Assert.assertEquals(codegen.toVarName("user-name"), "userName");
-       Assert.assertEquals(codegen.toVarName("user_name"), "userName");
-       Assert.assertEquals(codegen.toVarName("user|name"), "userName");
-       Assert.assertEquals(codegen.toVarName("user !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~name"), "user$Name");
-   }
+        Assert.assertEquals(codegen.toVarName("name"), "name");
+        Assert.assertEquals(codegen.toVarName("$name"), "$name");
+        Assert.assertEquals(codegen.toVarName("nam$$e"), "nam$$e");
+        Assert.assertEquals(codegen.toVarName("user-name"), "userName");
+        Assert.assertEquals(codegen.toVarName("user_name"), "userName");
+        Assert.assertEquals(codegen.toVarName("user|name"), "userName");
+        Assert.assertEquals(codegen.toVarName("user !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~name"), "user$Name");
+    }
 
-   @Test
-   public void testSnapshotVersion() {
-      OpenAPI api = TestUtils.createOpenAPI();
-      TypeScriptNodeClientCodegen codegen = new TypeScriptNodeClientCodegen();
+    @Test
+    public void testSnapshotVersion() {
+        OpenAPI api = TestUtils.createOpenAPI();
 
-      codegen.additionalProperties().put("npmName", "@openapi/typescript-angular-petstore");
-      codegen.additionalProperties().put("snapshot", true);
-      codegen.additionalProperties().put("npmVersion", "1.0.0-SNAPSHOT");
-      codegen.processOpts();
-      codegen.preprocessOpenAPI(api);
+        codegen.additionalProperties().put("npmName", "@openapi/typescript-angular-petstore");
+        codegen.additionalProperties().put("snapshot", true);
+        codegen.additionalProperties().put("npmVersion", "1.0.0-SNAPSHOT");
+        codegen.processOpts();
+        codegen.preprocessOpenAPI(api);
 
-      Assert.assertTrue(codegen.getNpmVersion().matches("^1.0.0-SNAPSHOT.[0-9]{12}$"));
+        Assert.assertTrue(codegen.getNpmVersion().matches("^1.0.0-SNAPSHOT.[0-9]{12}$"));
 
-      codegen = new TypeScriptNodeClientCodegen();
-      codegen.additionalProperties().put("npmName", "@openapi/typescript-angular-petstore");
-      codegen.additionalProperties().put("snapshot", true);
-      codegen.additionalProperties().put("npmVersion", "3.0.0-M1");
-      codegen.processOpts();
-      codegen.preprocessOpenAPI(api);
+        codegen = new TypeScriptNodeClientCodegen();
+        codegen.additionalProperties().put("npmName", "@openapi/typescript-angular-petstore");
+        codegen.additionalProperties().put("snapshot", true);
+        codegen.additionalProperties().put("npmVersion", "3.0.0-M1");
+        codegen.processOpts();
+        codegen.preprocessOpenAPI(api);
 
-      Assert.assertTrue(codegen.getNpmVersion().matches("^3.0.0-M1-SNAPSHOT.[0-9]{12}$"));
+        Assert.assertTrue(codegen.getNpmVersion().matches("^3.0.0-M1-SNAPSHOT.[0-9]{12}$"));
+    }
 
-   }
+    @Test
+    public void testWithoutSnapshotVersion() {
+        OpenAPI api = TestUtils.createOpenAPI();
 
-   @Test
-   public void testWithoutSnapshotVersion() {
-      OpenAPI api = TestUtils.createOpenAPI();
-      TypeScriptNodeClientCodegen codegen = new TypeScriptNodeClientCodegen();
+        codegen.additionalProperties().put("npmName", "@openapi/typescript-angular-petstore");
+        codegen.additionalProperties().put("snapshot", false);
+        codegen.additionalProperties().put("npmVersion", "1.0.0-SNAPSHOT");
+        codegen.processOpts();
+        codegen.preprocessOpenAPI(api);
 
-      codegen.additionalProperties().put("npmName", "@openapi/typescript-angular-petstore");
-      codegen.additionalProperties().put("snapshot", false);
-      codegen.additionalProperties().put("npmVersion", "1.0.0-SNAPSHOT");
-      codegen.processOpts();
-      codegen.preprocessOpenAPI(api);
+        Assert.assertTrue(codegen.getNpmVersion().matches("^1.0.0-SNAPSHOT$"));
 
-      Assert.assertTrue(codegen.getNpmVersion().matches("^1.0.0-SNAPSHOT$"));
+        codegen = new TypeScriptNodeClientCodegen();
+        codegen.additionalProperties().put("npmName", "@openapi/typescript-angular-petstore");
+        codegen.additionalProperties().put("snapshot", false);
+        codegen.additionalProperties().put("npmVersion", "3.0.0-M1");
+        codegen.processOpts();
+        codegen.preprocessOpenAPI(api);
 
-      codegen = new TypeScriptNodeClientCodegen();
-      codegen.additionalProperties().put("npmName", "@openapi/typescript-angular-petstore");
-      codegen.additionalProperties().put("snapshot", false);
-      codegen.additionalProperties().put("npmVersion", "3.0.0-M1");
-      codegen.processOpts();
-      codegen.preprocessOpenAPI(api);
+        Assert.assertTrue(codegen.getNpmVersion().matches("^3.0.0-M1$"));
+    }
 
-      Assert.assertTrue(codegen.getNpmVersion().matches("^3.0.0-M1$"));
+    @Test(description = "prepend model filename with ./ by default")
+    public void defaultModelFilenameTest() {
+        Assert.assertEquals(codegen.toModelFilename("ApiResponse"), "./apiResponse");
+    }
 
-   }
+    @Test(description = "use mapped name for model filename when provided")
+    public void modelFilenameWithMappingTest() {
+        final String mappedName = "@namespace/dir/response";
+        codegen.importMapping().put("ApiResponse", mappedName);
+
+        Assert.assertEquals(codegen.toModelFilename("ApiResponse"), mappedName);
+    }
+
+    @Test(description = "prepend model import with ./ by default")
+    public void defaultModelImportTest() {
+        Assert.assertEquals(codegen.toModelImport("ApiResponse"), "model/apiResponse");
+    }
+
+    @Test(description = "use mapped name for model import when provided")
+    public void modelImportWithMappingTest() {
+        final String mappedName = "@namespace/dir/response";
+        codegen.importMapping().put("ApiResponse", mappedName);
+
+        Assert.assertEquals(codegen.toModelImport("ApiResponse"), mappedName);
+    }
+
+    @Test(description = "append api suffix to default api filename")
+    public void emptyApiFilenameTest() {
+        Assert.assertEquals(codegen.toApiFilename(""), "defaultApi");
+    }
+
+    @Test(description = "appends api suffix to api filename")
+    public void defaultApiFilenameTest() {
+        Assert.assertEquals(codegen.toApiFilename("Category"), "categoryApi");
+    }
+
+    @Test(description = "appends api suffix to mapped api filename")
+    public void mappedApiFilenameTest() {
+        final String mappedName = "@namespace/dir/category";
+        codegen.importMapping().put("Category", mappedName);
+        Assert.assertEquals(codegen.toApiFilename("Category"), mappedName);
+    }
+
+    @Test(description = "append api suffix to default api import")
+    public void emptyApiImportTest() {
+        Assert.assertEquals(codegen.toApiImport(""), "api/defaultApi");
+    }
+
+    @Test(description = "appends api suffix to api import")
+    public void defaultApiImportTest() {
+        Assert.assertEquals(codegen.toApiImport("Category"), "api/categoryApi");
+    }
+
+    @Test(description = "appends api suffix to mapped api filename")
+    public void mappedApiImportTest() {
+        final String mappedName = "@namespace/dir/category";
+        codegen.importMapping().put("Category", mappedName);
+        Assert.assertEquals(codegen.toApiImport("Category"), mappedName);
+    }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
@@ -207,28 +207,28 @@ public class TypeScriptNodeModelTest {
     }
 
     @Test(description = "prepend imports with ./ by default")
-    public void defaultImportsTest() {
+    public void defaultFromModelTest() {
         final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
         final DefaultCodegen codegen = new TypeScriptNodeClientCodegen();
         codegen.setOpenAPI(openAPI);
-        final Schema categorySchema = openAPI.getComponents().getSchemas().get("Category");
-        final CodegenModel cm = codegen.fromModel("Category", categorySchema);
+        final Schema categorySchema = openAPI.getComponents().getSchemas().get("ApiResponse");
+        final CodegenModel cm = codegen.fromModel("ApiResponse", categorySchema);
 
-        Assert.assertEquals(cm.name, "Category");
-        Assert.assertEquals(cm.classFilename, "./category");
+        Assert.assertEquals(cm.name, "ApiResponse");
+        Assert.assertEquals(cm.classFilename, "./apiResponse");
     }
 
     @Test(description = "use mapped imports for type")
-    public void mappedImportsTest() {
+    public void mappedFromModelTest() {
         final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
         final DefaultCodegen codegen = new TypeScriptNodeClientCodegen();
-        final String mappedName = "@namespace/dir/category";
-        codegen.importMapping().put("Category", mappedName);
+        final String mappedName = "@namespace/dir/response";
+        codegen.importMapping().put("ApiResponse", mappedName);
         codegen.setOpenAPI(openAPI);
-        final Schema categorySchema = openAPI.getComponents().getSchemas().get("Category");
-        final CodegenModel cm = codegen.fromModel("Category", categorySchema);
+        final Schema categorySchema = openAPI.getComponents().getSchemas().get("ApiResponse");
+        final CodegenModel cm = codegen.fromModel("ApiResponse", categorySchema);
 
-        Assert.assertEquals(cm.name, "Category");
+        Assert.assertEquals(cm.name, "ApiResponse");
         Assert.assertEquals(cm.classFilename, mappedName);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnode/TypeScriptNodeModelTest.java
@@ -205,4 +205,30 @@ public class TypeScriptNodeModelTest {
         Assert.assertEquals(cm.imports.size(), 1);
         Assert.assertEquals(Sets.intersection(cm.imports, Sets.newHashSet("Children")).size(), 1);
     }
+
+    @Test(description = "prepend imports with ./ by default")
+    public void defaultImportsTest() {
+        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final DefaultCodegen codegen = new TypeScriptNodeClientCodegen();
+        codegen.setOpenAPI(openAPI);
+        final Schema categorySchema = openAPI.getComponents().getSchemas().get("Category");
+        final CodegenModel cm = codegen.fromModel("Category", categorySchema);
+
+        Assert.assertEquals(cm.name, "Category");
+        Assert.assertEquals(cm.classFilename, "./category");
+    }
+
+    @Test(description = "use mapped imports for type")
+    public void mappedImportsTest() {
+        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        final DefaultCodegen codegen = new TypeScriptNodeClientCodegen();
+        final String mappedName = "@namespace/dir/category";
+        codegen.importMapping().put("Category", mappedName);
+        codegen.setOpenAPI(openAPI);
+        final Schema categorySchema = openAPI.getComponents().getSchemas().get("Category");
+        final CodegenModel cm = codegen.fromModel("Category", categorySchema);
+
+        Assert.assertEquals(cm.name, "Category");
+        Assert.assertEquals(cm.classFilename, mappedName);
+    }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This addresses an issue similar to Issue #3149 but for the TypeScript Node generator. This is a more general issue that could be implemented for all TypeScript generators, but I'm keeping the scope small initially.

The `importMapping` behavior described [here](https://openapi-generator.tech/docs/customization#bringing-your-own-models) and [here](https://openapi-generator.tech/docs/usage#target-external-models) in the usage docs, and supported [by the Maven plugin configuration](https://github.com/OpenAPITools/openapi-generator/tree/master/modules/openapi-generator-maven-plugin#general-configuration-parameters) does not currently work for TypeScript generation.

This change allows a user to define these mappings and produce valid TypeScript import statements when using the TypeScriptNodeClientCodegen.

> Note: Running the shell script `./bin/openapi3/typescript-node-petstore-all.sh` in the **master** branch generates sample files that are different from the files currently in the repo. Running that script against this branch (typescript-import-mappings) produces the same differences. I have not included them here to avoid conflating unrelated changes. 

cc: 
* @TiFu 
* @taxpon 
* @sebastianhaas 
* @kenisteward 
* @Vrolijkx
* @macjohnny
* @nicokoenig
* @topce
* @akehir
