### PR TITLE
[Java][client] make it possible to send explicit nulls for nullable fields

### DIFF
--- a/modules/openapi-generator-maven-plugin/examples/java-client.xml
+++ b/modules/openapi-generator-maven-plugin/examples/java-client.xml
@@ -120,7 +120,12 @@
           <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-json-provider</artifactId>
           <version>${jackson-version}</version>
-        </dependency>
+      </dependency>
+      <dependency>
+          <groupId>org.openapitools</groupId>
+          <artifactId>jackson-databind-nullable</artifactId>
+          <version>${jackson-databind-nullable-version}</version>
+      </dependency>
 
         <!-- Joda time: if you use it -->
         <dependency>
@@ -146,6 +151,7 @@
         <swagger-annotations-version>1.5.8</swagger-annotations-version>
         <jersey-version>2.27</jersey-version>
         <jackson-version>2.8.9</jackson-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <jodatime-version>2.7</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.8.1</junit-version>

--- a/modules/openapi-generator-maven-plugin/examples/multi-module/java-client/pom.xml
+++ b/modules/openapi-generator-maven-plugin/examples/multi-module/java-client/pom.xml
@@ -133,7 +133,12 @@
           <groupId>com.fasterxml.jackson.jaxrs</groupId>
           <artifactId>jackson-jaxrs-json-provider</artifactId>
           <version>${jackson-version}</version>
-        </dependency>
+      </dependency>
+      <dependency>
+          <groupId>org.openapitools</groupId>
+          <artifactId>jackson-databind-nullable</artifactId>
+          <version>${jackson-databind-nullable-version}</version>
+      </dependency>
 
         <!-- Joda time: if you use it -->
         <dependency>

--- a/modules/openapi-generator-maven-plugin/examples/multi-module/pom.xml
+++ b/modules/openapi-generator-maven-plugin/examples/multi-module/pom.xml
@@ -16,6 +16,7 @@
         <swagger-annotations-version>1.5.8</swagger-annotations-version>
         <jersey-version>2.27</jersey-version>
         <jackson-version>2.8.9</jackson-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <jodatime-version>2.7</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.8.1</junit-version>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -417,6 +417,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         importMapping.put("JsonTypeInfo", "com.fasterxml.jackson.annotation.JsonTypeInfo");
         importMapping.put("JsonCreator", "com.fasterxml.jackson.annotation.JsonCreator");
         importMapping.put("JsonValue", "com.fasterxml.jackson.annotation.JsonValue");
+        importMapping.put("JsonIgnore", "com.fasterxml.jackson.annotation.JsonIgnore");
+        importMapping.put("JsonInclude", "com.fasterxml.jackson.annotation.JsonInclude");
         importMapping.put("SerializedName", "com.google.gson.annotations.SerializedName");
         importMapping.put("TypeAdapter", "com.google.gson.TypeAdapter");
         importMapping.put("JsonAdapter", "com.google.gson.annotations.JsonAdapter");
@@ -800,7 +802,13 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 }
             }
             return null;
+        } else if (ModelUtils.isObjectSchema(p)) {
+            if (p.getDefault() != null) {
+                return super.toDefaultValue(p);
+            }
+            return null;
         }
+
         return super.toDefaultValue(p);
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/jackson_annotations.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/jackson_annotations.mustache
@@ -1,0 +1,19 @@
+{{!
+ If this is map and items are nullable, make sure that nulls are included.
+ To determine what JsonInclude.Include method to use, consider the following:
+ * If the field is required, always include it, even if it is null.
+ * Else use custom behaviour, IOW use whatever is defined on the object mapper
+ }}
+  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
+  @JsonInclude({{#isMapContainer}}{{#items.isNullable}}content = JsonInclude.Include.ALWAYS, {{/items.isNullable}}{{/isMapContainer}}value = JsonInclude.Include.{{#required}}ALWAYS{{/required}}{{^required}}USE_DEFAULTS{{/required}})
+  {{#withXml}}
+    {{^isContainer}}
+  @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    {{/isContainer}}
+    {{#isContainer}}
+      {{#isXmlWrapped}}
+  // items.xmlName={{items.xmlName}}
+  @JacksonXmlElementWrapper(useWrapping = {{isXmlWrapped}}, {{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#items.xmlName}}{{items.xmlName}}{{/items.xmlName}}{{^items.xmlName}}{{items.baseName}}{{/items.xmlName}}")
+      {{/isXmlWrapped}}
+    {{/isContainer}}
+  {{/withXml}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -12,6 +12,7 @@ import org.threeten.bp.*;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 {{#joda}}
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 {{/joda}}
@@ -177,6 +178,8 @@ public class ApiClient {
     module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
     objectMapper.registerModule(module);
     {{/threetenbp}}
+    JsonNullableModule jnm = new JsonNullableModule();
+    objectMapper.registerModule(jnm);
     return objectMapper;
   }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -244,6 +244,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
         {{#withXml}}
 
             <!-- XML Support -->
@@ -310,6 +315,7 @@
         <feign-version>{{#useFeign10}}10.2.3{{/useFeign10}}{{^useFeign10}}9.7.0{{/useFeign10}}</feign-version>
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.9.9</jackson-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
         {{#threetenbp}}
         <jackson-threetenbp-version>2.6.4</jackson-threetenbp-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/ApiClient.mustache
@@ -4,6 +4,7 @@ import {{apiPackage}}.*;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 {{#joda}}
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 {{/joda}}
@@ -53,6 +54,8 @@ public class ApiClient {
         module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
         objectMapper.registerModule(module);
         {{/threetenbp}}
+        JsonNullableModule jnm = new JsonNullableModule();
+        objectMapper.registerModule(jnm);
         return objectMapper;
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
@@ -253,6 +253,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
         {{#withXml}}
             <!-- XML processing: Jackson -->
             <dependency>
@@ -303,6 +308,7 @@
         <jersey-common-version>2.25.1</jersey-common-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/joda}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/JSON.mustache
@@ -5,6 +5,7 @@ import org.threeten.bp.*;
 {{/threetenbp}}
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 {{#java8}}
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 {{/java8}}
@@ -45,6 +46,8 @@ public class JSON implements ContextResolver<ObjectMapper> {
     module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
     mapper.registerModule(module);
     {{/threetenbp}}
+    JsonNullableModule jnm = new JsonNullableModule();
+    mapper.registerModule(jnm);
   }
 
   /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -276,6 +276,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
         {{#withXml}}
 
             <!-- XML processing: JAXB -->
@@ -357,6 +362,7 @@
         {{/supportJava6}}
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         {{#threetenbp}}
         <threetenbp-version>2.6.4</threetenbp-version>
         {{/threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import java.net.URI;
 import java.net.URLEncoder;
@@ -151,6 +152,8 @@ public class ApiClient {
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.registerModule(new JavaTimeModule());
+    JsonNullableModule jnm = new JsonNullableModule();
+    mapper.registerModule(jnm);
     URI baseURI = URI.create("{{{basePath}}}");
     scheme = baseURI.getScheme();
     host = baseURI.getHost();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
@@ -188,6 +188,11 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
 
         <!-- @Nullable annotation -->
         <dependency>
@@ -210,6 +215,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <jackson-version>2.9.9</jackson-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
     </properties>
 </project>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/JSON.mustache
@@ -2,6 +2,7 @@ package {{invokerPackage}};
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 {{#java8}}
 import com.fasterxml.jackson.datatype.jsr310.*;
 {{/java8}}
@@ -26,6 +27,8 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.setDateFormat(new RFC3339DateFormat());
+    JsonNullableModule jnm = new JsonNullableModule();
+    mapper.registerModule(jnm);
     {{#java8}}
     mapper.registerModule(new JavaTimeModule());
     {{/java8}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -212,6 +212,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
         {{#withXml}}
 
         <!-- XML processing: Jackson -->
@@ -291,6 +296,7 @@
         <resteasy-version>3.1.3.Final</resteasy-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <threetenbp-version>2.6.4</threetenbp-version>
         {{^java8}}
         <jodatime-version>2.9.9</jodatime-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 {{/threetenbp}}
 
 import java.io.BufferedReader;
@@ -661,6 +662,7 @@ public class ApiClient {
         messageConverters.add(new MappingJackson2HttpMessageConverter());
         XmlMapper xmlMapper = new XmlMapper();
         xmlMapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        xmlMapper.registerModule(new JsonNullableModule());
         messageConverters.add(new MappingJackson2XmlHttpMessageConverter(xmlMapper));
 
         RestTemplate restTemplate = new RestTemplate(messageConverters);
@@ -674,6 +676,7 @@ public class ApiClient {
                 module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
                 module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
                 mapper.registerModule(module);
+                mapper.registerModule(new JsonNullableModule());
             }
         }
         {{/threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -255,6 +255,11 @@
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
         {{#withXml}}
 
             <!-- XML processing: Jackson -->
@@ -306,6 +311,7 @@
         <spring-web-version>4.3.9.RELEASE</spring-web-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/joda}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play24/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play24/ApiClient.mustache
@@ -8,6 +8,8 @@ import java.util.*;
 import retrofit2.Retrofit;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import play.libs.Json;
 import play.libs.ws.WSClient;
@@ -68,10 +70,14 @@ public class ApiClient {
             auth.applyToParams(extraQueryParams, extraHeaders);
         }
 
+        ObjectMapper mapper = Json.mapper();
+        JsonNullableModule jnm = new JsonNullableModule();
+        mapper.registerModule(jnm);
+
         return new Retrofit.Builder()
                        .baseUrl(basePath)
                        .addConverterFactory(ScalarsConverterFactory.create())
-                       .addConverterFactory(JacksonConverterFactory.create(Json.mapper()))
+                       .addConverterFactory(JacksonConverterFactory.create(mapper))
                        .callFactory(new Play24CallFactory(wsClient, extraHeaders, extraQueryParams))
                        .addCallAdapterFactory(new Play24CallAdapterFactory())
                        .build()

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play25/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play25/ApiClient.mustache
@@ -8,6 +8,8 @@ import java.util.*;
 import retrofit2.Retrofit;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import play.libs.Json;
 import play.libs.ws.WSClient;
@@ -67,10 +69,14 @@ public class ApiClient {
             auth.applyToParams(extraQueryParams, extraHeaders);
         }
 
+        ObjectMapper mapper = Json.mapper();
+        JsonNullableModule jnm = new JsonNullableModule();
+        mapper.registerModule(jnm);
+
         return new Retrofit.Builder()
                        .baseUrl(basePath)
                        .addConverterFactory(ScalarsConverterFactory.create())
-                       .addConverterFactory(JacksonConverterFactory.create(Json.mapper()))
+                       .addConverterFactory(JacksonConverterFactory.create(mapper))
                        .callFactory(new Play25CallFactory(wsClient, extraHeaders, extraQueryParams))
                        .addCallAdapterFactory(new Play25CallAdapterFactory())
                        .build()

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play26/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play26/ApiClient.mustache
@@ -13,6 +13,7 @@ import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import play.libs.Json;
 import play.libs.ws.WSClient;
@@ -89,6 +90,8 @@ public class ApiClient {
         }
         if (defaultMapper == null) {
             defaultMapper = Json.mapper();
+            JsonNullableModule jnm = new JsonNullableModule();
+            defaultMapper.registerModule(jnm);
         }
 
         return new Retrofit.Builder()

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -314,12 +314,22 @@
                 <artifactId>play-java-ws_2.11</artifactId>
                 <version>${play-version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.openapitools</groupId>
+                <artifactId>jackson-databind-nullable</artifactId>
+                <version>${jackson-databind-nullable-version}</version>
+            </dependency>
             {{/play24}}
             {{#play25}}
             <dependency>
                 <groupId>com.typesafe.play</groupId>
                 <artifactId>play-java-ws_2.11</artifactId>
                 <version>${play-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openapitools</groupId>
+                <artifactId>jackson-databind-nullable</artifactId>
+                <version>${jackson-databind-nullable-version}</version>
             </dependency>
             {{/play25}}
             {{#play26}}
@@ -332,6 +342,11 @@
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>1.1.0.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openapitools</groupId>
+                <artifactId>jackson-databind-nullable</artifactId>
+                <version>${jackson-databind-nullable-version}</version>
             </dependency>
             {{/play26}}
         {{/usePlayWS}}
@@ -373,6 +388,7 @@
         <jackson-version>2.9.9</jackson-version>
         <play-version>2.6.7</play-version>
         {{/play26}}
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         {{/usePlayWS}}
         <retrofit-version>2.5.0</retrofit-version>
         {{#useRxJava}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
@@ -77,6 +78,8 @@ public class ApiClient {
         this.objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
         this.objectMapper.registerModule(new JavaTimeModule());
         this.objectMapper.setDateFormat(dateFormat);
+        JsonNullableModule jnm = new JsonNullableModule();
+        this.objectMapper.registerModule(jnm);
 
         // Setup authentications (key: authentication name, value: authentication).
         this.authentications = new HashMap<>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -243,6 +243,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
         {{#joda}}
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -286,6 +291,7 @@
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
         <jackson-version>{{^threetenbp}}2.9.9{{/threetenbp}}{{#threetenbp}}2.6.4{{/threetenbp}}</jackson-version>
         <jackson-databind>{{^threetenbp}}2.9.9{{/threetenbp}}{{#threetenbp}}2.6.4{{/threetenbp}}</jackson-databind>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
     </properties>
 </project>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -3,6 +3,7 @@ package {{invokerPackage}};
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -96,6 +97,8 @@ public class ApiClient {
         mapper.setDateFormat(dateFormat);
         mapper.registerModule(new JavaTimeModule());
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        JsonNullableModule jnm = new JsonNullableModule();
+        mapper.registerModule(jnm);
 
         this.webClient = buildWebClient(mapper);
         this.init();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -105,6 +105,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
 
         {{#java8}}
             <dependency>
@@ -140,6 +145,7 @@
         <spring-web-version>5.0.7.RELEASE</spring-web-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
         <reactor-version>3.1.8.RELEASE</reactor-version>
         <reactor-netty-version>0.7.8.RELEASE</reactor-netty-version>

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -19,21 +19,6 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     {{/mostInnerItems}}
     {{/isContainer}}
     {{/isEnum}}
-  {{#jackson}}
-  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
-  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
-  {{#withXml}}
-    {{^isContainer}}
-  @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
-    {{/isContainer}}
-    {{#isContainer}}
-      {{#isXmlWrapped}}
-  // items.xmlName={{items.xmlName}}
-  @JacksonXmlElementWrapper(useWrapping = {{isXmlWrapped}}, {{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#items.xmlName}}{{items.xmlName}}{{/items.xmlName}}{{^items.xmlName}}{{items.baseName}}{{/items.xmlName}}")
-      {{/isXmlWrapped}}
-    {{/isContainer}}
-  {{/withXml}}
-  {{/jackson}}
   {{#withXml}}
   {{#isXmlAttribute}}
   @XmlAttribute(name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
@@ -59,12 +44,25 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
   @SerializedName(SERIALIZED_NAME_{{nameInSnakeCase}})
   {{/gson}}
+  {{#jackson}}
+  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
+  {{/jackson}}
+  {{#vendorExtensions.isJacksonOptionalNullable}}
+  {{#isContainer}}
+  private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>undefined();
+  {{/isContainer}}
+  {{^isContainer}}
+  private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
+  {{/isContainer}}
+  {{/vendorExtensions.isJacksonOptionalNullable}}
+  {{^vendorExtensions.isJacksonOptionalNullable}}
   {{#isContainer}}
   private {{{datatypeWithEnum}}} {{name}}{{#required}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/required}}{{^required}} = null{{/required}};
   {{/isContainer}}
   {{^isContainer}}
   private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
   {{/isContainer}}
+  {{/vendorExtensions.isJacksonOptionalNullable}}
 
   {{/vars}}
   {{#parcelableModel}}
@@ -89,14 +87,28 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{/gson}}
   {{/parcelableModel}}
   {{#vars}}
+
   {{^isReadOnly}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
-    this.{{name}} = {{name}};
+    {{#vendorExtensions.isJacksonOptionalNullable}}this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});{{/vendorExtensions.isJacksonOptionalNullable}}
+    {{^vendorExtensions.isJacksonOptionalNullable}}this.{{name}} = {{name}};{{/vendorExtensions.isJacksonOptionalNullable}}
     return this;
   }
   {{#isListContainer}}
 
   public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{#vendorExtensions.isJacksonOptionalNullable}}
+    if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}});
+    }
+    try {
+      this.{{name}}.get().add({{name}}Item);
+    } catch (java.util.NoSuchElementException e) {
+      // this can never happen, as we make sure above that the value is present
+    }
+    return this;
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+    {{^vendorExtensions.isJacksonOptionalNullable}}
     {{^required}}
     if (this.{{name}} == null) {
       this.{{name}} = {{{defaultValue}}};
@@ -104,11 +116,24 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     {{/required}}
     this.{{name}}.add({{name}}Item);
     return this;
+    {{/vendorExtensions.isJacksonOptionalNullable}}
   }
   {{/isListContainer}}
   {{#isMapContainer}}
 
   public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{#vendorExtensions.isJacksonOptionalNullable}}
+    if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}});
+    }
+    try {
+      this.{{name}}.get().put(key, {{name}}Item);
+    } catch (java.util.NoSuchElementException e) {
+      // this can never happen, as we make sure above that the value is present
+    }
+    return this;
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+    {{^vendorExtensions.isJacksonOptionalNullable}}
     {{^required}}
     if (this.{{name}} == null) {
       this.{{name}} = {{{defaultValue}}};
@@ -116,6 +141,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     {{/required}}
     this.{{name}}.put(key, {{name}}Item);
     return this;
+    {{/vendorExtensions.isJacksonOptionalNullable}}
   }
   {{/isMapContainer}}
 
@@ -147,13 +173,43 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}
+{{^vendorExtensions.isJacksonOptionalNullable}}{{#jackson}}{{> jackson_annotations}}{{/jackson}}{{/vendorExtensions.isJacksonOptionalNullable}}
   public {{{datatypeWithEnum}}} {{getter}}() {
+    {{#vendorExtensions.isJacksonOptionalNullable}}
+    {{#isReadOnly}}{{! A readonly attribute doesn't have setter => jackson will set null directly if explicitly returned by API, so make sure we have an empty JsonNullable}}
+    if ({{name}} == null) {
+      {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
+    }
+    {{/isReadOnly}}
+    return {{name}}.orElse(null);
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+    {{^vendorExtensions.isJacksonOptionalNullable}}
+    return {{name}};
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+  }
+
+  {{#vendorExtensions.isJacksonOptionalNullable}}
+{{> jackson_annotations}}
+  public JsonNullable<{{{datatypeWithEnum}}}> {{getter}}_JsonNullable() {
     return {{name}};
   }
+  {{/vendorExtensions.isJacksonOptionalNullable}}
+
   {{^isReadOnly}}
+  {{#vendorExtensions.isJacksonOptionalNullable}}
+  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
+  public void {{setter}}_JsonNullable(JsonNullable<{{{datatypeWithEnum}}}> {{name}}) {
+    this.{{name}} = {{name}};
+  }
+  {{/vendorExtensions.isJacksonOptionalNullable}}
 
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+    {{#vendorExtensions.isJacksonOptionalNullable}}
+    this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+    {{^vendorExtensions.isJacksonOptionalNullable}}
     this.{{name}} = {{name}};
+    {{/vendorExtensions.isJacksonOptionalNullable}}
   }
   {{/isReadOnly}}
 

--- a/samples/client/petstore/groovy/src/main/groovy/org/openapitools/model/Pet.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/org/openapitools/model/Pet.groovy
@@ -13,7 +13,7 @@ class Pet {
     
     Long id
     
-    Category category = null
+    Category category
     
     String name
     

--- a/samples/client/petstore/java/feign/pom.xml
+++ b/samples/client/petstore/java/feign/pom.xml
@@ -237,6 +237,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
             <dependency>
                 <groupId>com.github.joschi.jackson</groupId>
                 <artifactId>jackson-datatype-threetenbp</artifactId>
@@ -277,6 +282,7 @@
         <feign-version>9.7.0</feign-version>
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.9.9</jackson-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
         <jackson-threetenbp-version>2.6.4</jackson-threetenbp-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
@@ -10,6 +10,7 @@ import org.threeten.bp.*;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 
 import feign.Feign;
@@ -143,6 +144,8 @@ public class ApiClient {
     module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
     module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
     objectMapper.registerModule(module);
+    JsonNullableModule jnm = new JsonNullableModule();
+    objectMapper.registerModule(jnm);
     return objectMapper;
   }
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import org.threeten.bp.OffsetDateTime;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.threeten.bp.OffsetDateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import org.threeten.bp.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean isBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean isBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/feign10x/pom.xml
+++ b/samples/client/petstore/java/feign10x/pom.xml
@@ -237,6 +237,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
             <dependency>
                 <groupId>com.github.joschi.jackson</groupId>
                 <artifactId>jackson-datatype-threetenbp</artifactId>
@@ -277,6 +282,7 @@
         <feign-version>10.2.3</feign-version>
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.9.9</jackson-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
         <jackson-threetenbp-version>2.6.4</jackson-threetenbp-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/ApiClient.java
@@ -10,6 +10,7 @@ import org.threeten.bp.*;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 
 import feign.Feign;
@@ -143,6 +144,8 @@ public class ApiClient {
     module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
     module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
     objectMapper.registerModule(module);
+    JsonNullableModule jnm = new JsonNullableModule();
+    objectMapper.registerModule(jnm);
     return objectMapper;
   }
 

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import org.threeten.bp.OffsetDateTime;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.threeten.bp.OffsetDateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import org.threeten.bp.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean isBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean isBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/google-api-client/docs/UserApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/google-api-client/pom.xml
+++ b/samples/client/petstore/java/google-api-client/pom.xml
@@ -234,6 +234,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
             <dependency>
                 <groupId>com.github.joschi.jackson</groupId>
                 <artifactId>jackson-datatype-threetenbp</artifactId>
@@ -255,6 +260,7 @@
         <jersey-common-version>2.25.1</jersey-common-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <jackson-threetenbp-version>2.6.4</jackson-threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/ApiClient.java
@@ -4,6 +4,7 @@ import org.openapitools.client.api.*;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 import org.threeten.bp.*;
 import com.google.api.client.googleapis.util.Utils;
@@ -35,6 +36,8 @@ public class ApiClient {
         module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
         module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
         objectMapper.registerModule(module);
+        JsonNullableModule jnm = new JsonNullableModule();
+        objectMapper.registerModule(jnm);
         return objectMapper;
     }
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import org.threeten.bp.OffsetDateTime;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.threeten.bp.OffsetDateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import org.threeten.bp.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/jersey1/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey1/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import org.threeten.bp.OffsetDateTime;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.threeten.bp.OffsetDateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import org.threeten.bp.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/jersey2-java6/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/jersey2-java6/pom.xml
+++ b/samples/client/petstore/java/jersey2-java6/pom.xml
@@ -250,6 +250,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
             <dependency>
                 <groupId>com.github.joschi.jackson</groupId>
                 <artifactId>jackson-datatype-threetenbp</artifactId>
@@ -287,6 +292,7 @@
         <commons_lang3_version>3.6</commons_lang3_version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <threetenbp-version>2.6.4</threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/JSON.java
@@ -3,6 +3,7 @@ package org.openapitools.client;
 import org.threeten.bp.*;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 
 import java.text.DateFormat;
@@ -27,6 +28,8 @@ public class JSON implements ContextResolver<ObjectMapper> {
     module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
     module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
     mapper.registerModule(module);
+    JsonNullableModule jnm = new JsonNullableModule();
+    mapper.registerModule(jnm);
   }
 
   /**

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -42,9 +44,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -42,9 +44,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,50 +31,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -92,15 +84,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -119,15 +118,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -146,15 +152,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -173,15 +186,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -200,15 +220,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -227,15 +254,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -254,15 +288,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -281,15 +322,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -300,15 +348,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -319,15 +374,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -338,9 +400,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -42,9 +44,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -42,9 +44,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -42,9 +44,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Animal.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -34,14 +35,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -51,15 +52,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -70,9 +78,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -51,9 +53,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -51,9 +53,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,18 +30,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -59,15 +59,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -86,15 +93,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -113,9 +127,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,30 +27,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -60,15 +57,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -79,15 +83,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -98,15 +109,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -117,15 +135,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -136,15 +161,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -155,9 +187,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Cat.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -42,9 +44,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,10 +27,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -40,9 +42,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Category.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,14 +27,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -44,15 +45,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -62,9 +70,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -41,9 +43,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Client.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,10 +27,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -40,9 +42,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Dog.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -42,9 +44,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,10 +27,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -40,9 +42,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -63,7 +64,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -102,10 +102,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -116,15 +117,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -143,9 +151,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -105,7 +105,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -144,7 +143,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -183,14 +181,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -201,15 +199,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -219,15 +224,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -238,15 +250,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -257,15 +276,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -276,9 +302,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -46,15 +47,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -73,9 +81,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,58 +32,47 @@ import org.threeten.bp.OffsetDateTime;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -95,15 +85,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -116,15 +113,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -135,15 +139,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -155,15 +166,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -176,15 +194,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -197,15 +222,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -216,15 +248,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -234,15 +273,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -253,15 +299,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -271,15 +324,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -290,15 +350,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -309,15 +376,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -327,9 +401,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,12 +27,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -39,9 +39,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -49,9 +55,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MapTest.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,7 +30,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -68,18 +68,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -98,15 +97,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -125,15 +131,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -152,15 +165,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -179,9 +199,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,18 +33,17 @@ import org.threeten.bp.OffsetDateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -54,15 +54,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -73,15 +80,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -100,9 +114,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -45,15 +46,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -64,9 +72,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,18 +27,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -48,15 +48,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -67,15 +74,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -86,9 +100,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -41,9 +43,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Name.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,22 +28,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -52,13 +51,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -66,11 +71,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -81,13 +93,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -95,9 +113,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -41,9 +43,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Order.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,19 +28,15 @@ import org.threeten.bp.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -80,14 +77,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -98,15 +95,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -117,15 +121,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -136,15 +147,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -155,15 +173,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -174,15 +199,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -193,9 +225,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -49,15 +49,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -68,15 +75,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -87,9 +101,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Pet.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,23 +31,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -87,10 +83,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -101,15 +98,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -120,15 +124,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -138,15 +149,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -161,15 +179,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -188,15 +213,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -207,9 +239,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,12 +27,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -39,11 +39,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -54,9 +61,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,10 +27,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -40,9 +42,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Tag.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,14 +27,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -44,15 +45,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,26 +30,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -58,15 +56,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -76,15 +81,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -94,15 +106,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -112,15 +131,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean isBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -135,9 +161,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,26 +30,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -58,15 +56,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -76,15 +81,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -94,15 +106,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -112,15 +131,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean isBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -135,9 +161,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/User.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -26,38 +27,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -68,15 +63,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -87,15 +89,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -106,15 +115,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -125,15 +141,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -144,15 +167,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -163,15 +193,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -182,15 +219,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -201,9 +245,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,122 +30,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -155,15 +129,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -174,15 +155,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -193,15 +181,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -212,15 +207,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -239,15 +241,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -258,15 +267,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -277,15 +293,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -296,15 +319,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -315,15 +345,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -342,15 +379,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -369,15 +413,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -388,15 +439,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -407,15 +465,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -426,15 +491,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -445,15 +517,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -472,15 +551,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -499,15 +585,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -518,15 +611,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -537,15 +637,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -556,15 +663,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -575,15 +689,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -602,15 +723,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -629,15 +757,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -648,15 +783,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -667,15 +809,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -686,15 +835,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -705,15 +861,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -732,15 +895,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -759,9 +929,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/jersey2-java8/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -255,6 +255,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jsr310</artifactId>
@@ -274,6 +279,7 @@
         <jersey-version>2.27</jersey-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>
     </properties>

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/JSON.java
@@ -2,6 +2,7 @@ package org.openapitools.client;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.text.DateFormat;
@@ -22,6 +23,8 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.setDateFormat(new RFC3339DateFormat());
     mapper.registerModule(new JavaTimeModule());
+    JsonNullableModule jnm = new JsonNullableModule();
+    mapper.registerModule(jnm);
   }
 
   /**

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import java.util.UUID;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.openapitools.client.model.Animal;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import java.time.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/jersey2/docs/UserApi.md
+++ b/samples/client/petstore/java/jersey2/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/jersey2/pom.xml
+++ b/samples/client/petstore/java/jersey2/pom.xml
@@ -255,6 +255,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
             <dependency>
                 <groupId>com.github.joschi.jackson</groupId>
                 <artifactId>jackson-datatype-threetenbp</artifactId>
@@ -280,6 +285,7 @@
         <jersey-version>2.27</jersey-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <threetenbp-version>2.6.4</threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/JSON.java
@@ -3,6 +3,7 @@ package org.openapitools.client;
 import org.threeten.bp.*;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 
 import java.text.DateFormat;
@@ -27,6 +28,8 @@ public class JSON implements ContextResolver<ObjectMapper> {
     module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
     module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
     mapper.registerModule(module);
+    JsonNullableModule jnm = new JsonNullableModule();
+    mapper.registerModule(jnm);
   }
 
   /**

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import org.threeten.bp.OffsetDateTime;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.threeten.bp.OffsetDateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import org.threeten.bp.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/native/docs/UserApi.md
+++ b/samples/client/petstore/java/native/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/native/pom.xml
+++ b/samples/client/petstore/java/native/pom.xml
@@ -181,6 +181,11 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
 
         <!-- @Nullable annotation -->
         <dependency>
@@ -203,6 +208,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <jackson-version>2.9.9</jackson-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import java.net.URI;
 import java.net.URLEncoder;
@@ -162,6 +163,8 @@ public class ApiClient {
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.registerModule(new JavaTimeModule());
+    JsonNullableModule jnm = new JsonNullableModule();
+    mapper.registerModule(jnm);
     URI baseURI = URI.create("http://petstore.swagger.io:80/v2");
     scheme = baseURI.getScheme();
     host = baseURI.getHost();

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import java.util.UUID;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.openapitools.client.model.Animal;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import java.time.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/UserApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/UserApi.md
@@ -96,7 +96,7 @@ public class Example {
     defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
     UserApi apiInstance = new UserApi(defaultClient);
-    List<User> body = Arrays.asList(null); // List<User> | List of user object
+    List<User> body = Arrays.asList(); // List<User> | List of user object
     try {
       apiInstance.createUsersWithArrayInput(body);
     } catch (ApiException e) {
@@ -155,7 +155,7 @@ public class Example {
     defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
     UserApi apiInstance = new UserApi(defaultClient);
-    List<User> body = Arrays.asList(null); // List<User> | List of user object
+    List<User> body = Arrays.asList(); // List<User> | List of user object
     try {
       apiInstance.createUsersWithListInput(body);
     } catch (ApiException e) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -40,7 +40,9 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
   public AdditionalPropertiesAnyType() {
     super();
   }
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -51,9 +53,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -41,7 +41,9 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
   public AdditionalPropertiesArray() {
     super();
   }
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -52,9 +54,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -40,7 +40,9 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
   public AdditionalPropertiesBoolean() {
     super();
   }
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -51,9 +53,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -69,19 +69,21 @@ public class AdditionalPropertiesClass implements Parcelable {
 
   public static final String SERIALIZED_NAME_ANYTYPE1 = "anytype_1";
   @SerializedName(SERIALIZED_NAME_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String SERIALIZED_NAME_ANYTYPE2 = "anytype_2";
   @SerializedName(SERIALIZED_NAME_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String SERIALIZED_NAME_ANYTYPE3 = "anytype_3";
   @SerializedName(SERIALIZED_NAME_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass() {
   }
+
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -100,15 +102,20 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -127,15 +134,20 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -154,15 +166,20 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -181,15 +198,20 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -208,15 +230,20 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -235,15 +262,20 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -262,15 +294,20 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -289,15 +326,20 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -308,15 +350,20 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -327,15 +374,20 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -346,9 +398,12 @@ public class AdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -40,7 +40,9 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
   public AdditionalPropertiesInteger() {
     super();
   }
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -51,9 +53,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -41,7 +41,9 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
   public AdditionalPropertiesNumber() {
     super();
   }
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -52,9 +54,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -40,7 +40,9 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
   public AdditionalPropertiesObject() {
     super();
   }
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -51,9 +53,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -40,7 +40,9 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
   public AdditionalPropertiesString() {
     super();
   }
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -51,9 +53,12 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Animal.java
@@ -43,7 +43,9 @@ public class Animal implements Parcelable {
   public Animal() {
     this.className = this.getClass().getSimpleName();
   }
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -53,15 +55,20 @@ public class Animal implements Parcelable {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -72,9 +79,12 @@ public class Animal implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -40,7 +40,9 @@ public class ArrayOfArrayOfNumberOnly implements Parcelable {
 
   public ArrayOfArrayOfNumberOnly() {
   }
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -59,9 +61,12 @@ public class ArrayOfArrayOfNumberOnly implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -40,7 +40,9 @@ public class ArrayOfNumberOnly implements Parcelable {
 
   public ArrayOfNumberOnly() {
   }
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -59,9 +61,12 @@ public class ArrayOfNumberOnly implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -48,7 +48,9 @@ public class ArrayTest implements Parcelable {
 
   public ArrayTest() {
   }
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -67,15 +69,20 @@ public class ArrayTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -94,15 +101,20 @@ public class ArrayTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -121,9 +133,12 @@ public class ArrayTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -57,7 +57,9 @@ public class Capitalization implements Parcelable {
 
   public Capitalization() {
   }
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -68,15 +70,20 @@ public class Capitalization implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -87,15 +94,20 @@ public class Capitalization implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -106,15 +118,20 @@ public class Capitalization implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -125,15 +142,20 @@ public class Capitalization implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -144,15 +166,20 @@ public class Capitalization implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -163,9 +190,12 @@ public class Capitalization implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Cat.java
@@ -40,7 +40,9 @@ public class Cat extends Animal implements Parcelable {
   public Cat() {
     super();
   }
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -51,9 +53,12 @@ public class Cat extends Animal implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -37,7 +37,9 @@ public class CatAllOf implements Parcelable {
 
   public CatAllOf() {
   }
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -48,9 +50,12 @@ public class CatAllOf implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Category.java
@@ -41,7 +41,9 @@ public class Category implements Parcelable {
 
   public Category() {
   }
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -52,15 +54,20 @@ public class Category implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -70,9 +77,12 @@ public class Category implements Parcelable {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -38,7 +38,9 @@ public class ClassModel implements Parcelable {
 
   public ClassModel() {
   }
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -49,9 +51,12 @@ public class ClassModel implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Client.java
@@ -37,7 +37,9 @@ public class Client implements Parcelable {
 
   public Client() {
   }
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -48,9 +50,12 @@ public class Client implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Dog.java
@@ -40,7 +40,9 @@ public class Dog extends Animal implements Parcelable {
   public Dog() {
     super();
   }
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -51,9 +53,12 @@ public class Dog extends Animal implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -37,7 +37,9 @@ public class DogAllOf implements Parcelable {
 
   public DogAllOf() {
   }
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -48,9 +50,12 @@ public class DogAllOf implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -137,7 +137,9 @@ public class EnumArrays implements Parcelable {
 
   public EnumArrays() {
   }
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -148,15 +150,20 @@ public class EnumArrays implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -175,9 +182,12 @@ public class EnumArrays implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -246,7 +246,9 @@ public class EnumTest implements Parcelable {
 
   public EnumTest() {
   }
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -257,15 +259,20 @@ public class EnumTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -275,15 +282,20 @@ public class EnumTest implements Parcelable {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -294,15 +306,20 @@ public class EnumTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -313,15 +330,20 @@ public class EnumTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -332,9 +354,12 @@ public class EnumTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -35,7 +35,7 @@ import android.os.Parcel;
 public class FileSchemaTestClass implements Parcelable {
   public static final String SERIALIZED_NAME_FILE = "file";
   @SerializedName(SERIALIZED_NAME_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String SERIALIZED_NAME_FILES = "files";
   @SerializedName(SERIALIZED_NAME_FILES)
@@ -43,7 +43,9 @@ public class FileSchemaTestClass implements Parcelable {
 
   public FileSchemaTestClass() {
   }
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -54,15 +56,20 @@ public class FileSchemaTestClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -81,9 +88,12 @@ public class FileSchemaTestClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -90,7 +90,9 @@ public class FormatTest implements Parcelable {
 
   public FormatTest() {
   }
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -103,15 +105,20 @@ public class FormatTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -124,15 +131,20 @@ public class FormatTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -143,15 +155,20 @@ public class FormatTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -163,15 +180,20 @@ public class FormatTest implements Parcelable {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -184,15 +206,20 @@ public class FormatTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -205,15 +232,20 @@ public class FormatTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -224,15 +256,20 @@ public class FormatTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -242,15 +279,20 @@ public class FormatTest implements Parcelable {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -261,15 +303,20 @@ public class FormatTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -279,15 +326,20 @@ public class FormatTest implements Parcelable {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -298,15 +350,20 @@ public class FormatTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -317,15 +374,20 @@ public class FormatTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -335,9 +397,12 @@ public class FormatTest implements Parcelable {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -41,15 +41,20 @@ public class HasOnlyReadOnly implements Parcelable {
 
   public HasOnlyReadOnly() {
   }
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -57,9 +62,12 @@ public class HasOnlyReadOnly implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MapTest.java
@@ -99,7 +99,9 @@ public class MapTest implements Parcelable {
 
   public MapTest() {
   }
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -118,15 +120,20 @@ public class MapTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -145,15 +152,20 @@ public class MapTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -172,15 +184,20 @@ public class MapTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -199,9 +216,12 @@ public class MapTest implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -51,7 +51,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass implements Parcelable {
 
   public MixedPropertiesAndAdditionalPropertiesClass() {
   }
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -62,15 +64,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -81,15 +88,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -108,9 +120,12 @@ public class MixedPropertiesAndAdditionalPropertiesClass implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -42,7 +42,9 @@ public class Model200Response implements Parcelable {
 
   public Model200Response() {
   }
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,15 +55,20 @@ public class Model200Response implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -72,9 +79,12 @@ public class Model200Response implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -45,7 +45,9 @@ public class ModelApiResponse implements Parcelable {
 
   public ModelApiResponse() {
   }
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -56,15 +58,20 @@ public class ModelApiResponse implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -75,15 +82,20 @@ public class ModelApiResponse implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -94,9 +106,12 @@ public class ModelApiResponse implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -38,7 +38,9 @@ public class ModelReturn implements Parcelable {
 
   public ModelReturn() {
   }
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -49,9 +51,12 @@ public class ModelReturn implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Name.java
@@ -50,7 +50,9 @@ public class Name implements Parcelable {
 
   public Name() {
   }
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -60,13 +62,17 @@ public class Name implements Parcelable {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -74,11 +80,16 @@ public class Name implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -89,13 +100,17 @@ public class Name implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -103,9 +118,12 @@ public class Name implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -38,7 +38,9 @@ public class NumberOnly implements Parcelable {
 
   public NumberOnly() {
   }
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -49,9 +51,12 @@ public class NumberOnly implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
@@ -107,7 +107,9 @@ public class Order implements Parcelable {
 
   public Order() {
   }
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -118,15 +120,20 @@ public class Order implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -137,15 +144,20 @@ public class Order implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -156,15 +168,20 @@ public class Order implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -175,15 +192,20 @@ public class Order implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -194,15 +216,20 @@ public class Order implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -213,9 +240,12 @@ public class Order implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -46,7 +46,9 @@ public class OuterComposite implements Parcelable {
 
   public OuterComposite() {
   }
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -57,15 +59,20 @@ public class OuterComposite implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -76,15 +83,20 @@ public class OuterComposite implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -95,9 +107,12 @@ public class OuterComposite implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Pet.java
@@ -41,7 +41,7 @@ public class Pet implements Parcelable {
 
   public static final String SERIALIZED_NAME_CATEGORY = "category";
   @SerializedName(SERIALIZED_NAME_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -110,7 +110,9 @@ public class Pet implements Parcelable {
 
   public Pet() {
   }
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -121,15 +123,20 @@ public class Pet implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -140,15 +147,20 @@ public class Pet implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -158,15 +170,20 @@ public class Pet implements Parcelable {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -181,15 +198,20 @@ public class Pet implements Parcelable {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -208,15 +230,20 @@ public class Pet implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -227,9 +254,12 @@ public class Pet implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -41,17 +41,23 @@ public class ReadOnlyFirst implements Parcelable {
 
   public ReadOnlyFirst() {
   }
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -62,9 +68,12 @@ public class ReadOnlyFirst implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -37,7 +37,9 @@ public class SpecialModelName implements Parcelable {
 
   public SpecialModelName() {
   }
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -48,9 +50,12 @@ public class SpecialModelName implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Tag.java
@@ -41,7 +41,9 @@ public class Tag implements Parcelable {
 
   public Tag() {
   }
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -52,15 +54,20 @@ public class Tag implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -71,9 +78,12 @@ public class Tag implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -56,7 +56,9 @@ public class TypeHolderDefault implements Parcelable {
 
   public TypeHolderDefault() {
   }
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -66,15 +68,20 @@ public class TypeHolderDefault implements Parcelable {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -84,15 +91,20 @@ public class TypeHolderDefault implements Parcelable {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -102,15 +114,20 @@ public class TypeHolderDefault implements Parcelable {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -120,15 +137,20 @@ public class TypeHolderDefault implements Parcelable {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -143,9 +165,12 @@ public class TypeHolderDefault implements Parcelable {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -56,7 +56,9 @@ public class TypeHolderExample implements Parcelable {
 
   public TypeHolderExample() {
   }
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -66,15 +68,20 @@ public class TypeHolderExample implements Parcelable {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -84,15 +91,20 @@ public class TypeHolderExample implements Parcelable {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -102,15 +114,20 @@ public class TypeHolderExample implements Parcelable {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -120,15 +137,20 @@ public class TypeHolderExample implements Parcelable {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -143,9 +165,12 @@ public class TypeHolderExample implements Parcelable {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/User.java
@@ -65,7 +65,9 @@ public class User implements Parcelable {
 
   public User() {
   }
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -76,15 +78,20 @@ public class User implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -95,15 +102,20 @@ public class User implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -114,15 +126,20 @@ public class User implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -133,15 +150,20 @@ public class User implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -152,15 +174,20 @@ public class User implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -171,15 +198,20 @@ public class User implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -190,15 +222,20 @@ public class User implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -209,9 +246,12 @@ public class User implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -152,7 +152,9 @@ public class XmlItem implements Parcelable {
 
   public XmlItem() {
   }
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -163,15 +165,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -182,15 +189,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -201,15 +213,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -220,15 +237,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -247,15 +269,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -266,15 +293,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -285,15 +317,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -304,15 +341,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -323,15 +365,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -350,15 +397,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -377,15 +429,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -396,15 +453,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -415,15 +477,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -434,15 +501,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -453,15 +525,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -480,15 +557,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -507,15 +589,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -526,15 +613,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -545,15 +637,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -564,15 +661,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -583,15 +685,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -610,15 +717,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -637,15 +749,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -656,15 +773,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -675,15 +797,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -694,15 +821,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -713,15 +845,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -740,15 +877,20 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -767,9 +909,12 @@ public class XmlItem implements Parcelable {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/okhttp-gson/docs/UserApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/UserApi.md
@@ -96,7 +96,7 @@ public class Example {
     defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
     UserApi apiInstance = new UserApi(defaultClient);
-    List<User> body = Arrays.asList(null); // List<User> | List of user object
+    List<User> body = Arrays.asList(); // List<User> | List of user object
     try {
       apiInstance.createUsersWithArrayInput(body);
     } catch (ApiException e) {
@@ -155,7 +155,7 @@ public class Example {
     defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
     UserApi apiInstance = new UserApi(defaultClient);
-    List<User> body = Arrays.asList(null); // List<User> | List of user object
+    List<User> body = Arrays.asList(); // List<User> | List of user object
     try {
       apiInstance.createUsersWithListInput(body);
     } catch (ApiException e) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -67,17 +67,19 @@ public class AdditionalPropertiesClass {
 
   public static final String SERIALIZED_NAME_ANYTYPE1 = "anytype_1";
   @SerializedName(SERIALIZED_NAME_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String SERIALIZED_NAME_ANYTYPE2 = "anytype_2";
   @SerializedName(SERIALIZED_NAME_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String SERIALIZED_NAME_ANYTYPE3 = "anytype_3";
   @SerializedName(SERIALIZED_NAME_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -96,15 +98,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -123,15 +130,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -150,15 +162,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -177,15 +194,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -204,15 +226,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -231,15 +258,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -258,15 +290,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -285,15 +322,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -304,15 +346,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -323,15 +370,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -342,9 +394,12 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
@@ -41,7 +41,9 @@ public class Animal {
   public Animal() {
     this.className = this.getClass().getSimpleName();
   }
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -51,15 +53,20 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -70,9 +77,12 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -44,7 +44,9 @@ public class ArrayTest {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -63,15 +65,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -90,15 +97,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -117,9 +129,12 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,7 +53,9 @@ public class Capitalization {
   @SerializedName(SERIALIZED_NAME_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -64,15 +66,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -83,15 +90,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -102,15 +114,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -121,15 +138,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -140,15 +162,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -159,9 +186,12 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
@@ -35,7 +35,9 @@ public class Cat extends Animal {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -33,7 +33,9 @@ public class CatAllOf {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -44,9 +46,12 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
@@ -37,7 +37,9 @@ public class Category {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +73,12 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -34,7 +34,9 @@ public class ClassModel {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -45,9 +47,12 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
@@ -33,7 +33,9 @@ public class Client {
   @SerializedName(SERIALIZED_NAME_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -44,9 +46,12 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
@@ -35,7 +35,9 @@ public class Dog extends Animal {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -33,7 +33,9 @@ public class DogAllOf {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -44,9 +46,12 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,7 +133,9 @@ public class EnumArrays {
   @SerializedName(SERIALIZED_NAME_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -144,15 +146,20 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -171,9 +178,12 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -242,7 +242,9 @@ public class EnumTest {
   @SerializedName(SERIALIZED_NAME_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -253,15 +255,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -271,15 +278,20 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -290,15 +302,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -309,15 +326,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -328,9 +350,12 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -33,13 +33,15 @@ import java.util.List;
 public class FileSchemaTestClass {
   public static final String SERIALIZED_NAME_FILE = "file";
   @SerializedName(SERIALIZED_NAME_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String SERIALIZED_NAME_FILES = "files";
   @SerializedName(SERIALIZED_NAME_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -50,15 +52,20 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -77,9 +84,12 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,7 +86,9 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -99,15 +101,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -120,15 +127,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -139,15 +151,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -159,15 +176,20 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -180,15 +202,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -201,15 +228,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -220,15 +252,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -238,15 +275,20 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -257,15 +299,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -275,15 +322,20 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -294,15 +346,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -313,15 +370,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -331,9 +393,12 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -37,15 +37,20 @@ public class HasOnlyReadOnly {
   @SerializedName(SERIALIZED_NAME_FOO)
   private String foo;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -53,9 +58,12 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -95,7 +95,9 @@ public class MapTest {
   @SerializedName(SERIALIZED_NAME_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -114,15 +116,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -141,15 +148,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -168,15 +180,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -195,9 +212,12 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -47,7 +47,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @SerializedName(SERIALIZED_NAME_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -58,15 +60,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -77,15 +84,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -104,9 +116,12 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -38,7 +38,9 @@ public class Model200Response {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -49,15 +51,20 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -68,9 +75,12 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -41,7 +41,9 @@ public class ModelApiResponse {
   @SerializedName(SERIALIZED_NAME_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -52,15 +54,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -71,15 +78,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -90,9 +102,12 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -34,7 +34,9 @@ public class ModelReturn {
   @SerializedName(SERIALIZED_NAME_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -45,9 +47,12 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
@@ -46,7 +46,9 @@ public class Name {
   @SerializedName(SERIALIZED_NAME_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -56,13 +58,17 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -70,11 +76,16 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -85,13 +96,17 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -99,9 +114,12 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -34,7 +34,9 @@ public class NumberOnly {
   @SerializedName(SERIALIZED_NAME_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -45,9 +47,12 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
@@ -103,7 +103,9 @@ public class Order {
   @SerializedName(SERIALIZED_NAME_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -114,15 +116,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -133,15 +140,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -152,15 +164,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -171,15 +188,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -190,15 +212,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -209,9 +236,12 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -42,7 +42,9 @@ public class OuterComposite {
   @SerializedName(SERIALIZED_NAME_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -53,15 +55,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -72,15 +79,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -91,9 +103,12 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
@@ -39,7 +39,7 @@ public class Pet {
 
   public static final String SERIALIZED_NAME_CATEGORY = "category";
   @SerializedName(SERIALIZED_NAME_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -106,7 +106,9 @@ public class Pet {
   @SerializedName(SERIALIZED_NAME_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -117,15 +119,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -136,15 +143,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -154,15 +166,20 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -177,15 +194,20 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -204,15 +226,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -223,9 +250,12 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -37,17 +37,23 @@ public class ReadOnlyFirst {
   @SerializedName(SERIALIZED_NAME_BAZ)
   private String baz;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -58,9 +64,12 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -33,7 +33,9 @@ public class SpecialModelName {
   @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -44,9 +46,12 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
@@ -37,7 +37,9 @@ public class Tag {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -67,9 +74,12 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -52,7 +52,9 @@ public class TypeHolderDefault {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -52,7 +52,9 @@ public class TypeHolderExample {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
@@ -61,7 +61,9 @@ public class User {
   @SerializedName(SERIALIZED_NAME_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -72,15 +74,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -91,15 +98,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -110,15 +122,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -129,15 +146,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -148,15 +170,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -167,15 +194,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -186,15 +218,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -205,9 +242,12 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -148,7 +148,9 @@ public class XmlItem {
   @SerializedName(SERIALIZED_NAME_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -159,15 +161,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -178,15 +185,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -197,15 +209,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -216,15 +233,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -243,15 +265,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -262,15 +289,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -281,15 +313,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -300,15 +337,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -319,15 +361,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -346,15 +393,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -373,15 +425,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -392,15 +449,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -411,15 +473,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -430,15 +497,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -449,15 +521,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -476,15 +553,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -503,15 +585,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -522,15 +609,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -541,15 +633,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -560,15 +657,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -579,15 +681,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -606,15 +713,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -633,15 +745,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -652,15 +769,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -671,15 +793,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -690,15 +817,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -709,15 +841,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -736,15 +873,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -763,9 +905,12 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -67,17 +67,19 @@ public class AdditionalPropertiesClass {
 
   public static final String SERIALIZED_NAME_ANYTYPE1 = "anytype_1";
   @SerializedName(SERIALIZED_NAME_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String SERIALIZED_NAME_ANYTYPE2 = "anytype_2";
   @SerializedName(SERIALIZED_NAME_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String SERIALIZED_NAME_ANYTYPE3 = "anytype_3";
   @SerializedName(SERIALIZED_NAME_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -96,15 +98,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -123,15 +130,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -150,15 +162,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -177,15 +194,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -204,15 +226,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -231,15 +258,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -258,15 +290,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -285,15 +322,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -304,15 +346,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -323,15 +370,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -342,9 +394,12 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
@@ -41,7 +41,9 @@ public class Animal {
   public Animal() {
     this.className = this.getClass().getSimpleName();
   }
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -51,15 +53,20 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -70,9 +77,12 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -44,7 +44,9 @@ public class ArrayTest {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -63,15 +65,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -90,15 +97,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -117,9 +129,12 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,7 +53,9 @@ public class Capitalization {
   @SerializedName(SERIALIZED_NAME_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -64,15 +66,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -83,15 +90,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -102,15 +114,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -121,15 +138,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -140,15 +162,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -159,9 +186,12 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
@@ -35,7 +35,9 @@ public class Cat extends Animal {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean isDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -33,7 +33,9 @@ public class CatAllOf {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -44,9 +46,12 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean isDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
@@ -37,7 +37,9 @@ public class Category {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +73,12 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -34,7 +34,9 @@ public class ClassModel {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -45,9 +47,12 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
@@ -33,7 +33,9 @@ public class Client {
   @SerializedName(SERIALIZED_NAME_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -44,9 +46,12 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
@@ -35,7 +35,9 @@ public class Dog extends Animal {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -33,7 +33,9 @@ public class DogAllOf {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -44,9 +46,12 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,7 +133,9 @@ public class EnumArrays {
   @SerializedName(SERIALIZED_NAME_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -144,15 +146,20 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -171,9 +178,12 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -242,7 +242,9 @@ public class EnumTest {
   @SerializedName(SERIALIZED_NAME_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -253,15 +255,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -271,15 +278,20 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -290,15 +302,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -309,15 +326,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -328,9 +350,12 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -33,13 +33,15 @@ import java.util.List;
 public class FileSchemaTestClass {
   public static final String SERIALIZED_NAME_FILE = "file";
   @SerializedName(SERIALIZED_NAME_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String SERIALIZED_NAME_FILES = "files";
   @SerializedName(SERIALIZED_NAME_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -50,15 +52,20 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -77,9 +84,12 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,7 +86,9 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -99,15 +101,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -120,15 +127,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -139,15 +151,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -159,15 +176,20 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -180,15 +202,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -201,15 +228,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -220,15 +252,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -238,15 +275,20 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -257,15 +299,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -275,15 +322,20 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -294,15 +346,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -313,15 +370,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -331,9 +393,12 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -37,15 +37,20 @@ public class HasOnlyReadOnly {
   @SerializedName(SERIALIZED_NAME_FOO)
   private String foo;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -53,9 +58,12 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
@@ -95,7 +95,9 @@ public class MapTest {
   @SerializedName(SERIALIZED_NAME_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -114,15 +116,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -141,15 +148,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -168,15 +180,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -195,9 +212,12 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -47,7 +47,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @SerializedName(SERIALIZED_NAME_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -58,15 +60,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -77,15 +84,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -104,9 +116,12 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -38,7 +38,9 @@ public class Model200Response {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -49,15 +51,20 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -68,9 +75,12 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -41,7 +41,9 @@ public class ModelApiResponse {
   @SerializedName(SERIALIZED_NAME_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -52,15 +54,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -71,15 +78,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -90,9 +102,12 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -34,7 +34,9 @@ public class ModelReturn {
   @SerializedName(SERIALIZED_NAME_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -45,9 +47,12 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
@@ -46,7 +46,9 @@ public class Name {
   @SerializedName(SERIALIZED_NAME_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -56,13 +58,17 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -70,11 +76,16 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -85,13 +96,17 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -99,9 +114,12 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -34,7 +34,9 @@ public class NumberOnly {
   @SerializedName(SERIALIZED_NAME_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -45,9 +47,12 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
@@ -103,7 +103,9 @@ public class Order {
   @SerializedName(SERIALIZED_NAME_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -114,15 +116,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -133,15 +140,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -152,15 +164,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -171,15 +188,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -190,15 +212,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -209,9 +236,12 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean isComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -42,7 +42,9 @@ public class OuterComposite {
   @SerializedName(SERIALIZED_NAME_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -53,15 +55,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -72,15 +79,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -91,9 +103,12 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean isMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
@@ -39,7 +39,7 @@ public class Pet {
 
   public static final String SERIALIZED_NAME_CATEGORY = "category";
   @SerializedName(SERIALIZED_NAME_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -106,7 +106,9 @@ public class Pet {
   @SerializedName(SERIALIZED_NAME_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -117,15 +119,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -136,15 +143,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -154,15 +166,20 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -177,15 +194,20 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -204,15 +226,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -223,9 +250,12 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -37,17 +37,23 @@ public class ReadOnlyFirst {
   @SerializedName(SERIALIZED_NAME_BAZ)
   private String baz;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -58,9 +64,12 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -33,7 +33,9 @@ public class SpecialModelName {
   @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -44,9 +46,12 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
@@ -37,7 +37,9 @@ public class Tag {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -67,9 +74,12 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -52,7 +52,9 @@ public class TypeHolderDefault {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Boolean isBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -52,7 +52,9 @@ public class TypeHolderExample {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+
   public Boolean isBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
@@ -61,7 +61,9 @@ public class User {
   @SerializedName(SERIALIZED_NAME_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -72,15 +74,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -91,15 +98,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -110,15 +122,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -129,15 +146,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -148,15 +170,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -167,15 +194,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -186,15 +218,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -205,9 +242,12 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -148,7 +148,9 @@ public class XmlItem {
   @SerializedName(SERIALIZED_NAME_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -159,15 +161,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -178,15 +185,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -197,15 +209,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -216,15 +233,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -243,15 +265,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -262,15 +289,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -281,15 +313,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -300,15 +337,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -319,15 +361,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean isNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -346,15 +393,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -373,15 +425,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -392,15 +449,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -411,15 +473,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -430,15 +497,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -449,15 +521,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -476,15 +553,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -503,15 +585,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -522,15 +609,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -541,15 +633,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -560,15 +657,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -579,15 +681,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -606,15 +713,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -633,15 +745,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -652,15 +769,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -671,15 +793,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -690,15 +817,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -709,15 +841,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -736,15 +873,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -763,9 +905,12 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/resteasy/docs/UserApi.md
+++ b/samples/client/petstore/java/resteasy/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/resteasy/pom.xml
+++ b/samples/client/petstore/java/resteasy/pom.xml
@@ -194,6 +194,11 @@
             <version>${jackson-databind-version}</version>
         </dependency>
         <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
             <version>${jackson-version}</version>
@@ -240,6 +245,7 @@
         <resteasy-version>3.1.3.Final</resteasy-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <threetenbp-version>2.6.4</threetenbp-version>
         <jodatime-version>2.9.9</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/JSON.java
@@ -2,6 +2,7 @@ package org.openapitools.client;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import com.fasterxml.jackson.datatype.joda.*;
 
 import java.text.DateFormat;
@@ -21,6 +22,8 @@ public class JSON implements ContextResolver<ObjectMapper> {
     mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
     mapper.setDateFormat(new RFC3339DateFormat());
+    JsonNullableModule jnm = new JsonNullableModule();
+    mapper.registerModule(jnm);
     mapper.registerModule(new JodaModule());
   }
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import org.threeten.bp.OffsetDateTime;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.threeten.bp.OffsetDateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import org.threeten.bp.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/resttemplate-withXml/docs/UserApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/resttemplate-withXml/pom.xml
+++ b/samples/client/petstore/java/resttemplate-withXml/pom.xml
@@ -236,6 +236,11 @@
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
 
             <!-- XML processing: Jackson -->
             <dependency>
@@ -264,6 +269,7 @@
         <spring-web-version>4.3.9.RELEASE</spring-web-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <jackson-threetenbp-version>2.6.4</jackson-threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -649,6 +650,7 @@ public class ApiClient {
         messageConverters.add(new MappingJackson2HttpMessageConverter());
         XmlMapper xmlMapper = new XmlMapper();
         xmlMapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        xmlMapper.registerModule(new JsonNullableModule());
         messageConverters.add(new MappingJackson2XmlHttpMessageConverter(xmlMapper));
 
         RestTemplate restTemplate = new RestTemplate(messageConverters);
@@ -661,6 +663,7 @@ public class ApiClient {
                 module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
                 module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
                 mapper.registerModule(module);
+                mapper.registerModule(new JsonNullableModule());
             }
         }
         // This allows us to read the response more than once - Necessary for debugging.

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,13 +34,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesAnyType")
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -50,9 +51,15 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,13 +35,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesArray")
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -51,9 +52,15 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,13 +34,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesBoolean")
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -50,9 +51,15 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -35,89 +36,77 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesClass")
 public class AdditionalPropertiesClass {
-  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
   private Map<String, String> mapString = null;
 
-  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=BigDecimal
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
   private Map<String, BigDecimal> mapNumber = null;
 
-  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
   private Map<String, Integer> mapInteger = null;
 
-  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Boolean
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
   private Map<String, Boolean> mapBoolean = null;
 
-  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;Integer&gt;
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
   private Map<String, List<Integer>> mapArrayInteger = null;
 
-  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;Object&gt;
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
   private Map<String, List<Object>> mapArrayAnytype = null;
 
-  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Map&lt;String, String&gt;
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
   private Map<String, Map<String, String>> mapMapString = null;
 
-  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Map&lt;String, Object&gt;
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
-  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  @JacksonXmlProperty(localName = "anytype_1")
   @XmlElement(name = "anytype_1")
-  private Object anytype1 = null;
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  private Object anytype1;
 
-  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  @JacksonXmlProperty(localName = "anytype_2")
   @XmlElement(name = "anytype_2")
-  private Object anytype2 = null;
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  private Object anytype2;
 
-  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  @JacksonXmlProperty(localName = "anytype_3")
   @XmlElement(name = "anytype_3")
-  private Object anytype3 = null;
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -136,15 +125,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -163,15 +159,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -190,15 +193,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -217,15 +227,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -244,15 +261,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -271,15 +295,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -298,15 +329,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -325,15 +363,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -344,15 +389,23 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "anytype_1")
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -363,15 +416,23 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "anytype_2")
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -382,9 +443,15 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "anytype_3")
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,13 +34,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesInteger")
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -50,9 +51,15 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,13 +35,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesNumber")
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -51,9 +52,15 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,13 +34,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesObject")
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -50,9 +51,15 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,13 +34,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesString")
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -50,9 +51,15 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -39,19 +40,17 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Animal")
 public class Animal {
-  public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
-  @JacksonXmlProperty(localName = "className")
   @XmlElement(name = "className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
   private String className;
 
-  public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
-  @JacksonXmlProperty(localName = "color")
   @XmlElement(name = "color")
+  public static final String JSON_PROPERTY_COLOR = "color";
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -61,15 +60,23 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "className")
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -80,9 +87,15 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "color")
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,15 +35,16 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ArrayOfArrayOfNumberOnly")
 public class ArrayOfArrayOfNumberOnly {
-  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   // Is a container wrapped=false
   // items.name=arrayArrayNumber items.baseName=arrayArrayNumber items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;BigDecimal&gt;
   @XmlElement(name = "arrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -61,9 +63,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,15 +35,16 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ArrayOfNumberOnly")
 public class ArrayOfNumberOnly {
-  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   // Is a container wrapped=false
   // items.name=arrayNumber items.baseName=arrayNumber items.xmlName= items.xmlNamespace=
   // items.example= items.type=BigDecimal
   @XmlElement(name = "arrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -61,9 +63,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,31 +35,30 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ArrayTest")
 public class ArrayTest {
-  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   // Is a container wrapped=false
   // items.name=arrayOfString items.baseName=arrayOfString items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "arrayOfString")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
   private List<String> arrayOfString = null;
 
-  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   // Is a container wrapped=false
   // items.name=arrayArrayOfInteger items.baseName=arrayArrayOfInteger items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;Long&gt;
   @XmlElement(name = "arrayArrayOfInteger")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
   private List<List<Long>> arrayArrayOfInteger = null;
 
-  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   // Is a container wrapped=false
   // items.name=arrayArrayOfModel items.baseName=arrayArrayOfModel items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;ReadOnlyFirst&gt;
   @XmlElement(name = "arrayArrayOfModel")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -77,15 +77,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -104,15 +111,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -131,9 +145,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,43 +32,33 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Capitalization")
 public class Capitalization {
-  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
-  @JacksonXmlProperty(localName = "smallCamel")
   @XmlElement(name = "smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
   private String smallCamel;
 
-  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
-  @JacksonXmlProperty(localName = "CapitalCamel")
   @XmlElement(name = "CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
   private String capitalCamel;
 
-  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
-  @JacksonXmlProperty(localName = "small_Snake")
   @XmlElement(name = "small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
   private String smallSnake;
 
-  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
-  @JacksonXmlProperty(localName = "Capital_Snake")
   @XmlElement(name = "Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
   private String capitalSnake;
 
-  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
-  @JacksonXmlProperty(localName = "SCA_ETH_Flow_Points")
   @XmlElement(name = "SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
   private String scAETHFlowPoints;
 
-  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
-  @JacksonXmlProperty(localName = "ATT_NAME")
   @XmlElement(name = "ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -78,15 +69,23 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "smallCamel")
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -97,15 +96,23 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "CapitalCamel")
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -116,15 +123,23 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "small_Snake")
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -135,15 +150,23 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "Capital_Snake")
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -154,15 +177,23 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "SCA_ETH_Flow_Points")
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -173,9 +204,15 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "ATT_NAME")
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,13 +34,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Cat")
 public class Cat extends Animal {
-  public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
-  @JacksonXmlProperty(localName = "declawed")
   @XmlElement(name = "declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -50,9 +51,15 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "declawed")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,13 +32,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "CatAllOf")
 public class CatAllOf {
-  public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
-  @JacksonXmlProperty(localName = "declawed")
   @XmlElement(name = "declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -48,9 +49,15 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "declawed")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,19 +32,17 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Category")
 public class Category {
-  public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
-  @JacksonXmlProperty(localName = "id")
   @XmlElement(name = "id")
+  public static final String JSON_PROPERTY_ID = "id";
   private Long id;
 
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -54,15 +53,23 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "id")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -72,9 +79,15 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "name")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,13 +33,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ClassModel")
 public class ClassModel {
-  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
-  @JacksonXmlProperty(localName = "_class")
   @XmlElement(name = "_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -49,9 +50,15 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "_class")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,13 +32,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Client")
 public class Client {
-  public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
-  @JacksonXmlProperty(localName = "client")
   @XmlElement(name = "client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -48,9 +49,15 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "client")
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,13 +34,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Dog")
 public class Dog extends Animal {
-  public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
-  @JacksonXmlProperty(localName = "breed")
   @XmlElement(name = "breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -50,9 +51,15 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "breed")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,13 +32,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "DogAllOf")
 public class DogAllOf {
-  public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
-  @JacksonXmlProperty(localName = "breed")
   @XmlElement(name = "breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -48,9 +49,15 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "breed")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -68,10 +69,8 @@ public class EnumArrays {
     }
   }
 
-  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
-  @JacksonXmlProperty(localName = "just_symbol")
   @XmlElement(name = "just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
   private JustSymbolEnum justSymbol;
 
   /**
@@ -109,15 +108,16 @@ public class EnumArrays {
     }
   }
 
-  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   // Is a container wrapped=false
   // items.name=arrayEnum items.baseName=arrayEnum items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "arrayEnum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -128,15 +128,23 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "just_symbol")
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -155,9 +163,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -69,10 +70,8 @@ public class EnumTest {
     }
   }
 
-  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
-  @JacksonXmlProperty(localName = "enum_string")
   @XmlElement(name = "enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
   private EnumStringEnum enumString;
 
   /**
@@ -112,10 +111,8 @@ public class EnumTest {
     }
   }
 
-  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
-  @JacksonXmlProperty(localName = "enum_string_required")
   @XmlElement(name = "enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -153,10 +150,8 @@ public class EnumTest {
     }
   }
 
-  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
-  @JacksonXmlProperty(localName = "enum_integer")
   @XmlElement(name = "enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -194,19 +189,17 @@ public class EnumTest {
     }
   }
 
-  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
-  @JacksonXmlProperty(localName = "enum_number")
   @XmlElement(name = "enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
   private EnumNumberEnum enumNumber;
 
-  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
-  @JacksonXmlProperty(localName = "outerEnum")
   @XmlElement(name = "outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -217,15 +210,23 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "enum_string")
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -235,15 +236,23 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "enum_string_required")
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -254,15 +263,23 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "enum_integer")
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -273,15 +290,23 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "enum_number")
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -292,9 +317,15 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "outerEnum")
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,21 +34,20 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "FileSchemaTestClass")
 public class FileSchemaTestClass {
-  public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  @JacksonXmlProperty(localName = "file")
   @XmlElement(name = "file")
-  private java.io.File file = null;
+  public static final String JSON_PROPERTY_FILE = "file";
+  private java.io.File file;
 
-  public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   // Is a container wrapped=false
   // items.name=files items.baseName=files items.xmlName= items.xmlNamespace=
   // items.example= items.type=java.io.File
   @XmlElement(name = "files")
+  public static final String JSON_PROPERTY_FILES = "files";
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -58,15 +58,23 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "file")
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -85,9 +93,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -36,85 +37,61 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "FormatTest")
 public class FormatTest {
-  public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
-  @JacksonXmlProperty(localName = "integer")
   @XmlElement(name = "integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
   private Integer integer;
 
-  public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
-  @JacksonXmlProperty(localName = "int32")
   @XmlElement(name = "int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
   private Integer int32;
 
-  public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
-  @JacksonXmlProperty(localName = "int64")
   @XmlElement(name = "int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
   private Long int64;
 
-  public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
-  @JacksonXmlProperty(localName = "number")
   @XmlElement(name = "number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
   private BigDecimal number;
 
-  public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
-  @JacksonXmlProperty(localName = "float")
   @XmlElement(name = "float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
   private Float _float;
 
-  public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
-  @JacksonXmlProperty(localName = "double")
   @XmlElement(name = "double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
   private Double _double;
 
-  public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
-  @JacksonXmlProperty(localName = "string")
   @XmlElement(name = "string")
+  public static final String JSON_PROPERTY_STRING = "string";
   private String string;
 
-  public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
-  @JacksonXmlProperty(localName = "byte")
   @XmlElement(name = "byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
   private byte[] _byte;
 
-  public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
-  @JacksonXmlProperty(localName = "binary")
   @XmlElement(name = "binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
   private File binary;
 
-  public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
-  @JacksonXmlProperty(localName = "date")
   @XmlElement(name = "date")
+  public static final String JSON_PROPERTY_DATE = "date";
   private LocalDate date;
 
-  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
-  @JacksonXmlProperty(localName = "dateTime")
   @XmlElement(name = "dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
   private OffsetDateTime dateTime;
 
-  public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
-  @JacksonXmlProperty(localName = "uuid")
   @XmlElement(name = "uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
   private UUID uuid;
 
-  public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
-  @JacksonXmlProperty(localName = "password")
   @XmlElement(name = "password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -127,15 +104,23 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "integer")
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -148,15 +133,23 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "int32")
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -167,15 +160,23 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "int64")
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -187,15 +188,23 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "number")
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -208,15 +217,23 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "float")
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -229,15 +246,23 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "double")
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -248,15 +273,23 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "string")
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -266,15 +299,23 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "byte")
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -285,15 +326,23 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "binary")
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -303,15 +352,23 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "date")
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -322,15 +379,23 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "dateTime")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -341,15 +406,23 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "uuid")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -359,9 +432,15 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "password")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,17 +32,14 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "HasOnlyReadOnly")
 public class HasOnlyReadOnly {
-  public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
-  @JacksonXmlProperty(localName = "bar")
   @XmlElement(name = "bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
   private String bar;
 
-  public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
-  @JacksonXmlProperty(localName = "foo")
   @XmlElement(name = "foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
   private String foo;
+
 
    /**
    * Get bar
@@ -49,9 +47,16 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "bar")
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -59,9 +64,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "foo")
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,12 +35,11 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "MapTest")
 public class MapTest {
-  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Map&lt;String, String&gt;
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -77,31 +77,30 @@ public class MapTest {
     }
   }
 
-  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
   private Map<String, InnerEnum> mapOfEnumString = null;
 
-  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Boolean
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
   private Map<String, Boolean> directMap = null;
 
-  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Boolean
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -120,15 +119,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -147,15 +153,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -174,15 +187,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -201,9 +221,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -37,27 +38,24 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "MixedPropertiesAndAdditionalPropertiesClass")
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
-  @JacksonXmlProperty(localName = "uuid")
   @XmlElement(name = "uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
   private UUID uuid;
 
-  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
-  @JacksonXmlProperty(localName = "dateTime")
   @XmlElement(name = "dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
   private OffsetDateTime dateTime;
 
-  public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Animal
   @XmlElement(name = "inner")
+  public static final String JSON_PROPERTY_MAP = "map";
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -68,15 +66,23 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "uuid")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -87,15 +93,23 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "dateTime")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -114,9 +128,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,19 +33,17 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Name")
 public class Model200Response {
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private Integer name;
 
-  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
-  @JacksonXmlProperty(localName = "class")
   @XmlElement(name = "class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -55,15 +54,23 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -74,9 +81,15 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "class")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,25 +32,21 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ModelApiResponse")
 public class ModelApiResponse {
-  public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
-  @JacksonXmlProperty(localName = "code")
   @XmlElement(name = "code")
+  public static final String JSON_PROPERTY_CODE = "code";
   private Integer code;
 
-  public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
-  @JacksonXmlProperty(localName = "type")
   @XmlElement(name = "type")
+  public static final String JSON_PROPERTY_TYPE = "type";
   private String type;
 
-  public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
-  @JacksonXmlProperty(localName = "message")
   @XmlElement(name = "message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -60,15 +57,23 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "code")
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -79,15 +84,23 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "type")
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -98,9 +111,15 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "message")
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,13 +33,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Return")
 public class ModelReturn {
-  public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
-  @JacksonXmlProperty(localName = "return")
   @XmlElement(name = "return")
+  public static final String JSON_PROPERTY_RETURN = "return";
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -49,9 +50,15 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "return")
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,31 +33,25 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Name")
 public class Name {
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private Integer name;
 
-  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
-  @JacksonXmlProperty(localName = "snake_case")
   @XmlElement(name = "snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
   private Integer snakeCase;
 
-  public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
-  @JacksonXmlProperty(localName = "property")
   @XmlElement(name = "property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
   private String property;
 
-  public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
-  @JacksonXmlProperty(localName = "123Number")
   @XmlElement(name = "123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -66,13 +61,20 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "name")
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -80,11 +82,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "snake_case")
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -95,13 +105,20 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "property")
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -109,9 +126,15 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "123Number")
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,13 +33,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "NumberOnly")
 public class NumberOnly {
-  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
-  @JacksonXmlProperty(localName = "JustNumber")
   @XmlElement(name = "JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -49,9 +50,15 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "JustNumber")
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,28 +33,20 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Order")
 public class Order {
-  public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
-  @JacksonXmlProperty(localName = "id")
   @XmlElement(name = "id")
+  public static final String JSON_PROPERTY_ID = "id";
   private Long id;
 
-  public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
-  @JacksonXmlProperty(localName = "petId")
   @XmlElement(name = "petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
   private Long petId;
 
-  public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
-  @JacksonXmlProperty(localName = "quantity")
   @XmlElement(name = "quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
   private Integer quantity;
 
-  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
-  @JacksonXmlProperty(localName = "shipDate")
   @XmlElement(name = "shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
   private OffsetDateTime shipDate;
 
   /**
@@ -93,19 +86,17 @@ public class Order {
     }
   }
 
-  public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
-  @JacksonXmlProperty(localName = "status")
   @XmlElement(name = "status")
+  public static final String JSON_PROPERTY_STATUS = "status";
   private StatusEnum status;
 
-  public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
-  @JacksonXmlProperty(localName = "complete")
   @XmlElement(name = "complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -116,15 +107,23 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "id")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -135,15 +134,23 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "petId")
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -154,15 +161,23 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "quantity")
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -173,15 +188,23 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "shipDate")
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -192,15 +215,23 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "status")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -211,9 +242,15 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "complete")
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,25 +33,21 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "OuterComposite")
 public class OuterComposite {
-  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
-  @JacksonXmlProperty(localName = "my_number")
   @XmlElement(name = "my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
   private BigDecimal myNumber;
 
-  public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
-  @JacksonXmlProperty(localName = "my_string")
   @XmlElement(name = "my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
   private String myString;
 
-  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
-  @JacksonXmlProperty(localName = "my_boolean")
   @XmlElement(name = "my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -61,15 +58,23 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "my_number")
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -80,15 +85,23 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "my_string")
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -99,9 +112,15 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "my_boolean")
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -35,44 +36,32 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Pet")
 public class Pet {
-  public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
-  @JacksonXmlProperty(localName = "id")
   @XmlElement(name = "id")
+  public static final String JSON_PROPERTY_ID = "id";
   private Long id;
 
-  public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  @JacksonXmlProperty(localName = "category")
   @XmlElement(name = "category")
-  private Category category = null;
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  private Category category;
 
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private String name;
 
-  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
-  // items.xmlName=
-  @JacksonXmlElementWrapper(useWrapping = true, localName = "photoUrls")
   // Is a container wrapped=true
   // items.name=photoUrls items.baseName=photoUrls items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "photoUrls")
   @XmlElementWrapper(name = "photoUrl")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
   private List<String> photoUrls = new ArrayList<String>();
 
-  public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
-  // items.xmlName=
-  @JacksonXmlElementWrapper(useWrapping = true, localName = "tags")
   // Is a container wrapped=true
   // items.name=tags items.baseName=tags items.xmlName= items.xmlNamespace=
   // items.example= items.type=Tag
   @XmlElement(name = "tags")
   @XmlElementWrapper(name = "tag")
+  public static final String JSON_PROPERTY_TAGS = "tags";
   private List<Tag> tags = null;
 
   /**
@@ -112,13 +101,13 @@ public class Pet {
     }
   }
 
-  public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
-  @JacksonXmlProperty(localName = "status")
   @XmlElement(name = "status")
+  public static final String JSON_PROPERTY_STATUS = "status";
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -129,15 +118,23 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "id")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -148,15 +145,23 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "category")
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -166,15 +171,23 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "name")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -189,15 +202,24 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "photoUrls")
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -216,15 +238,24 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "tags")
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -235,9 +266,15 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "status")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,17 +32,14 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ReadOnlyFirst")
 public class ReadOnlyFirst {
-  public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
-  @JacksonXmlProperty(localName = "bar")
   @XmlElement(name = "bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
   private String bar;
 
-  public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
-  @JacksonXmlProperty(localName = "baz")
   @XmlElement(name = "baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
   private String baz;
+
 
    /**
    * Get bar
@@ -49,11 +47,19 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "bar")
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -64,9 +70,15 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "baz")
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,13 +32,13 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "$special[model.name]")
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "$special[property.name]")
   @XmlElement(name = "$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -48,9 +49,15 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "$special[property.name]")
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,19 +32,17 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Tag")
 public class Tag {
-  public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
-  @JacksonXmlProperty(localName = "id")
   @XmlElement(name = "id")
+  public static final String JSON_PROPERTY_ID = "id";
   private Long id;
 
-  public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
-  @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
+  public static final String JSON_PROPERTY_NAME = "name";
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -54,15 +53,23 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "id")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -73,9 +80,15 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "name")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,39 +35,32 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "TypeHolderDefault")
 public class TypeHolderDefault {
-  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
-  @JacksonXmlProperty(localName = "string_item")
   @XmlElement(name = "string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
   private String stringItem = "what";
 
-  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
-  @JacksonXmlProperty(localName = "number_item")
   @XmlElement(name = "number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
   private BigDecimal numberItem;
 
-  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
-  @JacksonXmlProperty(localName = "integer_item")
   @XmlElement(name = "integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
   private Integer integerItem;
 
-  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
-  @JacksonXmlProperty(localName = "bool_item")
   @XmlElement(name = "bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
   private Boolean boolItem = true;
 
-  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   // Is a container wrapped=false
   // items.name=arrayItem items.baseName=arrayItem items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "arrayItem")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -76,15 +70,23 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "string_item")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -94,15 +96,23 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "number_item")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -112,15 +122,23 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "integer_item")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -130,15 +148,23 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "bool_item")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -153,9 +179,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,39 +35,32 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "TypeHolderExample")
 public class TypeHolderExample {
-  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
-  @JacksonXmlProperty(localName = "string_item")
   @XmlElement(name = "string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
   private String stringItem;
 
-  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
-  @JacksonXmlProperty(localName = "number_item")
   @XmlElement(name = "number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
   private BigDecimal numberItem;
 
-  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
-  @JacksonXmlProperty(localName = "integer_item")
   @XmlElement(name = "integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
   private Integer integerItem;
 
-  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
-  @JacksonXmlProperty(localName = "bool_item")
   @XmlElement(name = "bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
   private Boolean boolItem;
 
-  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   // Is a container wrapped=false
   // items.name=arrayItem items.baseName=arrayItem items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "arrayItem")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -76,15 +70,23 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "string_item")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -94,15 +96,23 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "number_item")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -112,15 +122,23 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "integer_item")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -130,15 +148,23 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JacksonXmlProperty(localName = "bool_item")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -153,9 +179,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,55 +32,41 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "User")
 public class User {
-  public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
-  @JacksonXmlProperty(localName = "id")
   @XmlElement(name = "id")
+  public static final String JSON_PROPERTY_ID = "id";
   private Long id;
 
-  public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
-  @JacksonXmlProperty(localName = "username")
   @XmlElement(name = "username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
   private String username;
 
-  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
-  @JacksonXmlProperty(localName = "firstName")
   @XmlElement(name = "firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
   private String firstName;
 
-  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
-  @JacksonXmlProperty(localName = "lastName")
   @XmlElement(name = "lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
   private String lastName;
 
-  public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
-  @JacksonXmlProperty(localName = "email")
   @XmlElement(name = "email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
   private String email;
 
-  public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
-  @JacksonXmlProperty(localName = "password")
   @XmlElement(name = "password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
 
-  public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
-  @JacksonXmlProperty(localName = "phone")
   @XmlElement(name = "phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
   private String phone;
 
-  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
-  @JacksonXmlProperty(localName = "userStatus")
   @XmlElement(name = "userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -90,15 +77,23 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "id")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -109,15 +104,23 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "username")
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -128,15 +131,23 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "firstName")
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -147,15 +158,23 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "lastName")
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -166,15 +185,23 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "email")
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -185,15 +212,23 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "password")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -204,15 +239,23 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "phone")
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -223,9 +266,15 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "userStatus")
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,214 +35,157 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(namespace="http://a.com/schema", localName = "XmlItem")
 public class XmlItem {
-  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
-  @JacksonXmlProperty(isAttribute = true, localName = "attribute_string")
   @XmlAttribute(name = "attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
   private String attributeString;
 
-  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
-  @JacksonXmlProperty(isAttribute = true, localName = "attribute_number")
   @XmlAttribute(name = "attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
   private BigDecimal attributeNumber;
 
-  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
-  @JacksonXmlProperty(isAttribute = true, localName = "attribute_integer")
   @XmlAttribute(name = "attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
   private Integer attributeInteger;
 
-  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
-  @JacksonXmlProperty(isAttribute = true, localName = "attribute_boolean")
   @XmlAttribute(name = "attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
   private Boolean attributeBoolean;
 
-  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
-  // items.xmlName=
-  @JacksonXmlElementWrapper(useWrapping = true, localName = "wrappedArray")
   // Is a container wrapped=true
   // items.name=wrappedArray items.baseName=wrappedArray items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "wrappedArray")
   @XmlElementWrapper(name = "wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
   private List<Integer> wrappedArray = null;
 
-  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
-  @JacksonXmlProperty(localName = "xml_name_string")
   @XmlElement(name = "xml_name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
   private String nameString;
 
-  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
-  @JacksonXmlProperty(localName = "xml_name_number")
   @XmlElement(name = "xml_name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
   private BigDecimal nameNumber;
 
-  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
-  @JacksonXmlProperty(localName = "xml_name_integer")
   @XmlElement(name = "xml_name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
   private Integer nameInteger;
 
-  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
-  @JacksonXmlProperty(localName = "xml_name_boolean")
   @XmlElement(name = "xml_name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
   private Boolean nameBoolean;
 
-  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   // Is a container wrapped=false
   // items.name=nameArray items.baseName=nameArray items.xmlName=xml_name_array_item items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "xml_name_array_item")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
   private List<Integer> nameArray = null;
 
-  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
-  // items.xmlName=xml_name_wrapped_array_item
-  @JacksonXmlElementWrapper(useWrapping = true, localName = "xml_name_wrapped_array_item")
   // Is a container wrapped=true
   // items.name=nameWrappedArray items.baseName=nameWrappedArray items.xmlName=xml_name_wrapped_array_item items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "xml_name_wrapped_array_item")
   @XmlElementWrapper(name = "xml_name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
   private List<Integer> nameWrappedArray = null;
 
-  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
-  @JacksonXmlProperty(localName = "prefix_string")
   @XmlElement(name = "prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
   private String prefixString;
 
-  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
-  @JacksonXmlProperty(localName = "prefix_number")
   @XmlElement(name = "prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
   private BigDecimal prefixNumber;
 
-  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
-  @JacksonXmlProperty(localName = "prefix_integer")
   @XmlElement(name = "prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
   private Integer prefixInteger;
 
-  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
-  @JacksonXmlProperty(localName = "prefix_boolean")
   @XmlElement(name = "prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
   private Boolean prefixBoolean;
 
-  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   // Is a container wrapped=false
   // items.name=prefixArray items.baseName=prefixArray items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "prefixArray")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
   private List<Integer> prefixArray = null;
 
-  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
-  // items.xmlName=
-  @JacksonXmlElementWrapper(useWrapping = true, localName = "prefixWrappedArray")
   // Is a container wrapped=true
   // items.name=prefixWrappedArray items.baseName=prefixWrappedArray items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "prefixWrappedArray")
   @XmlElementWrapper(name = "prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
   private List<Integer> prefixWrappedArray = null;
 
-  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
-  @JacksonXmlProperty(namespace="http://a.com/schema", localName = "namespace_string")
   @XmlElement(namespace="http://a.com/schema", name = "namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
   private String namespaceString;
 
-  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
-  @JacksonXmlProperty(namespace="http://b.com/schema", localName = "namespace_number")
   @XmlElement(namespace="http://b.com/schema", name = "namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
   private BigDecimal namespaceNumber;
 
-  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
-  @JacksonXmlProperty(namespace="http://c.com/schema", localName = "namespace_integer")
   @XmlElement(namespace="http://c.com/schema", name = "namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
   private Integer namespaceInteger;
 
-  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
-  @JacksonXmlProperty(namespace="http://d.com/schema", localName = "namespace_boolean")
   @XmlElement(namespace="http://d.com/schema", name = "namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
   private Boolean namespaceBoolean;
 
-  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   // Is a container wrapped=false
   // items.name=namespaceArray items.baseName=namespaceArray items.xmlName= items.xmlNamespace=http://e.com/schema
   // items.example= items.type=Integer
   @XmlElement(namespace="http://e.com/schema", name = "namespaceArray")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
   private List<Integer> namespaceArray = null;
 
-  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
-  // items.xmlName=
-  @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "namespaceWrappedArray")
   // Is a container wrapped=true
   // items.name=namespaceWrappedArray items.baseName=namespaceWrappedArray items.xmlName= items.xmlNamespace=http://g.com/schema
   // items.example= items.type=Integer
   @XmlElement(namespace="http://g.com/schema", name = "namespaceWrappedArray")
   @XmlElementWrapper(namespace="http://f.com/schema", name = "namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
   private List<Integer> namespaceWrappedArray = null;
 
-  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
-  @JacksonXmlProperty(namespace="http://a.com/schema", localName = "prefix_ns_string")
   @XmlElement(namespace="http://a.com/schema", name = "prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
   private String prefixNsString;
 
-  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
-  @JacksonXmlProperty(namespace="http://b.com/schema", localName = "prefix_ns_number")
   @XmlElement(namespace="http://b.com/schema", name = "prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
   private BigDecimal prefixNsNumber;
 
-  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
-  @JacksonXmlProperty(namespace="http://c.com/schema", localName = "prefix_ns_integer")
   @XmlElement(namespace="http://c.com/schema", name = "prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
   private Integer prefixNsInteger;
 
-  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
-  @JacksonXmlProperty(namespace="http://d.com/schema", localName = "prefix_ns_boolean")
   @XmlElement(namespace="http://d.com/schema", name = "prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
   private Boolean prefixNsBoolean;
 
-  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   // Is a container wrapped=false
   // items.name=prefixNsArray items.baseName=prefixNsArray items.xmlName= items.xmlNamespace=http://e.com/schema
   // items.example= items.type=Integer
   @XmlElement(namespace="http://e.com/schema", name = "prefixNsArray")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
   private List<Integer> prefixNsArray = null;
 
-  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
-  // items.xmlName=
-  @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "prefixNsWrappedArray")
   // Is a container wrapped=true
   // items.name=prefixNsWrappedArray items.baseName=prefixNsWrappedArray items.xmlName= items.xmlNamespace=http://g.com/schema
   // items.example= items.type=Integer
   @XmlElement(namespace="http://g.com/schema", name = "prefixNsWrappedArray")
   @XmlElementWrapper(namespace="http://f.com/schema", name = "prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -252,15 +196,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(isAttribute = true, localName = "attribute_string")
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -271,15 +223,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(isAttribute = true, localName = "attribute_number")
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -290,15 +250,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(isAttribute = true, localName = "attribute_integer")
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -309,15 +277,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(isAttribute = true, localName = "attribute_boolean")
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -336,15 +312,24 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "wrappedArray")
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -355,15 +340,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "xml_name_string")
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -374,15 +367,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "xml_name_number")
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -393,15 +394,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "xml_name_integer")
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -412,15 +421,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "xml_name_boolean")
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -439,15 +456,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -466,15 +490,24 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=xml_name_wrapped_array_item
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "xml_name_wrapped_array_item")
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -485,15 +518,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "prefix_string")
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -504,15 +545,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "prefix_number")
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -523,15 +572,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "prefix_integer")
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -542,15 +599,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "prefix_boolean")
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -569,15 +634,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -596,15 +668,24 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, localName = "prefixWrappedArray")
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -615,15 +696,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://a.com/schema", localName = "namespace_string")
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -634,15 +723,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://b.com/schema", localName = "namespace_number")
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -653,15 +750,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://c.com/schema", localName = "namespace_integer")
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -672,15 +777,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://d.com/schema", localName = "namespace_boolean")
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -699,15 +812,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -726,15 +846,24 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "namespaceWrappedArray")
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -745,15 +874,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://a.com/schema", localName = "prefix_ns_string")
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -764,15 +901,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://b.com/schema", localName = "prefix_ns_number")
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -783,15 +928,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://c.com/schema", localName = "prefix_ns_integer")
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -802,15 +955,23 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(namespace="http://d.com/schema", localName = "prefix_ns_boolean")
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -829,15 +990,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -856,9 +1024,16 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  // items.xmlName=
+  @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "prefixNsWrappedArray")
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/resttemplate/docs/UserApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/resttemplate/pom.xml
+++ b/samples/client/petstore/java/resttemplate/pom.xml
@@ -236,6 +236,11 @@
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
             <dependency>
                 <groupId>com.github.joschi.jackson</groupId>
                 <artifactId>jackson-datatype-threetenbp</artifactId>
@@ -256,6 +261,7 @@
         <spring-web-version>4.3.9.RELEASE</spring-web-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <jackson-threetenbp-version>2.6.4</jackson-threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -649,6 +650,7 @@ public class ApiClient {
                 module.addDeserializer(OffsetDateTime.class, CustomInstantDeserializer.OFFSET_DATE_TIME);
                 module.addDeserializer(ZonedDateTime.class, CustomInstantDeserializer.ZONED_DATE_TIME);
                 mapper.registerModule(module);
+                mapper.registerModule(new JsonNullableModule());
             }
         }
         // This allows us to read the response more than once - Necessary for debugging.

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import org.threeten.bp.OffsetDateTime;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.threeten.bp.OffsetDateTime;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import org.threeten.bp.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -67,17 +67,19 @@ public class AdditionalPropertiesClass {
 
   public static final String SERIALIZED_NAME_ANYTYPE1 = "anytype_1";
   @SerializedName(SERIALIZED_NAME_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String SERIALIZED_NAME_ANYTYPE2 = "anytype_2";
   @SerializedName(SERIALIZED_NAME_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String SERIALIZED_NAME_ANYTYPE3 = "anytype_3";
   @SerializedName(SERIALIZED_NAME_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -96,15 +98,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -123,15 +130,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -150,15 +162,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -177,15 +194,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -204,15 +226,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -231,15 +258,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -258,15 +290,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -285,15 +322,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -304,15 +346,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -323,15 +370,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -342,9 +394,12 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Animal.java
@@ -41,7 +41,9 @@ public class Animal {
   public Animal() {
     this.className = this.getClass().getSimpleName();
   }
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -51,15 +53,20 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -70,9 +77,12 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -44,7 +44,9 @@ public class ArrayTest {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -63,15 +65,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -90,15 +97,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -117,9 +129,12 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,7 +53,9 @@ public class Capitalization {
   @SerializedName(SERIALIZED_NAME_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -64,15 +66,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -83,15 +90,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -102,15 +114,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -121,15 +138,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -140,15 +162,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -159,9 +186,12 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Cat.java
@@ -35,7 +35,9 @@ public class Cat extends Animal {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -33,7 +33,9 @@ public class CatAllOf {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -44,9 +46,12 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Category.java
@@ -37,7 +37,9 @@ public class Category {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +73,12 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -34,7 +34,9 @@ public class ClassModel {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -45,9 +47,12 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Client.java
@@ -33,7 +33,9 @@ public class Client {
   @SerializedName(SERIALIZED_NAME_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -44,9 +46,12 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Dog.java
@@ -35,7 +35,9 @@ public class Dog extends Animal {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -33,7 +33,9 @@ public class DogAllOf {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -44,9 +46,12 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,7 +133,9 @@ public class EnumArrays {
   @SerializedName(SERIALIZED_NAME_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -144,15 +146,20 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -171,9 +178,12 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -242,7 +242,9 @@ public class EnumTest {
   @SerializedName(SERIALIZED_NAME_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -253,15 +255,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -271,15 +278,20 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -290,15 +302,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -309,15 +326,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -328,9 +350,12 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -33,13 +33,15 @@ import java.util.List;
 public class FileSchemaTestClass {
   public static final String SERIALIZED_NAME_FILE = "file";
   @SerializedName(SERIALIZED_NAME_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String SERIALIZED_NAME_FILES = "files";
   @SerializedName(SERIALIZED_NAME_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -50,15 +52,20 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -77,9 +84,12 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,7 +86,9 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -99,15 +101,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -120,15 +127,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -139,15 +151,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -159,15 +176,20 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -180,15 +202,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -201,15 +228,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -220,15 +252,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -238,15 +275,20 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -257,15 +299,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -275,15 +322,20 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(DateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -294,15 +346,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public DateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(DateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -313,15 +370,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -331,9 +393,12 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -37,15 +37,20 @@ public class HasOnlyReadOnly {
   @SerializedName(SERIALIZED_NAME_FOO)
   private String foo;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -53,9 +58,12 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MapTest.java
@@ -95,7 +95,9 @@ public class MapTest {
   @SerializedName(SERIALIZED_NAME_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -114,15 +116,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -141,15 +148,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -168,15 +180,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -195,9 +212,12 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -47,7 +47,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @SerializedName(SERIALIZED_NAME_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -58,15 +60,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(DateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -77,15 +84,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public DateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(DateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -104,9 +116,12 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -38,7 +38,9 @@ public class Model200Response {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -49,15 +51,20 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -68,9 +75,12 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -41,7 +41,9 @@ public class ModelApiResponse {
   @SerializedName(SERIALIZED_NAME_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -52,15 +54,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -71,15 +78,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -90,9 +102,12 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -34,7 +34,9 @@ public class ModelReturn {
   @SerializedName(SERIALIZED_NAME_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -45,9 +47,12 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Name.java
@@ -46,7 +46,9 @@ public class Name {
   @SerializedName(SERIALIZED_NAME_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -56,13 +58,17 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -70,11 +76,16 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -85,13 +96,17 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -99,9 +114,12 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -34,7 +34,9 @@ public class NumberOnly {
   @SerializedName(SERIALIZED_NAME_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -45,9 +47,12 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Order.java
@@ -103,7 +103,9 @@ public class Order {
   @SerializedName(SERIALIZED_NAME_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -114,15 +116,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -133,15 +140,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -152,15 +164,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(DateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -171,15 +188,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public DateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(DateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -190,15 +212,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -209,9 +236,12 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -42,7 +42,9 @@ public class OuterComposite {
   @SerializedName(SERIALIZED_NAME_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -53,15 +55,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -72,15 +79,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -91,9 +103,12 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Pet.java
@@ -39,7 +39,7 @@ public class Pet {
 
   public static final String SERIALIZED_NAME_CATEGORY = "category";
   @SerializedName(SERIALIZED_NAME_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -106,7 +106,9 @@ public class Pet {
   @SerializedName(SERIALIZED_NAME_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -117,15 +119,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -136,15 +143,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -154,15 +166,20 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -177,15 +194,20 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -204,15 +226,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -223,9 +250,12 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -37,17 +37,23 @@ public class ReadOnlyFirst {
   @SerializedName(SERIALIZED_NAME_BAZ)
   private String baz;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -58,9 +64,12 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -33,7 +33,9 @@ public class SpecialModelName {
   @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -44,9 +46,12 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Tag.java
@@ -37,7 +37,9 @@ public class Tag {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -67,9 +74,12 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -52,7 +52,9 @@ public class TypeHolderDefault {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -52,7 +52,9 @@ public class TypeHolderExample {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/User.java
@@ -61,7 +61,9 @@ public class User {
   @SerializedName(SERIALIZED_NAME_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -72,15 +74,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -91,15 +98,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -110,15 +122,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -129,15 +146,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -148,15 +170,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -167,15 +194,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -186,15 +218,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -205,9 +242,12 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -148,7 +148,9 @@ public class XmlItem {
   @SerializedName(SERIALIZED_NAME_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -159,15 +161,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -178,15 +185,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -197,15 +209,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -216,15 +233,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -243,15 +265,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -262,15 +289,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -281,15 +313,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -300,15 +337,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -319,15 +361,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -346,15 +393,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -373,15 +425,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -392,15 +449,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -411,15 +473,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -430,15 +497,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -449,15 +521,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -476,15 +553,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -503,15 +585,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -522,15 +609,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -541,15 +633,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -560,15 +657,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -579,15 +681,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -606,15 +713,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -633,15 +745,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -652,15 +769,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -671,15 +793,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -690,15 +817,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -709,15 +841,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -736,15 +873,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -763,9 +905,12 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2-play24/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/retrofit2-play24/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play24/pom.xml
@@ -259,6 +259,11 @@
                 <artifactId>play-java-ws_2.11</artifactId>
                 <version>${play-version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.openapitools</groupId>
+                <artifactId>jackson-databind-nullable</artifactId>
+                <version>${jackson-databind-nullable-version}</version>
+            </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -277,6 +282,7 @@
         <jackson-databind-version>2.9.9</jackson-databind-version>
         <jackson-version>2.6.6</jackson-version>
         <play-version>2.4.11</play-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <retrofit-version>2.5.0</retrofit-version>
         <oltu-version>1.0.1</oltu-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/ApiClient.java
@@ -8,6 +8,8 @@ import java.util.*;
 import retrofit2.Retrofit;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import play.libs.Json;
 import play.libs.ws.WSClient;
@@ -68,10 +70,14 @@ public class ApiClient {
             auth.applyToParams(extraQueryParams, extraHeaders);
         }
 
+        ObjectMapper mapper = Json.mapper();
+        JsonNullableModule jnm = new JsonNullableModule();
+        mapper.registerModule(jnm);
+
         return new Retrofit.Builder()
                        .baseUrl(basePath)
                        .addConverterFactory(ScalarsConverterFactory.create())
-                       .addConverterFactory(JacksonConverterFactory.create(Json.mapper()))
+                       .addConverterFactory(JacksonConverterFactory.create(mapper))
                        .callFactory(new Play24CallFactory(wsClient, extraHeaders, extraQueryParams))
                        .addCallAdapterFactory(new Play24CallAdapterFactory())
                        .build()

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,50 +34,41 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -95,15 +87,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -123,15 +122,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -150,15 +156,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -177,15 +190,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -205,15 +225,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -233,15 +260,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -261,15 +295,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -289,15 +330,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -309,15 +357,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -329,15 +384,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -349,9 +411,14 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -37,14 +38,14 @@ import javax.validation.Valid;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -55,15 +56,22 @@ public class Animal {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -74,9 +82,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -55,9 +57,14 @@ public class ArrayOfArrayOfNumberOnly {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -55,9 +57,14 @@ public class ArrayOfNumberOnly {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,18 +33,17 @@ import javax.validation.Valid;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -62,15 +62,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -90,15 +97,22 @@ public class ArrayTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -118,9 +132,14 @@ public class ArrayTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,30 +30,26 @@ import javax.validation.Valid;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -63,15 +60,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -82,15 +86,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -101,15 +112,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -120,15 +138,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -139,15 +164,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -158,9 +190,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -45,9 +47,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import javax.validation.Valid;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -47,15 +48,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +74,14 @@ public class Category {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import javax.validation.Valid;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -44,9 +46,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -43,9 +45,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -45,9 +47,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -66,7 +67,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -105,10 +105,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -119,15 +120,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -146,9 +154,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -67,7 +68,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -108,7 +108,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -147,7 +146,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -186,14 +184,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -204,15 +202,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -223,15 +228,22 @@ public class EnumTest {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -242,15 +254,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -261,15 +280,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -281,9 +307,14 @@ public class EnumTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,14 +32,14 @@ import javax.validation.Valid;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -50,15 +51,22 @@ public class FileSchemaTestClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -78,9 +86,14 @@ public class FileSchemaTestClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,58 +35,47 @@ import javax.validation.Valid;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -98,15 +88,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @Min(10) @Max(100)  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -119,15 +116,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @Min(20) @Max(200)  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -138,15 +142,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -160,15 +171,22 @@ public class FormatTest {
   @NotNull
   @Valid
  @DecimalMin("32.1") @DecimalMax("543.2")  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -181,15 +199,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @DecimalMin("54.3") @DecimalMax("987.6")  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -202,15 +227,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @DecimalMin("67.8") @DecimalMax("123.4")  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -221,15 +253,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @Pattern(regexp="/[a-z]/i")  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -240,15 +279,22 @@ public class FormatTest {
   **/
   @NotNull
  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -260,15 +306,22 @@ public class FormatTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -280,15 +333,22 @@ public class FormatTest {
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -300,15 +360,22 @@ public class FormatTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -320,15 +387,22 @@ public class FormatTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -339,9 +413,14 @@ public class FormatTest {
   **/
   @NotNull
  @Size(min=10,max=64)  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,12 +30,11 @@ import javax.validation.Valid;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -42,9 +42,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -52,9 +58,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,7 +33,6 @@ import javax.validation.Valid;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -71,18 +71,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -102,15 +101,22 @@ public class MapTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -129,15 +135,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -156,15 +169,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -183,9 +203,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -35,18 +36,17 @@ import javax.validation.Valid;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -58,15 +58,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -78,15 +85,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -106,9 +120,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,14 +31,14 @@ import javax.validation.Valid;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -48,15 +49,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -67,9 +75,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,18 +30,17 @@ import javax.validation.Valid;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -51,15 +51,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -70,15 +77,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -89,9 +103,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import javax.validation.Valid;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -44,9 +46,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,22 +31,20 @@ import javax.validation.Valid;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -56,13 +55,19 @@ public class Name {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -70,11 +75,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -85,13 +97,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -99,9 +117,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import javax.validation.Valid;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -45,9 +47,14 @@ public class NumberOnly {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,19 +31,15 @@ import javax.validation.Valid;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -83,14 +80,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -101,15 +98,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -120,15 +124,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -139,15 +150,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -159,15 +177,22 @@ public class Order {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -178,15 +203,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -197,9 +229,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import javax.validation.Valid;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -53,15 +53,22 @@ public class OuterComposite {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -72,15 +79,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -91,9 +105,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,23 +34,18 @@ import javax.validation.Valid;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -90,10 +86,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -104,15 +101,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -124,15 +128,22 @@ public class Pet {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -143,15 +154,22 @@ public class Pet {
   **/
   @NotNull
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -167,15 +185,22 @@ public class Pet {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -195,15 +220,22 @@ public class Pet {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -214,9 +246,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,12 +30,11 @@ import javax.validation.Valid;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -42,11 +42,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -57,9 +64,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -43,9 +45,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import javax.validation.Valid;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -47,15 +48,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +74,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,26 +33,23 @@ import javax.validation.Valid;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +60,22 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -82,15 +87,22 @@ public class TypeHolderDefault {
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -101,15 +113,22 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -120,15 +139,22 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -144,9 +170,14 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,26 +33,23 @@ import javax.validation.Valid;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +60,22 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -82,15 +87,22 @@ public class TypeHolderExample {
   @NotNull
   @Valid
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -101,15 +113,22 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -120,15 +139,22 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -144,9 +170,14 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,38 +30,32 @@ import javax.validation.Valid;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -71,15 +66,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -90,15 +92,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -109,15 +118,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -128,15 +144,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -147,15 +170,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -166,15 +196,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -185,15 +222,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -204,9 +248,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,122 +33,95 @@ import javax.validation.Valid;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -158,15 +132,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -178,15 +159,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -197,15 +185,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -216,15 +211,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -243,15 +245,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -262,15 +271,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -282,15 +298,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -301,15 +324,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -320,15 +350,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -347,15 +384,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -374,15 +418,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -393,15 +444,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -413,15 +471,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -432,15 +497,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -451,15 +523,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -478,15 +557,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -505,15 +591,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -524,15 +617,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -544,15 +644,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -563,15 +670,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -582,15 +696,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -609,15 +730,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -636,15 +764,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -655,15 +790,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -675,15 +817,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -694,15 +843,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -713,15 +869,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -740,15 +903,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -767,9 +937,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2-play25/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/retrofit2-play25/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play25/pom.xml
@@ -264,6 +264,11 @@
                 <artifactId>play-java-ws_2.11</artifactId>
                 <version>${play-version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.openapitools</groupId>
+                <artifactId>jackson-databind-nullable</artifactId>
+                <version>${jackson-databind-nullable-version}</version>
+            </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -282,6 +287,7 @@
         <jackson-databind-version>2.9.9</jackson-databind-version>
         <jackson-version>2.9.9</jackson-version>
         <play-version>2.5.15</play-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <retrofit-version>2.5.0</retrofit-version>
         <threetenbp-version>1.3.8</threetenbp-version>
         <oltu-version>1.0.1</oltu-version>

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/ApiClient.java
@@ -8,6 +8,8 @@ import java.util.*;
 import retrofit2.Retrofit;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import play.libs.Json;
 import play.libs.ws.WSClient;
@@ -68,10 +70,14 @@ public class ApiClient {
             auth.applyToParams(extraQueryParams, extraHeaders);
         }
 
+        ObjectMapper mapper = Json.mapper();
+        JsonNullableModule jnm = new JsonNullableModule();
+        mapper.registerModule(jnm);
+
         return new Retrofit.Builder()
                        .baseUrl(basePath)
                        .addConverterFactory(ScalarsConverterFactory.create())
-                       .addConverterFactory(JacksonConverterFactory.create(Json.mapper()))
+                       .addConverterFactory(JacksonConverterFactory.create(mapper))
                        .callFactory(new Play25CallFactory(wsClient, extraHeaders, extraQueryParams))
                        .addCallAdapterFactory(new Play25CallAdapterFactory())
                        .build()

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,50 +34,41 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -95,15 +87,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -123,15 +122,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -150,15 +156,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -177,15 +190,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -205,15 +225,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -233,15 +260,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -261,15 +295,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -289,15 +330,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -309,15 +357,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -329,15 +384,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -349,9 +411,14 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -37,14 +38,14 @@ import javax.validation.Valid;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -55,15 +56,22 @@ public class Animal {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -74,9 +82,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -55,9 +57,14 @@ public class ArrayOfArrayOfNumberOnly {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -55,9 +57,14 @@ public class ArrayOfNumberOnly {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,18 +33,17 @@ import javax.validation.Valid;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -62,15 +62,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -90,15 +97,22 @@ public class ArrayTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -118,9 +132,14 @@ public class ArrayTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,30 +30,26 @@ import javax.validation.Valid;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -63,15 +60,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -82,15 +86,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -101,15 +112,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -120,15 +138,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -139,15 +164,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -158,9 +190,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -45,9 +47,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import javax.validation.Valid;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -47,15 +48,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +74,14 @@ public class Category {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import javax.validation.Valid;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -44,9 +46,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -43,9 +45,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -45,9 +47,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -66,7 +67,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -105,10 +105,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -119,15 +120,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -146,9 +154,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -67,7 +68,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -108,7 +108,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -147,7 +146,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -186,14 +184,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -204,15 +202,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -223,15 +228,22 @@ public class EnumTest {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -242,15 +254,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -261,15 +280,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -281,9 +307,14 @@ public class EnumTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,14 +32,14 @@ import javax.validation.Valid;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -50,15 +51,22 @@ public class FileSchemaTestClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -78,9 +86,14 @@ public class FileSchemaTestClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,58 +35,47 @@ import javax.validation.Valid;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -98,15 +88,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @Min(10) @Max(100)  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -119,15 +116,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @Min(20) @Max(200)  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -138,15 +142,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -160,15 +171,22 @@ public class FormatTest {
   @NotNull
   @Valid
  @DecimalMin("32.1") @DecimalMax("543.2")  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -181,15 +199,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @DecimalMin("54.3") @DecimalMax("987.6")  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -202,15 +227,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @DecimalMin("67.8") @DecimalMax("123.4")  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -221,15 +253,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @Pattern(regexp="/[a-z]/i")  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -240,15 +279,22 @@ public class FormatTest {
   **/
   @NotNull
  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -260,15 +306,22 @@ public class FormatTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -280,15 +333,22 @@ public class FormatTest {
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -300,15 +360,22 @@ public class FormatTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -320,15 +387,22 @@ public class FormatTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -339,9 +413,14 @@ public class FormatTest {
   **/
   @NotNull
  @Size(min=10,max=64)  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,12 +30,11 @@ import javax.validation.Valid;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -42,9 +42,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -52,9 +58,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,7 +33,6 @@ import javax.validation.Valid;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -71,18 +71,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -102,15 +101,22 @@ public class MapTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -129,15 +135,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -156,15 +169,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -183,9 +203,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -35,18 +36,17 @@ import javax.validation.Valid;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -58,15 +58,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -78,15 +85,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -106,9 +120,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,14 +31,14 @@ import javax.validation.Valid;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -48,15 +49,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -67,9 +75,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,18 +30,17 @@ import javax.validation.Valid;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -51,15 +51,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -70,15 +77,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -89,9 +103,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import javax.validation.Valid;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -44,9 +46,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,22 +31,20 @@ import javax.validation.Valid;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -56,13 +55,19 @@ public class Name {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -70,11 +75,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -85,13 +97,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -99,9 +117,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import javax.validation.Valid;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -45,9 +47,14 @@ public class NumberOnly {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,19 +31,15 @@ import javax.validation.Valid;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -83,14 +80,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -101,15 +98,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -120,15 +124,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -139,15 +150,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -159,15 +177,22 @@ public class Order {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -178,15 +203,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -197,9 +229,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import javax.validation.Valid;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -53,15 +53,22 @@ public class OuterComposite {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -72,15 +79,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -91,9 +105,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,23 +34,18 @@ import javax.validation.Valid;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -90,10 +86,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -104,15 +101,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -124,15 +128,22 @@ public class Pet {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -143,15 +154,22 @@ public class Pet {
   **/
   @NotNull
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -167,15 +185,22 @@ public class Pet {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -195,15 +220,22 @@ public class Pet {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -214,9 +246,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,12 +30,11 @@ import javax.validation.Valid;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -42,11 +42,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -57,9 +64,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -43,9 +45,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import javax.validation.Valid;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -47,15 +48,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +74,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,26 +33,23 @@ import javax.validation.Valid;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +60,22 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -82,15 +87,22 @@ public class TypeHolderDefault {
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -101,15 +113,22 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -120,15 +139,22 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -144,9 +170,14 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,26 +33,23 @@ import javax.validation.Valid;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +60,22 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -82,15 +87,22 @@ public class TypeHolderExample {
   @NotNull
   @Valid
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -101,15 +113,22 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -120,15 +139,22 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -144,9 +170,14 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,38 +30,32 @@ import javax.validation.Valid;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -71,15 +66,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -90,15 +92,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -109,15 +118,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -128,15 +144,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -147,15 +170,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -166,15 +196,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -185,15 +222,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -204,9 +248,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,122 +33,95 @@ import javax.validation.Valid;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -158,15 +132,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -178,15 +159,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -197,15 +185,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -216,15 +211,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -243,15 +245,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -262,15 +271,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -282,15 +298,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -301,15 +324,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -320,15 +350,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -347,15 +384,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -374,15 +418,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -393,15 +444,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -413,15 +471,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -432,15 +497,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -451,15 +523,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -478,15 +557,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -505,15 +591,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -524,15 +617,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -544,15 +644,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -563,15 +670,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -582,15 +696,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -609,15 +730,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -636,15 +764,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -655,15 +790,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -675,15 +817,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -694,15 +843,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -713,15 +869,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -740,15 +903,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -767,9 +937,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2-play26/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/retrofit2-play26/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play26/pom.xml
@@ -269,6 +269,11 @@
                 <artifactId>validation-api</artifactId>
                 <version>1.1.0.Final</version>
             </dependency>
+            <dependency>
+                <groupId>org.openapitools</groupId>
+                <artifactId>jackson-databind-nullable</artifactId>
+                <version>${jackson-databind-nullable-version}</version>
+            </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -287,6 +292,7 @@
         <jackson-databind-version>2.9.9</jackson-databind-version>
         <jackson-version>2.9.9</jackson-version>
         <play-version>2.6.7</play-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <retrofit-version>2.5.0</retrofit-version>
         <threetenbp-version>1.3.8</threetenbp-version>
         <oltu-version>1.0.1</oltu-version>

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@ import retrofit2.Converter;
 import retrofit2.Retrofit;
 import retrofit2.converter.scalars.ScalarsConverterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import play.libs.Json;
 import play.libs.ws.WSClient;
@@ -90,6 +91,8 @@ public class ApiClient {
         }
         if (defaultMapper == null) {
             defaultMapper = Json.mapper();
+            JsonNullableModule jnm = new JsonNullableModule();
+            defaultMapper.registerModule(jnm);
         }
 
         return new Retrofit.Builder()

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,50 +34,41 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -95,15 +87,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -123,15 +122,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -150,15 +156,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -177,15 +190,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -205,15 +225,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -233,15 +260,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -261,15 +295,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -289,15 +330,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -309,15 +357,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -329,15 +384,22 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -349,9 +411,14 @@ public class AdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -45,9 +47,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -37,14 +38,14 @@ import javax.validation.Valid;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -55,15 +56,22 @@ public class Animal {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -74,9 +82,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -55,9 +57,14 @@ public class ArrayOfArrayOfNumberOnly {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,10 +33,11 @@ import javax.validation.Valid;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -55,9 +57,14 @@ public class ArrayOfNumberOnly {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,18 +33,17 @@ import javax.validation.Valid;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -62,15 +62,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -90,15 +97,22 @@ public class ArrayTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -118,9 +132,14 @@ public class ArrayTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,30 +30,26 @@ import javax.validation.Valid;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -63,15 +60,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -82,15 +86,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -101,15 +112,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -120,15 +138,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -139,15 +164,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -158,9 +190,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -45,9 +47,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import javax.validation.Valid;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -47,15 +48,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +74,14 @@ public class Category {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import javax.validation.Valid;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -44,9 +46,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -43,9 +45,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,10 +32,11 @@ import javax.validation.Valid;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -45,9 +47,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -66,7 +67,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -105,10 +105,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -119,15 +120,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -146,9 +154,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -67,7 +68,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -108,7 +108,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -147,7 +146,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -186,14 +184,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -204,15 +202,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -223,15 +228,22 @@ public class EnumTest {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -242,15 +254,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -261,15 +280,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -281,9 +307,14 @@ public class EnumTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,14 +32,14 @@ import javax.validation.Valid;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -50,15 +51,22 @@ public class FileSchemaTestClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -78,9 +86,14 @@ public class FileSchemaTestClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -34,58 +35,47 @@ import javax.validation.Valid;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -98,15 +88,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @Min(10) @Max(100)  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -119,15 +116,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @Min(20) @Max(200)  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -138,15 +142,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -160,15 +171,22 @@ public class FormatTest {
   @NotNull
   @Valid
  @DecimalMin("32.1") @DecimalMax("543.2")  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -181,15 +199,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @DecimalMin("54.3") @DecimalMax("987.6")  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -202,15 +227,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @DecimalMin("67.8") @DecimalMax("123.4")  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -221,15 +253,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
  @Pattern(regexp="/[a-z]/i")  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -240,15 +279,22 @@ public class FormatTest {
   **/
   @NotNull
  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -260,15 +306,22 @@ public class FormatTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -280,15 +333,22 @@ public class FormatTest {
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -300,15 +360,22 @@ public class FormatTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -320,15 +387,22 @@ public class FormatTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -339,9 +413,14 @@ public class FormatTest {
   **/
   @NotNull
  @Size(min=10,max=64)  @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,12 +30,11 @@ import javax.validation.Valid;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -42,9 +42,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -52,9 +58,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,7 +33,6 @@ import javax.validation.Valid;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -71,18 +71,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -102,15 +101,22 @@ public class MapTest {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -129,15 +135,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -156,15 +169,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -183,9 +203,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -35,18 +36,17 @@ import javax.validation.Valid;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -58,15 +58,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -78,15 +85,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -106,9 +120,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,14 +31,14 @@ import javax.validation.Valid;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -48,15 +49,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -67,9 +75,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,18 +30,17 @@ import javax.validation.Valid;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -51,15 +51,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -70,15 +77,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -89,9 +103,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import javax.validation.Valid;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -44,9 +46,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,22 +31,20 @@ import javax.validation.Valid;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -56,13 +55,19 @@ public class Name {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -70,11 +75,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -85,13 +97,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -99,9 +117,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import javax.validation.Valid;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -45,9 +47,14 @@ public class NumberOnly {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,19 +31,15 @@ import javax.validation.Valid;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -83,14 +80,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -101,15 +98,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -120,15 +124,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -139,15 +150,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -159,15 +177,22 @@ public class Order {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -178,15 +203,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -197,9 +229,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import javax.validation.Valid;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -53,15 +53,22 @@ public class OuterComposite {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -72,15 +79,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -91,9 +105,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,23 +34,18 @@ import javax.validation.Valid;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -90,10 +86,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -104,15 +101,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -124,15 +128,22 @@ public class Pet {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -143,15 +154,22 @@ public class Pet {
   **/
   @NotNull
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -167,15 +185,22 @@ public class Pet {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -195,15 +220,22 @@ public class Pet {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -214,9 +246,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,12 +30,11 @@ import javax.validation.Valid;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -42,11 +42,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -57,9 +64,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import javax.validation.Valid;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -43,9 +45,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import javax.validation.Valid;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -47,15 +48,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +74,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,26 +33,23 @@ import javax.validation.Valid;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +60,22 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -82,15 +87,22 @@ public class TypeHolderDefault {
   @NotNull
   @Valid
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -101,15 +113,22 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -120,15 +139,22 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -144,9 +170,14 @@ public class TypeHolderDefault {
   **/
   @NotNull
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,26 +33,23 @@ import javax.validation.Valid;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +60,22 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -82,15 +87,22 @@ public class TypeHolderExample {
   @NotNull
   @Valid
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -101,15 +113,22 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -120,15 +139,22 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -144,9 +170,14 @@ public class TypeHolderExample {
   **/
   @NotNull
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,38 +30,32 @@ import javax.validation.Valid;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -71,15 +66,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -90,15 +92,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -109,15 +118,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -128,15 +144,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -147,15 +170,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -166,15 +196,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -185,15 +222,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -204,9 +248,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,122 +33,95 @@ import javax.validation.Valid;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -158,15 +132,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -178,15 +159,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -197,15 +185,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -216,15 +211,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -243,15 +245,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -262,15 +271,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -282,15 +298,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -301,15 +324,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -320,15 +350,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -347,15 +384,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -374,15 +418,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -393,15 +444,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -413,15 +471,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -432,15 +497,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -451,15 +523,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -478,15 +557,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -505,15 +591,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -524,15 +617,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -544,15 +644,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -563,15 +670,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -582,15 +696,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -609,15 +730,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -636,15 +764,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -655,15 +790,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -675,15 +817,22 @@ public class XmlItem {
   @javax.annotation.Nullable
   @Valid
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -694,15 +843,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -713,15 +869,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -740,15 +903,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -767,9 +937,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -67,17 +67,19 @@ public class AdditionalPropertiesClass {
 
   public static final String SERIALIZED_NAME_ANYTYPE1 = "anytype_1";
   @SerializedName(SERIALIZED_NAME_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String SERIALIZED_NAME_ANYTYPE2 = "anytype_2";
   @SerializedName(SERIALIZED_NAME_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String SERIALIZED_NAME_ANYTYPE3 = "anytype_3";
   @SerializedName(SERIALIZED_NAME_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -96,15 +98,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -123,15 +130,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -150,15 +162,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -177,15 +194,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -204,15 +226,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -231,15 +258,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -258,15 +290,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -285,15 +322,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -304,15 +346,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -323,15 +370,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -342,9 +394,12 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Animal.java
@@ -41,7 +41,9 @@ public class Animal {
   public Animal() {
     this.className = this.getClass().getSimpleName();
   }
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -51,15 +53,20 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -70,9 +77,12 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -44,7 +44,9 @@ public class ArrayTest {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -63,15 +65,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -90,15 +97,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -117,9 +129,12 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,7 +53,9 @@ public class Capitalization {
   @SerializedName(SERIALIZED_NAME_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -64,15 +66,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -83,15 +90,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -102,15 +114,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -121,15 +138,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -140,15 +162,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -159,9 +186,12 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Cat.java
@@ -35,7 +35,9 @@ public class Cat extends Animal {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -33,7 +33,9 @@ public class CatAllOf {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -44,9 +46,12 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Category.java
@@ -37,7 +37,9 @@ public class Category {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +73,12 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -34,7 +34,9 @@ public class ClassModel {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -45,9 +47,12 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Client.java
@@ -33,7 +33,9 @@ public class Client {
   @SerializedName(SERIALIZED_NAME_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -44,9 +46,12 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Dog.java
@@ -35,7 +35,9 @@ public class Dog extends Animal {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -33,7 +33,9 @@ public class DogAllOf {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -44,9 +46,12 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,7 +133,9 @@ public class EnumArrays {
   @SerializedName(SERIALIZED_NAME_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -144,15 +146,20 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -171,9 +178,12 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -242,7 +242,9 @@ public class EnumTest {
   @SerializedName(SERIALIZED_NAME_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -253,15 +255,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -271,15 +278,20 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -290,15 +302,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -309,15 +326,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -328,9 +350,12 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -33,13 +33,15 @@ import java.util.List;
 public class FileSchemaTestClass {
   public static final String SERIALIZED_NAME_FILE = "file";
   @SerializedName(SERIALIZED_NAME_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String SERIALIZED_NAME_FILES = "files";
   @SerializedName(SERIALIZED_NAME_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -50,15 +52,20 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -77,9 +84,12 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,7 +86,9 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -99,15 +101,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -120,15 +127,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -139,15 +151,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -159,15 +176,20 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -180,15 +202,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -201,15 +228,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -220,15 +252,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -238,15 +275,20 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -257,15 +299,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -275,15 +322,20 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -294,15 +346,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -313,15 +370,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -331,9 +393,12 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -37,15 +37,20 @@ public class HasOnlyReadOnly {
   @SerializedName(SERIALIZED_NAME_FOO)
   private String foo;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -53,9 +58,12 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -95,7 +95,9 @@ public class MapTest {
   @SerializedName(SERIALIZED_NAME_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -114,15 +116,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -141,15 +148,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -168,15 +180,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -195,9 +212,12 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -47,7 +47,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @SerializedName(SERIALIZED_NAME_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -58,15 +60,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -77,15 +84,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -104,9 +116,12 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -38,7 +38,9 @@ public class Model200Response {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -49,15 +51,20 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -68,9 +75,12 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -41,7 +41,9 @@ public class ModelApiResponse {
   @SerializedName(SERIALIZED_NAME_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -52,15 +54,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -71,15 +78,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -90,9 +102,12 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -34,7 +34,9 @@ public class ModelReturn {
   @SerializedName(SERIALIZED_NAME_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -45,9 +47,12 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Name.java
@@ -46,7 +46,9 @@ public class Name {
   @SerializedName(SERIALIZED_NAME_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -56,13 +58,17 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -70,11 +76,16 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -85,13 +96,17 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -99,9 +114,12 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -34,7 +34,9 @@ public class NumberOnly {
   @SerializedName(SERIALIZED_NAME_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -45,9 +47,12 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
@@ -103,7 +103,9 @@ public class Order {
   @SerializedName(SERIALIZED_NAME_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -114,15 +116,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -133,15 +140,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -152,15 +164,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -171,15 +188,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -190,15 +212,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -209,9 +236,12 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -42,7 +42,9 @@ public class OuterComposite {
   @SerializedName(SERIALIZED_NAME_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -53,15 +55,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -72,15 +79,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -91,9 +103,12 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Pet.java
@@ -39,7 +39,7 @@ public class Pet {
 
   public static final String SERIALIZED_NAME_CATEGORY = "category";
   @SerializedName(SERIALIZED_NAME_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -106,7 +106,9 @@ public class Pet {
   @SerializedName(SERIALIZED_NAME_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -117,15 +119,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -136,15 +143,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -154,15 +166,20 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -177,15 +194,20 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -204,15 +226,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -223,9 +250,12 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -37,17 +37,23 @@ public class ReadOnlyFirst {
   @SerializedName(SERIALIZED_NAME_BAZ)
   private String baz;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -58,9 +64,12 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -33,7 +33,9 @@ public class SpecialModelName {
   @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -44,9 +46,12 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Tag.java
@@ -37,7 +37,9 @@ public class Tag {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -67,9 +74,12 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -52,7 +52,9 @@ public class TypeHolderDefault {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -52,7 +52,9 @@ public class TypeHolderExample {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/User.java
@@ -61,7 +61,9 @@ public class User {
   @SerializedName(SERIALIZED_NAME_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -72,15 +74,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -91,15 +98,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -110,15 +122,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -129,15 +146,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -148,15 +170,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -167,15 +194,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -186,15 +218,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -205,9 +242,12 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -148,7 +148,9 @@ public class XmlItem {
   @SerializedName(SERIALIZED_NAME_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -159,15 +161,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -178,15 +185,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -197,15 +209,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -216,15 +233,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -243,15 +265,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -262,15 +289,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -281,15 +313,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -300,15 +337,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -319,15 +361,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -346,15 +393,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -373,15 +425,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -392,15 +449,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -411,15 +473,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -430,15 +497,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -449,15 +521,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -476,15 +553,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -503,15 +585,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -522,15 +609,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -541,15 +633,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -560,15 +657,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -579,15 +681,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -606,15 +713,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -633,15 +745,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -652,15 +769,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -671,15 +793,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -690,15 +817,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -709,15 +841,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -736,15 +873,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -763,9 +905,12 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2rx/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -67,17 +67,19 @@ public class AdditionalPropertiesClass {
 
   public static final String SERIALIZED_NAME_ANYTYPE1 = "anytype_1";
   @SerializedName(SERIALIZED_NAME_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String SERIALIZED_NAME_ANYTYPE2 = "anytype_2";
   @SerializedName(SERIALIZED_NAME_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String SERIALIZED_NAME_ANYTYPE3 = "anytype_3";
   @SerializedName(SERIALIZED_NAME_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -96,15 +98,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -123,15 +130,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -150,15 +162,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -177,15 +194,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -204,15 +226,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -231,15 +258,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -258,15 +290,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -285,15 +322,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -304,15 +346,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -323,15 +370,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -342,9 +394,12 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Animal.java
@@ -41,7 +41,9 @@ public class Animal {
   public Animal() {
     this.className = this.getClass().getSimpleName();
   }
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -51,15 +53,20 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -70,9 +77,12 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -44,7 +44,9 @@ public class ArrayTest {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -63,15 +65,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -90,15 +97,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -117,9 +129,12 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,7 +53,9 @@ public class Capitalization {
   @SerializedName(SERIALIZED_NAME_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -64,15 +66,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -83,15 +90,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -102,15 +114,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -121,15 +138,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -140,15 +162,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -159,9 +186,12 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Cat.java
@@ -35,7 +35,9 @@ public class Cat extends Animal {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -33,7 +33,9 @@ public class CatAllOf {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -44,9 +46,12 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Category.java
@@ -37,7 +37,9 @@ public class Category {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +73,12 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -34,7 +34,9 @@ public class ClassModel {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -45,9 +47,12 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Client.java
@@ -33,7 +33,9 @@ public class Client {
   @SerializedName(SERIALIZED_NAME_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -44,9 +46,12 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Dog.java
@@ -35,7 +35,9 @@ public class Dog extends Animal {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -33,7 +33,9 @@ public class DogAllOf {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -44,9 +46,12 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,7 +133,9 @@ public class EnumArrays {
   @SerializedName(SERIALIZED_NAME_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -144,15 +146,20 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -171,9 +178,12 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -242,7 +242,9 @@ public class EnumTest {
   @SerializedName(SERIALIZED_NAME_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -253,15 +255,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -271,15 +278,20 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -290,15 +302,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -309,15 +326,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -328,9 +350,12 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -33,13 +33,15 @@ import java.util.List;
 public class FileSchemaTestClass {
   public static final String SERIALIZED_NAME_FILE = "file";
   @SerializedName(SERIALIZED_NAME_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String SERIALIZED_NAME_FILES = "files";
   @SerializedName(SERIALIZED_NAME_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -50,15 +52,20 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -77,9 +84,12 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,7 +86,9 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -99,15 +101,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -120,15 +127,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -139,15 +151,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -159,15 +176,20 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -180,15 +202,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -201,15 +228,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -220,15 +252,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -238,15 +275,20 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -257,15 +299,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -275,15 +322,20 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -294,15 +346,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -313,15 +370,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -331,9 +393,12 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -37,15 +37,20 @@ public class HasOnlyReadOnly {
   @SerializedName(SERIALIZED_NAME_FOO)
   private String foo;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -53,9 +58,12 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -95,7 +95,9 @@ public class MapTest {
   @SerializedName(SERIALIZED_NAME_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -114,15 +116,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -141,15 +148,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -168,15 +180,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -195,9 +212,12 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -47,7 +47,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @SerializedName(SERIALIZED_NAME_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -58,15 +60,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -77,15 +84,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -104,9 +116,12 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -38,7 +38,9 @@ public class Model200Response {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -49,15 +51,20 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -68,9 +75,12 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -41,7 +41,9 @@ public class ModelApiResponse {
   @SerializedName(SERIALIZED_NAME_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -52,15 +54,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -71,15 +78,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -90,9 +102,12 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -34,7 +34,9 @@ public class ModelReturn {
   @SerializedName(SERIALIZED_NAME_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -45,9 +47,12 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Name.java
@@ -46,7 +46,9 @@ public class Name {
   @SerializedName(SERIALIZED_NAME_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -56,13 +58,17 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -70,11 +76,16 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -85,13 +96,17 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -99,9 +114,12 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -34,7 +34,9 @@ public class NumberOnly {
   @SerializedName(SERIALIZED_NAME_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -45,9 +47,12 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Order.java
@@ -103,7 +103,9 @@ public class Order {
   @SerializedName(SERIALIZED_NAME_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -114,15 +116,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -133,15 +140,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -152,15 +164,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -171,15 +188,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -190,15 +212,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -209,9 +236,12 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -42,7 +42,9 @@ public class OuterComposite {
   @SerializedName(SERIALIZED_NAME_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -53,15 +55,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -72,15 +79,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -91,9 +103,12 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Pet.java
@@ -39,7 +39,7 @@ public class Pet {
 
   public static final String SERIALIZED_NAME_CATEGORY = "category";
   @SerializedName(SERIALIZED_NAME_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -106,7 +106,9 @@ public class Pet {
   @SerializedName(SERIALIZED_NAME_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -117,15 +119,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -136,15 +143,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -154,15 +166,20 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -177,15 +194,20 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -204,15 +226,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -223,9 +250,12 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -37,17 +37,23 @@ public class ReadOnlyFirst {
   @SerializedName(SERIALIZED_NAME_BAZ)
   private String baz;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -58,9 +64,12 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -33,7 +33,9 @@ public class SpecialModelName {
   @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -44,9 +46,12 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Tag.java
@@ -37,7 +37,9 @@ public class Tag {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -67,9 +74,12 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -52,7 +52,9 @@ public class TypeHolderDefault {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -52,7 +52,9 @@ public class TypeHolderExample {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/User.java
@@ -61,7 +61,9 @@ public class User {
   @SerializedName(SERIALIZED_NAME_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -72,15 +74,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -91,15 +98,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -110,15 +122,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -129,15 +146,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -148,15 +170,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -167,15 +194,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -186,15 +218,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -205,9 +242,12 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -148,7 +148,9 @@ public class XmlItem {
   @SerializedName(SERIALIZED_NAME_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -159,15 +161,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -178,15 +185,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -197,15 +209,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -216,15 +233,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -243,15 +265,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -262,15 +289,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -281,15 +313,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -300,15 +337,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -319,15 +361,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -346,15 +393,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -373,15 +425,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -392,15 +449,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -411,15 +473,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -430,15 +497,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -449,15 +521,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -476,15 +553,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -503,15 +585,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -522,15 +609,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -541,15 +633,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -560,15 +657,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -579,15 +681,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -606,15 +713,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -633,15 +745,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -652,15 +769,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -671,15 +793,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -690,15 +817,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -709,15 +841,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -736,15 +873,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -763,9 +905,12 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/retrofit2rx2/docs/UserApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -67,17 +67,19 @@ public class AdditionalPropertiesClass {
 
   public static final String SERIALIZED_NAME_ANYTYPE1 = "anytype_1";
   @SerializedName(SERIALIZED_NAME_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String SERIALIZED_NAME_ANYTYPE2 = "anytype_2";
   @SerializedName(SERIALIZED_NAME_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String SERIALIZED_NAME_ANYTYPE3 = "anytype_3";
   @SerializedName(SERIALIZED_NAME_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -96,15 +98,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -123,15 +130,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -150,15 +162,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -177,15 +194,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -204,15 +226,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -231,15 +258,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -258,15 +290,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -285,15 +322,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -304,15 +346,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -323,15 +370,20 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -342,9 +394,12 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -36,7 +36,9 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -47,9 +49,12 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -35,7 +35,9 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -46,9 +48,12 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Animal.java
@@ -41,7 +41,9 @@ public class Animal {
   public Animal() {
     this.className = this.getClass().getSimpleName();
   }
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -51,15 +53,20 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -70,9 +77,12 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -36,7 +36,9 @@ public class ArrayOfNumberOnly {
   @SerializedName(SERIALIZED_NAME_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -55,9 +57,12 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -44,7 +44,9 @@ public class ArrayTest {
   @SerializedName(SERIALIZED_NAME_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -63,15 +65,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -90,15 +97,20 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -117,9 +129,12 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -53,7 +53,9 @@ public class Capitalization {
   @SerializedName(SERIALIZED_NAME_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -64,15 +66,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -83,15 +90,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -102,15 +114,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -121,15 +138,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -140,15 +162,20 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -159,9 +186,12 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Cat.java
@@ -35,7 +35,9 @@ public class Cat extends Animal {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -33,7 +33,9 @@ public class CatAllOf {
   @SerializedName(SERIALIZED_NAME_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -44,9 +46,12 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Category.java
@@ -37,7 +37,9 @@ public class Category {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -66,9 +73,12 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -34,7 +34,9 @@ public class ClassModel {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -45,9 +47,12 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Client.java
@@ -33,7 +33,9 @@ public class Client {
   @SerializedName(SERIALIZED_NAME_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -44,9 +46,12 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Dog.java
@@ -35,7 +35,9 @@ public class Dog extends Animal {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -46,9 +48,12 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -33,7 +33,9 @@ public class DogAllOf {
   @SerializedName(SERIALIZED_NAME_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -44,9 +46,12 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,7 +133,9 @@ public class EnumArrays {
   @SerializedName(SERIALIZED_NAME_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -144,15 +146,20 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -171,9 +178,12 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -242,7 +242,9 @@ public class EnumTest {
   @SerializedName(SERIALIZED_NAME_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -253,15 +255,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -271,15 +278,20 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -290,15 +302,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -309,15 +326,20 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -328,9 +350,12 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -33,13 +33,15 @@ import java.util.List;
 public class FileSchemaTestClass {
   public static final String SERIALIZED_NAME_FILE = "file";
   @SerializedName(SERIALIZED_NAME_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String SERIALIZED_NAME_FILES = "files";
   @SerializedName(SERIALIZED_NAME_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -50,15 +52,20 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -77,9 +84,12 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,7 +86,9 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -99,15 +101,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -120,15 +127,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -139,15 +151,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -159,15 +176,20 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -180,15 +202,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -201,15 +228,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -220,15 +252,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -238,15 +275,20 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -257,15 +299,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -275,15 +322,20 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -294,15 +346,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -313,15 +370,20 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -331,9 +393,12 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -37,15 +37,20 @@ public class HasOnlyReadOnly {
   @SerializedName(SERIALIZED_NAME_FOO)
   private String foo;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -53,9 +58,12 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -95,7 +95,9 @@ public class MapTest {
   @SerializedName(SERIALIZED_NAME_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -114,15 +116,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -141,15 +148,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -168,15 +180,20 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -195,9 +212,12 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -47,7 +47,9 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   @SerializedName(SERIALIZED_NAME_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -58,15 +60,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -77,15 +84,20 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -104,9 +116,12 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -38,7 +38,9 @@ public class Model200Response {
   @SerializedName(SERIALIZED_NAME_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -49,15 +51,20 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -68,9 +75,12 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -41,7 +41,9 @@ public class ModelApiResponse {
   @SerializedName(SERIALIZED_NAME_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -52,15 +54,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -71,15 +78,20 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -90,9 +102,12 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -34,7 +34,9 @@ public class ModelReturn {
   @SerializedName(SERIALIZED_NAME_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -45,9 +47,12 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Name.java
@@ -46,7 +46,9 @@ public class Name {
   @SerializedName(SERIALIZED_NAME_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -56,13 +58,17 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -70,11 +76,16 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -85,13 +96,17 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -99,9 +114,12 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -34,7 +34,9 @@ public class NumberOnly {
   @SerializedName(SERIALIZED_NAME_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -45,9 +47,12 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
@@ -103,7 +103,9 @@ public class Order {
   @SerializedName(SERIALIZED_NAME_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -114,15 +116,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -133,15 +140,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -152,15 +164,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -171,15 +188,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -190,15 +212,20 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -209,9 +236,12 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -42,7 +42,9 @@ public class OuterComposite {
   @SerializedName(SERIALIZED_NAME_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -53,15 +55,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -72,15 +79,20 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -91,9 +103,12 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Pet.java
@@ -39,7 +39,7 @@ public class Pet {
 
   public static final String SERIALIZED_NAME_CATEGORY = "category";
   @SerializedName(SERIALIZED_NAME_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
@@ -106,7 +106,9 @@ public class Pet {
   @SerializedName(SERIALIZED_NAME_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -117,15 +119,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -136,15 +143,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -154,15 +166,20 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -177,15 +194,20 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -204,15 +226,20 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -223,9 +250,12 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -37,17 +37,23 @@ public class ReadOnlyFirst {
   @SerializedName(SERIALIZED_NAME_BAZ)
   private String baz;
 
+
    /**
    * Get bar
    * @return bar
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -58,9 +64,12 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -33,7 +33,9 @@ public class SpecialModelName {
   @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -44,9 +46,12 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Tag.java
@@ -37,7 +37,9 @@ public class Tag {
   @SerializedName(SERIALIZED_NAME_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -48,15 +50,20 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -67,9 +74,12 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -52,7 +52,9 @@ public class TypeHolderDefault {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -52,7 +52,9 @@ public class TypeHolderExample {
   @SerializedName(SERIALIZED_NAME_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -62,15 +64,20 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -80,15 +87,20 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -98,15 +110,20 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -116,15 +133,20 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -139,9 +161,12 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/User.java
@@ -61,7 +61,9 @@ public class User {
   @SerializedName(SERIALIZED_NAME_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -72,15 +74,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -91,15 +98,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -110,15 +122,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -129,15 +146,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -148,15 +170,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -167,15 +194,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -186,15 +218,20 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -205,9 +242,12 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -148,7 +148,9 @@ public class XmlItem {
   @SerializedName(SERIALIZED_NAME_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -159,15 +161,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -178,15 +185,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -197,15 +209,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -216,15 +233,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -243,15 +265,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -262,15 +289,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -281,15 +313,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -300,15 +337,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -319,15 +361,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -346,15 +393,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -373,15 +425,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -392,15 +449,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -411,15 +473,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -430,15 +497,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -449,15 +521,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -476,15 +553,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -503,15 +585,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -522,15 +609,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -541,15 +633,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -560,15 +657,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -579,15 +681,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -606,15 +713,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -633,15 +745,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -652,15 +769,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -671,15 +793,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -690,15 +817,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -709,15 +841,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -736,15 +873,20 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -763,9 +905,12 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/vertx/docs/UserApi.md
+++ b/samples/client/petstore/java/vertx/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/vertx/pom.xml
+++ b/samples/client/petstore/java/vertx/pom.xml
@@ -236,6 +236,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jsr310</artifactId>
@@ -263,6 +268,7 @@
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind>2.9.9</jackson-databind>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.AsyncFile;
@@ -75,6 +76,8 @@ public class ApiClient {
         this.objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
         this.objectMapper.registerModule(new JavaTimeModule());
         this.objectMapper.setDateFormat(dateFormat);
+        JsonNullableModule jnm = new JsonNullableModule();
+        this.objectMapper.registerModule(jnm);
 
         // Setup authentications (key: authentication name, value: authentication).
         this.authentications = new HashMap<>();

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import java.util.UUID;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private AsyncFile binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(AsyncFile binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public AsyncFile getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(AsyncFile binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.openapitools.client.model.Animal;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import java.time.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/java/webclient/docs/UserApi.md
+++ b/samples/client/petstore/java/webclient/docs/UserApi.md
@@ -101,7 +101,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithArrayInput(body);
         } catch (ApiException e) {
@@ -163,7 +163,7 @@ public class Example {
         defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
 
         UserApi apiInstance = new UserApi(defaultClient);
-        List<User> body = Arrays.asList(null); // List<User> | List of user object
+        List<User> body = Arrays.asList(); // List<User> | List of user object
         try {
             apiInstance.createUsersWithListInput(body);
         } catch (ApiException e) {

--- a/samples/client/petstore/java/webclient/pom.xml
+++ b/samples/client/petstore/java/webclient/pom.xml
@@ -98,6 +98,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>${jackson-databind-nullable-version}</version>
+        </dependency>
 
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -119,6 +124,7 @@
         <spring-web-version>5.0.7.RELEASE</spring-web-version>
         <jackson-version>2.9.9</jackson-version>
         <jackson-databind-version>2.9.9</jackson-databind-version>
+        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
         <reactor-version>3.1.8.RELEASE</reactor-version>
         <reactor-netty-version>0.7.8.RELEASE</reactor-netty-version>

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -3,6 +3,7 @@ package org.openapitools.client;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.core.ParameterizedTypeReference;
@@ -94,6 +95,8 @@ public class ApiClient {
         mapper.setDateFormat(dateFormat);
         mapper.registerModule(new JavaTimeModule());
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        JsonNullableModule jnm = new JsonNullableModule();
+        mapper.registerModule(jnm);
 
         this.webClient = buildWebClient(mapper);
         this.init();

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesAnyType name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesArray name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesBoolean name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,50 +32,41 @@ import java.util.Map;
 
 public class AdditionalPropertiesClass {
   public static final String JSON_PROPERTY_MAP_STRING = "map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
   public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
-  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
   public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
   public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
-  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
   public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
   public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
-  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
+
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
+    
     this.mapString = mapString;
     return this;
   }
@@ -93,15 +85,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, String> getMapString() {
     return mapString;
   }
+
+
 
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
 
+
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
+    
     this.mapNumber = mapNumber;
     return this;
   }
@@ -120,15 +119,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
+
+
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
     this.mapNumber = mapNumber;
   }
 
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
+    
     this.mapInteger = mapInteger;
     return this;
   }
@@ -147,15 +153,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Integer> getMapInteger() {
     return mapInteger;
   }
+
+
 
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
 
+
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
+    
     this.mapBoolean = mapBoolean;
     return this;
   }
@@ -174,15 +187,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
+
+
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
     this.mapBoolean = mapBoolean;
   }
 
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
+    
     this.mapArrayInteger = mapArrayInteger;
     return this;
   }
@@ -201,15 +221,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
+
+
 
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
+    
     this.mapArrayAnytype = mapArrayAnytype;
     return this;
   }
@@ -228,15 +255,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
+
+
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     this.mapArrayAnytype = mapArrayAnytype;
   }
 
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
+    
     this.mapMapString = mapMapString;
     return this;
   }
@@ -255,15 +289,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
+
+
 
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
 
+
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
+    
     this.mapMapAnytype = mapMapAnytype;
     return this;
   }
@@ -282,15 +323,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
+
+
 
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
 
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
+    
     this.anytype1 = anytype1;
     return this;
   }
@@ -301,15 +349,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype1() {
     return anytype1;
   }
+
+
 
   public void setAnytype1(Object anytype1) {
     this.anytype1 = anytype1;
   }
 
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
+    
     this.anytype2 = anytype2;
     return this;
   }
@@ -320,15 +375,22 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype2() {
     return anytype2;
   }
+
+
 
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
 
+
   public AdditionalPropertiesClass anytype3(Object anytype3) {
+    
     this.anytype3 = anytype3;
     return this;
   }
@@ -339,9 +401,14 @@ public class AdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Object getAnytype3() {
     return anytype3;
   }
+
+
 
   public void setAnytype3(Object anytype3) {
     this.anytype3 = anytype3;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesInteger name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesNumber name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -44,9 +46,14 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesObject name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import java.util.Map;
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public AdditionalPropertiesString name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -43,9 +45,14 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -35,14 +36,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Animal {
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
-  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
   public static final String JSON_PROPERTY_COLOR = "color";
-  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
+
   public Animal className(String className) {
+    
     this.className = className;
     return this;
   }
@@ -52,15 +53,22 @@ public class Animal {
    * @return className
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getClassName() {
     return className;
   }
+
+
 
   public void setClassName(String className) {
     this.className = className;
   }
 
+
   public Animal color(String color) {
+    
     this.color = color;
     return this;
   }
@@ -71,9 +79,14 @@ public class Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COLOR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getColor() {
     return color;
   }
+
+
 
   public void setColor(String color) {
     this.color = color;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
+    
     this.arrayArrayNumber = arrayArrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
+
+
 
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,10 +31,11 @@ import java.util.List;
 
 public class ArrayOfNumberOnly {
   public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
-  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
+    
     this.arrayNumber = arrayNumber;
     return this;
   }
@@ -52,9 +54,14 @@ public class ArrayOfNumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
+
+
 
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,18 +31,17 @@ import org.openapitools.client.model.ReadOnlyFirst;
 
 public class ArrayTest {
   public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
-  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
   public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
+    
     this.arrayOfString = arrayOfString;
     return this;
   }
@@ -60,15 +60,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<String> getArrayOfString() {
     return arrayOfString;
   }
+
+
 
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
 
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
+    
     this.arrayArrayOfInteger = arrayArrayOfInteger;
     return this;
   }
@@ -87,15 +94,22 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
+
+
 
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
+    
     this.arrayArrayOfModel = arrayArrayOfModel;
     return this;
   }
@@ -114,9 +128,14 @@ public class ArrayTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
+
+
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     this.arrayArrayOfModel = arrayArrayOfModel;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,30 +28,26 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Capitalization {
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
-  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
-  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
-  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
-  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
-  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
+
   public Capitalization smallCamel(String smallCamel) {
+    
     this.smallCamel = smallCamel;
     return this;
   }
@@ -61,15 +58,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallCamel() {
     return smallCamel;
   }
+
+
 
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
 
+
   public Capitalization capitalCamel(String capitalCamel) {
+    
     this.capitalCamel = capitalCamel;
     return this;
   }
@@ -80,15 +84,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalCamel() {
     return capitalCamel;
   }
+
+
 
   public void setCapitalCamel(String capitalCamel) {
     this.capitalCamel = capitalCamel;
   }
 
+
   public Capitalization smallSnake(String smallSnake) {
+    
     this.smallSnake = smallSnake;
     return this;
   }
@@ -99,15 +110,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getSmallSnake() {
     return smallSnake;
   }
+
+
 
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
 
+
   public Capitalization capitalSnake(String capitalSnake) {
+    
     this.capitalSnake = capitalSnake;
     return this;
   }
@@ -118,15 +136,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getCapitalSnake() {
     return capitalSnake;
   }
+
+
 
   public void setCapitalSnake(String capitalSnake) {
     this.capitalSnake = capitalSnake;
   }
 
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
+    
     this.scAETHFlowPoints = scAETHFlowPoints;
     return this;
   }
@@ -137,15 +162,22 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getScAETHFlowPoints() {
     return scAETHFlowPoints;
   }
+
+
 
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
   public Capitalization ATT_NAME(String ATT_NAME) {
+    
     this.ATT_NAME = ATT_NAME;
     return this;
   }
@@ -156,9 +188,14 @@ public class Capitalization {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Name of the pet ")
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getATTNAME() {
     return ATT_NAME;
   }
+
+
 
   public void setATTNAME(String ATT_NAME) {
     this.ATT_NAME = ATT_NAME;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.CatAllOf;
 
 public class Cat extends Animal {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public Cat declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Cat extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class CatAllOf {
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
-  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
+
   public CatAllOf declawed(Boolean declawed) {
+    
     this.declawed = declawed;
     return this;
   }
@@ -41,9 +43,14 @@ public class CatAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getDeclawed() {
     return declawed;
   }
+
+
 
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Category {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
+
   public Category id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Category {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Category name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -63,9 +71,14 @@ public class Category {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ClassModel {
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public ClassModel propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -42,9 +44,14 @@ public class ClassModel {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Client {
   public static final String JSON_PROPERTY_CLIENT = "client";
-  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
+
   public Client client(String client) {
+    
     this.client = client;
     return this;
   }
@@ -41,9 +43,14 @@ public class Client {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CLIENT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getClient() {
     return client;
   }
+
+
 
   public void setClient(String client) {
     this.client = client;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,10 +30,11 @@ import org.openapitools.client.model.DogAllOf;
 
 public class Dog extends Animal {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public Dog breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -43,9 +45,14 @@ public class Dog extends Animal {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class DogAllOf {
   public static final String JSON_PROPERTY_BREED = "breed";
-  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
+
   public DogAllOf breed(String breed) {
+    
     this.breed = breed;
     return this;
   }
@@ -41,9 +43,14 @@ public class DogAllOf {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BREED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBreed() {
     return breed;
   }
+
+
 
   public void setBreed(String breed) {
     this.breed = breed;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -64,7 +65,6 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
-  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,10 +103,11 @@ public class EnumArrays {
   }
 
   public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
+    
     this.justSymbol = justSymbol;
     return this;
   }
@@ -117,15 +118,22 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public JustSymbolEnum getJustSymbol() {
     return justSymbol;
   }
+
+
 
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
 
+
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
+    
     this.arrayEnum = arrayEnum;
     return this;
   }
@@ -144,9 +152,14 @@ public class EnumArrays {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
+
+
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {
     this.arrayEnum = arrayEnum;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -65,7 +66,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +106,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
-  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -145,7 +144,6 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
-  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -184,14 +182,14 @@ public class EnumTest {
   }
 
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
-  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
-  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
+
   public EnumTest enumString(EnumStringEnum enumString) {
+    
     this.enumString = enumString;
     return this;
   }
@@ -202,15 +200,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumStringEnum getEnumString() {
     return enumString;
   }
+
+
 
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
 
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
+    
     this.enumStringRequired = enumStringRequired;
     return this;
   }
@@ -220,15 +225,22 @@ public class EnumTest {
    * @return enumStringRequired
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
+
+
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     this.enumStringRequired = enumStringRequired;
   }
 
+
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
+    
     this.enumInteger = enumInteger;
     return this;
   }
@@ -239,15 +251,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumIntegerEnum getEnumInteger() {
     return enumInteger;
   }
+
+
 
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
 
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
+    
     this.enumNumber = enumNumber;
     return this;
   }
@@ -258,15 +277,22 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
+
+
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
 
+
   public EnumTest outerEnum(OuterEnum outerEnum) {
+    
     this.outerEnum = outerEnum;
     return this;
   }
@@ -277,9 +303,14 @@ public class EnumTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
+
+
 
   public void setOuterEnum(OuterEnum outerEnum) {
     this.outerEnum = outerEnum;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -29,14 +30,14 @@ import java.util.List;
 
 public class FileSchemaTestClass {
   public static final String JSON_PROPERTY_FILE = "file";
-  @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
-  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
+
   public FileSchemaTestClass file(java.io.File file) {
+    
     this.file = file;
     return this;
   }
@@ -47,15 +48,22 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public java.io.File getFile() {
     return file;
   }
+
+
 
   public void setFile(java.io.File file) {
     this.file = file;
   }
 
+
   public FileSchemaTestClass files(List<java.io.File> files) {
+    
     this.files = files;
     return this;
   }
@@ -74,9 +82,14 @@ public class FileSchemaTestClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FILES)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<java.io.File> getFiles() {
     return files;
   }
+
+
 
   public void setFiles(List<java.io.File> files) {
     this.files = files;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -32,58 +33,47 @@ import java.util.UUID;
 
 public class FormatTest {
   public static final String JSON_PROPERTY_INTEGER = "integer";
-  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
   public static final String JSON_PROPERTY_INT32 = "int32";
-  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
   public static final String JSON_PROPERTY_INT64 = "int64";
-  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
   public static final String JSON_PROPERTY_NUMBER = "number";
-  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
   public static final String JSON_PROPERTY_FLOAT = "float";
-  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
   public static final String JSON_PROPERTY_DOUBLE = "double";
-  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
   public static final String JSON_PROPERTY_STRING = "string";
-  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
   public static final String JSON_PROPERTY_BYTE = "byte";
-  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
   public static final String JSON_PROPERTY_BINARY = "binary";
-  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
   public static final String JSON_PROPERTY_DATE = "date";
-  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
+
   public FormatTest integer(Integer integer) {
+    
     this.integer = integer;
     return this;
   }
@@ -96,15 +86,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInteger() {
     return integer;
   }
+
+
 
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
 
+
   public FormatTest int32(Integer int32) {
+    
     this.int32 = int32;
     return this;
   }
@@ -117,15 +114,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT32)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getInt32() {
     return int32;
   }
+
+
 
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
 
+
   public FormatTest int64(Long int64) {
+    
     this.int64 = int64;
     return this;
   }
@@ -136,15 +140,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INT64)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getInt64() {
     return int64;
   }
+
+
 
   public void setInt64(Long int64) {
     this.int64 = int64;
   }
 
+
   public FormatTest number(BigDecimal number) {
+    
     this.number = number;
     return this;
   }
@@ -156,15 +167,22 @@ public class FormatTest {
    * @return number
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumber() {
     return number;
   }
+
+
 
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
 
+
   public FormatTest _float(Float _float) {
+    
     this._float = _float;
     return this;
   }
@@ -177,15 +195,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FLOAT)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Float getFloat() {
     return _float;
   }
+
+
 
   public void setFloat(Float _float) {
     this._float = _float;
   }
 
+
   public FormatTest _double(Double _double) {
+    
     this._double = _double;
     return this;
   }
@@ -198,15 +223,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Double getDouble() {
     return _double;
   }
+
+
 
   public void setDouble(Double _double) {
     this._double = _double;
   }
 
+
   public FormatTest string(String string) {
+    
     this.string = string;
     return this;
   }
@@ -217,15 +249,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getString() {
     return string;
   }
+
+
 
   public void setString(String string) {
     this.string = string;
   }
 
+
   public FormatTest _byte(byte[] _byte) {
+    
     this._byte = _byte;
     return this;
   }
@@ -235,15 +274,22 @@ public class FormatTest {
    * @return _byte
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BYTE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public byte[] getByte() {
     return _byte;
   }
+
+
 
   public void setByte(byte[] _byte) {
     this._byte = _byte;
   }
 
+
   public FormatTest binary(File binary) {
+    
     this.binary = binary;
     return this;
   }
@@ -254,15 +300,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BINARY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public File getBinary() {
     return binary;
   }
+
+
 
   public void setBinary(File binary) {
     this.binary = binary;
   }
 
+
   public FormatTest date(LocalDate date) {
+    
     this.date = date;
     return this;
   }
@@ -272,15 +325,22 @@ public class FormatTest {
    * @return date
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_DATE)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public LocalDate getDate() {
     return date;
   }
+
+
 
   public void setDate(LocalDate date) {
     this.date = date;
   }
 
+
   public FormatTest dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -291,15 +351,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public FormatTest uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -310,15 +377,22 @@ public class FormatTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public FormatTest password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -328,9 +402,14 @@ public class FormatTest {
    * @return password
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class HasOnlyReadOnly {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_FOO = "foo";
-  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
+
 
    /**
    * Get bar
@@ -40,9 +40,15 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
+
+
+
 
    /**
    * Get foo
@@ -50,9 +56,14 @@ public class HasOnlyReadOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FOO)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFoo() {
     return foo;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 public class MapTest {
   public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
-  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -69,18 +69,17 @@ public class MapTest {
   }
 
   public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
-  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
   public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
-  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
   public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
-  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
+    
     this.mapMapOfString = mapMapOfString;
     return this;
   }
@@ -99,15 +98,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
+
+
 
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
 
+
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
+    
     this.mapOfEnumString = mapOfEnumString;
     return this;
   }
@@ -126,15 +132,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
+
+
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     this.mapOfEnumString = mapOfEnumString;
   }
 
+
   public MapTest directMap(Map<String, Boolean> directMap) {
+    
     this.directMap = directMap;
     return this;
   }
@@ -153,15 +166,22 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getDirectMap() {
     return directMap;
   }
+
+
 
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
 
+
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
+    
     this.indirectMap = indirectMap;
     return this;
   }
@@ -180,9 +200,14 @@ public class MapTest {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
+
+
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {
     this.indirectMap = indirectMap;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -33,18 +34,17 @@ import org.openapitools.client.model.Animal;
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
   public static final String JSON_PROPERTY_UUID = "uuid";
-  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
-  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
   public static final String JSON_PROPERTY_MAP = "map";
-  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
+    
     this.uuid = uuid;
     return this;
   }
@@ -55,15 +55,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_UUID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public UUID getUuid() {
     return uuid;
   }
+
+
 
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
+    
     this.dateTime = dateTime;
     return this;
   }
@@ -74,15 +81,22 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
+
+
 
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
 
+
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
+    
     this.map = map;
     return this;
   }
@@ -101,9 +115,14 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MAP)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Map<String, Animal> getMap() {
     return map;
   }
+
+
 
   public void setMap(Map<String, Animal> map) {
     this.map = map;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,14 +29,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Model200Response {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
-  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
+
   public Model200Response name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -46,15 +47,22 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getName() {
     return name;
   }
+
+
 
   public void setName(Integer name) {
     this.name = name;
   }
 
+
   public Model200Response propertyClass(String propertyClass) {
+    
     this.propertyClass = propertyClass;
     return this;
   }
@@ -65,9 +73,14 @@ public class Model200Response {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPropertyClass() {
     return propertyClass;
   }
+
+
 
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,18 +28,17 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelApiResponse {
   public static final String JSON_PROPERTY_CODE = "code";
-  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
   public static final String JSON_PROPERTY_TYPE = "type";
-  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
   public static final String JSON_PROPERTY_MESSAGE = "message";
-  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
+
   public ModelApiResponse code(Integer code) {
+    
     this.code = code;
     return this;
   }
@@ -49,15 +49,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getCode() {
     return code;
   }
+
+
 
   public void setCode(Integer code) {
     this.code = code;
   }
 
+
   public ModelApiResponse type(String type) {
+    
     this.type = type;
     return this;
   }
@@ -68,15 +75,22 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TYPE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getType() {
     return type;
   }
+
+
 
   public void setType(String type) {
     this.type = type;
   }
 
+
   public ModelApiResponse message(String message) {
+    
     this.message = message;
     return this;
   }
@@ -87,9 +101,14 @@ public class ModelApiResponse {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMessage() {
     return message;
   }
+
+
 
   public void setMessage(String message) {
     this.message = message;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ModelReturn {
   public static final String JSON_PROPERTY_RETURN = "return";
-  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
+
   public ModelReturn _return(Integer _return) {
+    
     this._return = _return;
     return this;
   }
@@ -42,9 +44,14 @@ public class ModelReturn {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_RETURN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getReturn() {
     return _return;
   }
+
+
 
   public void setReturn(Integer _return) {
     this._return = _return;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,22 +29,20 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Name {
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
-  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
   public static final String JSON_PROPERTY_PROPERTY = "property";
-  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
-  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
+
   public Name name(Integer name) {
+    
     this.name = name;
     return this;
   }
@@ -53,13 +52,19 @@ public class Name {
    * @return name
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getName() {
     return name;
   }
 
+
+
   public void setName(Integer name) {
     this.name = name;
   }
+
 
    /**
    * Get snakeCase
@@ -67,11 +72,18 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getSnakeCase() {
     return snakeCase;
   }
 
+
+
+
   public Name property(String property) {
+    
     this.property = property;
     return this;
   }
@@ -82,13 +94,19 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getProperty() {
     return property;
   }
 
+
+
   public void setProperty(String property) {
     this.property = property;
   }
+
 
    /**
    * Get _123number
@@ -96,9 +114,14 @@ public class Name {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer get123number() {
     return _123number;
   }
+
+
 
 
   @Override

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,10 +29,11 @@ import java.math.BigDecimal;
 
 public class NumberOnly {
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
-  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
+
   public NumberOnly justNumber(BigDecimal justNumber) {
+    
     this.justNumber = justNumber;
     return this;
   }
@@ -42,9 +44,14 @@ public class NumberOnly {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getJustNumber() {
     return justNumber;
   }
+
+
 
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,19 +29,15 @@ import java.time.OffsetDateTime;
 
 public class Order {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_PET_ID = "petId";
-  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
-  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
-  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -81,14 +78,14 @@ public class Order {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public static final String JSON_PROPERTY_COMPLETE = "complete";
-  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
+
   public Order id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -99,15 +96,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Order petId(Long petId) {
+    
     this.petId = petId;
     return this;
   }
@@ -118,15 +122,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PET_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getPetId() {
     return petId;
   }
+
+
 
   public void setPetId(Long petId) {
     this.petId = petId;
   }
 
+
   public Order quantity(Integer quantity) {
+    
     this.quantity = quantity;
     return this;
   }
@@ -137,15 +148,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getQuantity() {
     return quantity;
   }
+
+
 
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
 
+
   public Order shipDate(OffsetDateTime shipDate) {
+    
     this.shipDate = shipDate;
     return this;
   }
@@ -156,15 +174,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
+
+
 
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
 
+
   public Order status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -175,15 +200,22 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "Order Status")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
 
+
   public Order complete(Boolean complete) {
+    
     this.complete = complete;
     return this;
   }
@@ -194,9 +226,14 @@ public class Order {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getComplete() {
     return complete;
   }
+
+
 
   public void setComplete(Boolean complete) {
     this.complete = complete;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -28,18 +29,17 @@ import java.math.BigDecimal;
 
 public class OuterComposite {
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
-  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
-  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
-  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
+
   public OuterComposite myNumber(BigDecimal myNumber) {
+    
     this.myNumber = myNumber;
     return this;
   }
@@ -50,15 +50,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getMyNumber() {
     return myNumber;
   }
+
+
 
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
 
+
   public OuterComposite myString(String myString) {
+    
     this.myString = myString;
     return this;
   }
@@ -69,15 +76,22 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getMyString() {
     return myString;
   }
+
+
 
   public void setMyString(String myString) {
     this.myString = myString;
   }
 
+
   public OuterComposite myBoolean(Boolean myBoolean) {
+    
     this.myBoolean = myBoolean;
     return this;
   }
@@ -88,9 +102,14 @@ public class OuterComposite {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getMyBoolean() {
     return myBoolean;
   }
+
+
 
   public void setMyBoolean(Boolean myBoolean) {
     this.myBoolean = myBoolean;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -31,23 +32,18 @@ import org.openapitools.client.model.Tag;
 
 public class Pet {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
-  @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
-  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
   public static final String JSON_PROPERTY_TAGS = "tags";
-  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -88,10 +84,11 @@ public class Pet {
   }
 
   public static final String JSON_PROPERTY_STATUS = "status";
-  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
+
   public Pet id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -102,15 +99,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Pet category(Category category) {
+    
     this.category = category;
     return this;
   }
@@ -121,15 +125,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Category getCategory() {
     return category;
   }
+
+
 
   public void setCategory(Category category) {
     this.category = category;
   }
 
+
   public Pet name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -139,15 +150,22 @@ public class Pet {
    * @return name
   **/
   @ApiModelProperty(example = "doggie", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;
   }
 
+
   public Pet photoUrls(List<String> photoUrls) {
+    
     this.photoUrls = photoUrls;
     return this;
   }
@@ -162,15 +180,22 @@ public class Pet {
    * @return photoUrls
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
+
+
 
   public void setPhotoUrls(List<String> photoUrls) {
     this.photoUrls = photoUrls;
   }
 
+
   public Pet tags(List<Tag> tags) {
+    
     this.tags = tags;
     return this;
   }
@@ -189,15 +214,22 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_TAGS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Tag> getTags() {
     return tags;
   }
+
+
 
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
 
+
   public Pet status(StatusEnum status) {
+    
     this.status = status;
     return this;
   }
@@ -208,9 +240,14 @@ public class Pet {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "pet status in the store")
+  @JsonProperty(JSON_PROPERTY_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public StatusEnum getStatus() {
     return status;
   }
+
+
 
   public void setStatus(StatusEnum status) {
     this.status = status;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,12 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class ReadOnlyFirst {
   public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
   public static final String JSON_PROPERTY_BAZ = "baz";
-  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
+
 
    /**
    * Get bar
@@ -40,11 +40,18 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAR)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBar() {
     return bar;
   }
 
+
+
+
   public ReadOnlyFirst baz(String baz) {
+    
     this.baz = baz;
     return this;
   }
@@ -55,9 +62,14 @@ public class ReadOnlyFirst {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BAZ)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getBaz() {
     return baz;
   }
+
+
 
   public void setBaz(String baz) {
     this.baz = baz;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,10 +28,11 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class SpecialModelName {
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
+    
     this.$specialPropertyName = $specialPropertyName;
     return this;
   }
@@ -41,9 +43,14 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long get$SpecialPropertyName() {
     return $specialPropertyName;
   }
+
+
 
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,14 +28,14 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class Tag {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_NAME = "name";
-  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
+
   public Tag id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -45,15 +46,22 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public Tag name(String name) {
+    
     this.name = name;
     return this;
   }
@@ -64,9 +72,14 @@ public class Tag {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getName() {
     return name;
   }
+
+
 
   public void setName(String name) {
     this.name = name;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderDefault {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderDefault stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderDefault {
    * @return stringItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderDefault {
    * @return numberItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderDefault integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderDefault {
    * @return integerItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderDefault {
    * @return boolItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderDefault {
    * @return arrayItem
   **/
   @ApiModelProperty(required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,26 +31,23 @@ import java.util.List;
 
 public class TypeHolderExample {
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
-  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
-  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
-  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
-  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
   public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
-  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
+
   public TypeHolderExample stringItem(String stringItem) {
+    
     this.stringItem = stringItem;
     return this;
   }
@@ -59,15 +57,22 @@ public class TypeHolderExample {
    * @return stringItem
   **/
   @ApiModelProperty(example = "what", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public String getStringItem() {
     return stringItem;
   }
+
+
 
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
 
+
   public TypeHolderExample numberItem(BigDecimal numberItem) {
+    
     this.numberItem = numberItem;
     return this;
   }
@@ -77,15 +82,22 @@ public class TypeHolderExample {
    * @return numberItem
   **/
   @ApiModelProperty(example = "1.234", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public BigDecimal getNumberItem() {
     return numberItem;
   }
+
+
 
   public void setNumberItem(BigDecimal numberItem) {
     this.numberItem = numberItem;
   }
 
+
   public TypeHolderExample integerItem(Integer integerItem) {
+    
     this.integerItem = integerItem;
     return this;
   }
@@ -95,15 +107,22 @@ public class TypeHolderExample {
    * @return integerItem
   **/
   @ApiModelProperty(example = "-2", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Integer getIntegerItem() {
     return integerItem;
   }
+
+
 
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
 
+
   public TypeHolderExample boolItem(Boolean boolItem) {
+    
     this.boolItem = boolItem;
     return this;
   }
@@ -113,15 +132,22 @@ public class TypeHolderExample {
    * @return boolItem
   **/
   @ApiModelProperty(example = "true", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public Boolean getBoolItem() {
     return boolItem;
   }
+
+
 
   public void setBoolItem(Boolean boolItem) {
     this.boolItem = boolItem;
   }
 
+
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
+    
     this.arrayItem = arrayItem;
     return this;
   }
@@ -136,9 +162,14 @@ public class TypeHolderExample {
    * @return arrayItem
   **/
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
+
+
 
   public void setArrayItem(List<Integer> arrayItem) {
     this.arrayItem = arrayItem;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -27,38 +28,32 @@ import io.swagger.annotations.ApiModelProperty;
 
 public class User {
   public static final String JSON_PROPERTY_ID = "id";
-  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
   public static final String JSON_PROPERTY_USERNAME = "username";
-  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
-  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
-  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
   public static final String JSON_PROPERTY_EMAIL = "email";
-  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
-  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public static final String JSON_PROPERTY_PHONE = "phone";
-  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
-  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
+
   public User id(Long id) {
+    
     this.id = id;
     return this;
   }
@@ -69,15 +64,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Long getId() {
     return id;
   }
+
+
 
   public void setId(Long id) {
     this.id = id;
   }
 
+
   public User username(String username) {
+    
     this.username = username;
     return this;
   }
@@ -88,15 +90,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_USERNAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getUsername() {
     return username;
   }
+
+
 
   public void setUsername(String username) {
     this.username = username;
   }
 
+
   public User firstName(String firstName) {
+    
     this.firstName = firstName;
     return this;
   }
@@ -107,15 +116,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getFirstName() {
     return firstName;
   }
+
+
 
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
 
+
   public User lastName(String lastName) {
+    
     this.lastName = lastName;
     return this;
   }
@@ -126,15 +142,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getLastName() {
     return lastName;
   }
+
+
 
   public void setLastName(String lastName) {
     this.lastName = lastName;
   }
 
+
   public User email(String email) {
+    
     this.email = email;
     return this;
   }
@@ -145,15 +168,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_EMAIL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getEmail() {
     return email;
   }
+
+
 
   public void setEmail(String email) {
     this.email = email;
   }
 
+
   public User password(String password) {
+    
     this.password = password;
     return this;
   }
@@ -164,15 +194,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPassword() {
     return password;
   }
+
+
 
   public void setPassword(String password) {
     this.password = password;
   }
 
+
   public User phone(String phone) {
+    
     this.phone = phone;
     return this;
   }
@@ -183,15 +220,22 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PHONE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPhone() {
     return phone;
   }
+
+
 
   public void setPhone(String phone) {
     this.phone = phone;
   }
 
+
   public User userStatus(Integer userStatus) {
+    
     this.userStatus = userStatus;
     return this;
   }
@@ -202,9 +246,14 @@ public class User {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "User Status")
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getUserStatus() {
     return userStatus;
   }
+
+
 
   public void setUserStatus(Integer userStatus) {
     this.userStatus = userStatus;

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -15,6 +15,7 @@ package org.openapitools.client.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -30,122 +31,95 @@ import java.util.List;
 
 public class XmlItem {
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
-  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
   public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
-  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
-  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
-  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
-  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
-  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
   public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
-  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
   public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
   public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
   public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
   public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
   public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
-  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
+
   public XmlItem attributeString(String attributeString) {
+    
     this.attributeString = attributeString;
     return this;
   }
@@ -156,15 +130,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getAttributeString() {
     return attributeString;
   }
+
+
 
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
 
+
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
+    
     this.attributeNumber = attributeNumber;
     return this;
   }
@@ -175,15 +156,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
+
+
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
     this.attributeNumber = attributeNumber;
   }
 
+
   public XmlItem attributeInteger(Integer attributeInteger) {
+    
     this.attributeInteger = attributeInteger;
     return this;
   }
@@ -194,15 +182,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getAttributeInteger() {
     return attributeInteger;
   }
+
+
 
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
 
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
+    
     this.attributeBoolean = attributeBoolean;
     return this;
   }
@@ -213,15 +208,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
+
+
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
     this.attributeBoolean = attributeBoolean;
   }
 
+
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
+    
     this.wrappedArray = wrappedArray;
     return this;
   }
@@ -240,15 +242,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getWrappedArray() {
     return wrappedArray;
   }
+
+
 
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
 
+
   public XmlItem nameString(String nameString) {
+    
     this.nameString = nameString;
     return this;
   }
@@ -259,15 +268,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNameString() {
     return nameString;
   }
+
+
 
   public void setNameString(String nameString) {
     this.nameString = nameString;
   }
 
+
   public XmlItem nameNumber(BigDecimal nameNumber) {
+    
     this.nameNumber = nameNumber;
     return this;
   }
@@ -278,15 +294,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNameNumber() {
     return nameNumber;
   }
+
+
 
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
 
+
   public XmlItem nameInteger(Integer nameInteger) {
+    
     this.nameInteger = nameInteger;
     return this;
   }
@@ -297,15 +320,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNameInteger() {
     return nameInteger;
   }
+
+
 
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
 
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
+    
     this.nameBoolean = nameBoolean;
     return this;
   }
@@ -316,15 +346,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
+
+
 
   public void setNameBoolean(Boolean nameBoolean) {
     this.nameBoolean = nameBoolean;
   }
 
+
   public XmlItem nameArray(List<Integer> nameArray) {
+    
     this.nameArray = nameArray;
     return this;
   }
@@ -343,15 +380,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameArray() {
     return nameArray;
   }
+
+
 
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
 
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
+    
     this.nameWrappedArray = nameWrappedArray;
     return this;
   }
@@ -370,15 +414,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNameWrappedArray() {
     return nameWrappedArray;
   }
+
+
 
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
 
+
   public XmlItem prefixString(String prefixString) {
+    
     this.prefixString = prefixString;
     return this;
   }
@@ -389,15 +440,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixString() {
     return prefixString;
   }
+
+
 
   public void setPrefixString(String prefixString) {
     this.prefixString = prefixString;
   }
 
+
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
+    
     this.prefixNumber = prefixNumber;
     return this;
   }
@@ -408,15 +466,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
+
+
 
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
 
+
   public XmlItem prefixInteger(Integer prefixInteger) {
+    
     this.prefixInteger = prefixInteger;
     return this;
   }
@@ -427,15 +492,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixInteger() {
     return prefixInteger;
   }
+
+
 
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
 
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
+    
     this.prefixBoolean = prefixBoolean;
     return this;
   }
@@ -446,15 +518,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
+
+
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
     this.prefixBoolean = prefixBoolean;
   }
 
+
   public XmlItem prefixArray(List<Integer> prefixArray) {
+    
     this.prefixArray = prefixArray;
     return this;
   }
@@ -473,15 +552,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
+
+
 
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
 
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
+    
     this.prefixWrappedArray = prefixWrappedArray;
     return this;
   }
@@ -500,15 +586,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixWrappedArray() {
     return prefixWrappedArray;
   }
+
+
 
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
 
+
   public XmlItem namespaceString(String namespaceString) {
+    
     this.namespaceString = namespaceString;
     return this;
   }
@@ -519,15 +612,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getNamespaceString() {
     return namespaceString;
   }
+
+
 
   public void setNamespaceString(String namespaceString) {
     this.namespaceString = namespaceString;
   }
 
+
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
+    
     this.namespaceNumber = namespaceNumber;
     return this;
   }
@@ -538,15 +638,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
+
+
 
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
 
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
+    
     this.namespaceInteger = namespaceInteger;
     return this;
   }
@@ -557,15 +664,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getNamespaceInteger() {
     return namespaceInteger;
   }
+
+
 
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
 
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
+    
     this.namespaceBoolean = namespaceBoolean;
     return this;
   }
@@ -576,15 +690,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
+
+
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
+    
     this.namespaceArray = namespaceArray;
     return this;
   }
@@ -603,15 +724,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
+
+
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
 
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
+    
     this.namespaceWrappedArray = namespaceWrappedArray;
     return this;
   }
@@ -630,15 +758,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getNamespaceWrappedArray() {
     return namespaceWrappedArray;
   }
+
+
 
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
 
+
   public XmlItem prefixNsString(String prefixNsString) {
+    
     this.prefixNsString = prefixNsString;
     return this;
   }
@@ -649,15 +784,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "string", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public String getPrefixNsString() {
     return prefixNsString;
   }
+
+
 
   public void setPrefixNsString(String prefixNsString) {
     this.prefixNsString = prefixNsString;
   }
 
+
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
+    
     this.prefixNsNumber = prefixNsNumber;
     return this;
   }
@@ -668,15 +810,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "1.234", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
+
+
 
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
 
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
+    
     this.prefixNsInteger = prefixNsInteger;
     return this;
   }
@@ -687,15 +836,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "-2", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Integer getPrefixNsInteger() {
     return prefixNsInteger;
   }
+
+
 
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
 
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
+    
     this.prefixNsBoolean = prefixNsBoolean;
     return this;
   }
@@ -706,15 +862,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(example = "true", value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
+
+
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
+    
     this.prefixNsArray = prefixNsArray;
     return this;
   }
@@ -733,15 +896,22 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsArray() {
     return prefixNsArray;
   }
+
+
 
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
 
+
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
+    
     this.prefixNsWrappedArray = prefixNsWrappedArray;
     return this;
   }
@@ -760,9 +930,14 @@ public class XmlItem {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
+
+
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     this.prefixNsWrappedArray = prefixNsWrappedArray;

--- a/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud-async/src/main/java/org/openapitools/model/Pet.java
@@ -24,7 +24,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/model/Pet.java
@@ -24,7 +24,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/client/petstore/spring-stubs/src/main/java/org/openapitools/model/Pet.java
@@ -24,7 +24,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -40,13 +40,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   private List<java.io.File> files = null;

--- a/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/model/Pet.java
@@ -20,7 +20,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-annotated-base-path/src/gen/java/org/openapitools/model/Pet.java
@@ -29,7 +29,7 @@ public class Pet  {
 
   @ApiModelProperty(value = "")
   @Valid
-  private Category category = null;
+  private Category category;
 
   @ApiModelProperty(example = "doggie", required = true, value = "")
   private String name;

--- a/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-cdi/src/gen/java/org/openapitools/model/Pet.java
@@ -24,7 +24,7 @@ public class Pet   {
   
   private Long id;
 
-  private Category category = null;
+  private Category category;
 
   private String name;
 

--- a/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf-non-spring-app/src/gen/java/org/openapitools/model/Pet.java
@@ -29,7 +29,7 @@ public class Pet  {
 
   @ApiModelProperty(value = "")
   @Valid
-  private Category category = null;
+  private Category category;
 
   @ApiModelProperty(example = "doggie", required = true, value = "")
   private String name;

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -50,15 +50,15 @@ public class AdditionalPropertiesClass  {
 
   @ApiModelProperty(value = "")
   @Valid
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @ApiModelProperty(value = "")
   @Valid
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @ApiModelProperty(value = "")
   @Valid
-  private Object anytype3 = null;
+  private Object anytype3;
  /**
    * Get mapString
    * @return mapString

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -19,7 +19,7 @@ public class FileSchemaTestClass  {
   
   @ApiModelProperty(value = "")
   @Valid
-  private java.io.File file = null;
+  private java.io.File file;
 
   @ApiModelProperty(value = "")
   @Valid

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/Pet.java
@@ -24,7 +24,7 @@ public class Pet  {
 
   @ApiModelProperty(value = "")
   @Valid
-  private Category category = null;
+  private Category category;
 
   @ApiModelProperty(example = "doggie", required = true, value = "")
   private String name;

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -65,15 +65,15 @@ public class AdditionalPropertiesClass  implements Serializable {
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
   @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
   @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
   @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -31,7 +31,7 @@ import javax.validation.Valid;
 public class FileSchemaTestClass  implements Serializable {
   public static final String JSON_PROPERTY_FILE = "file";
   @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
   @JsonProperty(JSON_PROPERTY_FILES)

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Pet.java
@@ -38,7 +38,7 @@ public class Pet  implements Serializable {
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
   @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
   @JsonProperty(JSON_PROPERTY_NAME)

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -30,7 +30,7 @@ import javax.validation.Valid;
 public class FileSchemaTestClass   {
   public static final String JSON_PROPERTY_FILE = "file";
   @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
   @JsonProperty(JSON_PROPERTY_FILES)

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineResponseDefault.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineResponseDefault.java
@@ -29,7 +29,7 @@ import javax.validation.Valid;
 public class InlineResponseDefault   {
   public static final String JSON_PROPERTY_STRING = "string";
   @JsonProperty(JSON_PROPERTY_STRING)
-  private Foo string = null;
+  private Foo string;
 
   public InlineResponseDefault string(Foo string) {
     this.string = string;

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Pet.java
@@ -37,7 +37,7 @@ public class Pet   {
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
   @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
   @JsonProperty(JSON_PROPERTY_NAME)

--- a/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/default/src/gen/java/org/openapitools/model/Pet.java
@@ -18,7 +18,7 @@ import io.swagger.annotations.*;
 public class Pet   {
   
   private Long id;
-  private Category category = null;
+  private Category category;
   private String name;
   private List<String> photoUrls = new ArrayList<String>();
   private List<Tag> tags = new ArrayList<Tag>();

--- a/samples/server/petstore/jaxrs-resteasy/eap-java8/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-java8/src/gen/java/org/openapitools/model/Pet.java
@@ -20,7 +20,7 @@ public class Pet   {
 
   private Long id;
 
-  private Category category = null;
+  private Category category;
 
   private String name;
 

--- a/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap-joda/src/gen/java/org/openapitools/model/Pet.java
@@ -20,7 +20,7 @@ public class Pet   {
 
   private Long id;
 
-  private Category category = null;
+  private Category category;
 
   private String name;
 

--- a/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/eap/src/gen/java/org/openapitools/model/Pet.java
@@ -20,7 +20,7 @@ public class Pet   {
 
   private Long id;
 
-  private Category category = null;
+  private Category category;
 
   private String name;
 

--- a/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-resteasy/joda/src/gen/java/org/openapitools/model/Pet.java
@@ -18,7 +18,7 @@ import io.swagger.annotations.*;
 public class Pet   {
   
   private Long id;
-  private Category category = null;
+  private Category category;
   private String name;
   private List<String> photoUrls = new ArrayList<String>();
   private List<Tag> tags = new ArrayList<Tag>();

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -28,9 +28,9 @@ public class AdditionalPropertiesClass  implements Serializable {
   private @Valid Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
   private @Valid Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
   private @Valid Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
-  private @Valid Object anytype1 = null;
-  private @Valid Object anytype2 = null;
-  private @Valid Object anytype3 = null;
+  private @Valid Object anytype1;
+  private @Valid Object anytype2;
+  private @Valid Object anytype3;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public class FileSchemaTestClass  implements Serializable {
   
-  private @Valid java.io.File file = null;
+  private @Valid java.io.File file;
   private @Valid List<java.io.File> files = new ArrayList<java.io.File>();
 
   /**

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public class Pet  implements Serializable {
   
   private @Valid Long id;
-  private @Valid Category category = null;
+  private @Valid Category category;
   private @Valid String name;
   private @Valid List<String> photoUrls = new ArrayList<String>();
   private @Valid List<Tag> tags = new ArrayList<Tag>();

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -28,9 +28,9 @@ public class AdditionalPropertiesClass  implements Serializable {
   private @Valid Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
   private @Valid Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
   private @Valid Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
-  private @Valid Object anytype1 = null;
-  private @Valid Object anytype2 = null;
-  private @Valid Object anytype3 = null;
+  private @Valid Object anytype1;
+  private @Valid Object anytype2;
+  private @Valid Object anytype3;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public class FileSchemaTestClass  implements Serializable {
   
-  private @Valid java.io.File file = null;
+  private @Valid java.io.File file;
   private @Valid List<java.io.File> files = new ArrayList<java.io.File>();
 
   /**

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public class Pet  implements Serializable {
   
   private @Valid Long id;
-  private @Valid Category category = null;
+  private @Valid Category category;
   private @Valid String name;
   private @Valid List<String> photoUrls = new ArrayList<String>();
   private @Valid List<Tag> tags = new ArrayList<Tag>();

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -64,15 +64,15 @@ public class AdditionalPropertiesClass   {
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
   @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
   @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
   @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -30,7 +30,7 @@ import javax.validation.Valid;
 public class FileSchemaTestClass   {
   public static final String JSON_PROPERTY_FILE = "file";
   @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
   @JsonProperty(JSON_PROPERTY_FILES)

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Pet.java
@@ -37,7 +37,7 @@ public class Pet   {
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
   @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
   @JsonProperty(JSON_PROPERTY_NAME)

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -64,15 +64,15 @@ public class AdditionalPropertiesClass   {
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
   @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
   @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
   @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -30,7 +30,7 @@ import javax.validation.Valid;
 public class FileSchemaTestClass   {
   public static final String JSON_PROPERTY_FILE = "file";
   @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
   @JsonProperty(JSON_PROPERTY_FILES)

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Pet.java
@@ -37,7 +37,7 @@ public class Pet   {
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
   @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
   @JsonProperty(JSON_PROPERTY_NAME)

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -64,15 +64,15 @@ public class AdditionalPropertiesClass   {
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
   @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
   @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
   @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -30,7 +30,7 @@ import javax.validation.Valid;
 public class FileSchemaTestClass   {
   public static final String JSON_PROPERTY_FILE = "file";
   @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
   @JsonProperty(JSON_PROPERTY_FILES)

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Pet.java
@@ -37,7 +37,7 @@ public class Pet   {
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
   @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
   @JsonProperty(JSON_PROPERTY_NAME)

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -64,15 +64,15 @@ public class AdditionalPropertiesClass   {
 
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
   @JsonProperty(JSON_PROPERTY_ANYTYPE1)
-  private Object anytype1 = null;
+  private Object anytype1;
 
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
   @JsonProperty(JSON_PROPERTY_ANYTYPE2)
-  private Object anytype2 = null;
+  private Object anytype2;
 
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
   @JsonProperty(JSON_PROPERTY_ANYTYPE3)
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -30,7 +30,7 @@ import javax.validation.Valid;
 public class FileSchemaTestClass   {
   public static final String JSON_PROPERTY_FILE = "file";
   @JsonProperty(JSON_PROPERTY_FILE)
-  private java.io.File file = null;
+  private java.io.File file;
 
   public static final String JSON_PROPERTY_FILES = "files";
   @JsonProperty(JSON_PROPERTY_FILES)

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Pet.java
@@ -37,7 +37,7 @@ public class Pet   {
 
   public static final String JSON_PROPERTY_CATEGORY = "category";
   @JsonProperty(JSON_PROPERTY_CATEGORY)
-  private Category category = null;
+  private Category category;
 
   public static final String JSON_PROPERTY_NAME = "name";
   @JsonProperty(JSON_PROPERTY_NAME)

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -51,13 +51,13 @@ public class AdditionalPropertiesClass   {
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
   @JsonProperty("anytype_1")
-  private Object anytype1 = null;
+  private Object anytype1;
 
   @JsonProperty("anytype_2")
-  private Object anytype2 = null;
+  private Object anytype2;
 
   @JsonProperty("anytype_3")
-  private Object anytype3 = null;
+  private Object anytype3;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     this.mapString = mapString;

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FileSchemaTestClass.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.*;
 
 public class FileSchemaTestClass   {
   @JsonProperty("file")
-  private java.io.File file = null;
+  private java.io.File file;
 
   @JsonProperty("files")
   @Valid

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Pet.java
@@ -23,7 +23,7 @@ public class Pet   {
   private Long id;
 
   @JsonProperty("category")
-  private Category category = null;
+  private Category category;
 
   @JsonProperty("name")
   private String name;


### PR DESCRIPTION
# PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)

### Description of the PR

This is my attempt to fix https://github.com/OpenAPITools/openapi-generator/issues/3435. Basically it makes sure that explicit `null` values can be sent for nullable fields:

* For a required nullable field, the `null` is always sent when that's the value.
* For an optional (not required) nullable field, I introduced a simple new `Optional` class with `OptionalFilter` that make sure that the `null` is sent if and only if it was set explicitly. AFAICS, the API of any of the generated classes didn't change in a backwards-incompatible way.

Discussion points:
* I added the `Optional` since `java.util.Optional` was added in JDK 8 and the templates still have support for previous Java versions. If desired, I can replace this with a different (third party) implementation pretty easily.
* I didn't run the `./bin/...` generators yet to keep the PR clean and reviewable. I'm planning to run it later.
* I only added this for jackson, as I didn't figure out an easy way to do this for gson. I could try working on a different PR that would do this for gson, but that would take me a lot more time.