### PR TITLE
[java-client][okhttp-gson] fixes for interceptors in ApiClient.java

### DIFF
--- a/CI/samples.ci/client/petstore/java/test-manual/okhttp-gson/ApiClientTest.java
+++ b/CI/samples.ci/client/petstore/java/test-manual/okhttp-gson/ApiClientTest.java
@@ -335,7 +335,7 @@ public class ApiClientTest {
         OkHttpClient oldClient = apiClient.getHttpClient();
         assertEquals(1, oldClient.networkInterceptors().size());
 
-        OkHttpClient newClient = new OkHttpClient();
+        OkHttpClient newClient = apiClient.getHttpClient().newBuilder().build();
         apiClient.setHttpClient(newClient);
         assertEquals(1, apiClient.getHttpClient().networkInterceptors().size());
         apiClient.setHttpClient(newClient);

--- a/CI/samples.ci/client/petstore/java/test-manual/okhttp-gson/ApiClientTest.java
+++ b/CI/samples.ci/client/petstore/java/test-manual/okhttp-gson/ApiClientTest.java
@@ -10,6 +10,7 @@ import java.util.TimeZone;
 
 import org.junit.*;
 import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
 
 
 public class ApiClientTest {
@@ -329,24 +330,18 @@ public class ApiClientTest {
         assertEquals("sun.gif", apiClient.sanitizeFilename(".\\sun.gif"));
     }
 
-
     @Test
-    public void testInterceptorCleanupWithNewClient() {
+    public void testNewHttpClient() {
         OkHttpClient oldClient = apiClient.getHttpClient();
-        assertEquals(1, oldClient.networkInterceptors().size());
-
-        OkHttpClient newClient = apiClient.getHttpClient().newBuilder().build();
-        apiClient.setHttpClient(newClient);
-        assertEquals(1, apiClient.getHttpClient().networkInterceptors().size());
-        apiClient.setHttpClient(newClient);
-        assertEquals(1, apiClient.getHttpClient().networkInterceptors().size());
+        apiClient.setHttpClient(oldClient.newBuilder().build());
+        assertThat(apiClient.getHttpClient(), is(not(oldClient)));
     }
 
-    @Test
-    public void testInterceptorCleanupWithSameClient() {
-        OkHttpClient oldClient = apiClient.getHttpClient();
-        assertEquals(1, oldClient.networkInterceptors().size());
-        apiClient.setHttpClient(oldClient);
-        assertEquals(1, apiClient.getHttpClient().networkInterceptors().size());
+    /**
+     * Tests the invariant that the HttpClient for the ApiClient must never be null
+     */
+    @Test(expected = NullPointerException.class)
+    public void testNullHttpClient() {
+        apiClient.setHttpClient(null);
     }
 }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -194,16 +194,7 @@ public class ApiClient {
      */
     public ApiClient setHttpClient(OkHttpClient newHttpClient) {
         if(!httpClient.equals(newHttpClient)) {
-            OkHttpClient.Builder builder = newHttpClient.newBuilder();
-            Iterator<Interceptor> networkInterceptorIterator = httpClient.networkInterceptors().iterator();
-            while(networkInterceptorIterator.hasNext()) {
-                builder.addNetworkInterceptor(networkInterceptorIterator.next());
-            }
-            Iterator<Interceptor> interceptorIterator = httpClient.interceptors().iterator();
-            while(interceptorIterator.hasNext()) {
-                builder.addInterceptor(interceptorIterator.next());
-            }
-            this.httpClient = builder.build();
+            this.httpClient = newHttpClient;
         }
         return this;
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -187,15 +187,14 @@ public class ApiClient {
     }
 
     /**
-     * Set HTTP client
+     * Set HTTP client, which must never be null.
      *
      * @param newHttpClient An instance of OkHttpClient
      * @return Api Client
+     * @throws NullPointerException when newHttpClient is null
      */
     public ApiClient setHttpClient(OkHttpClient newHttpClient) {
-        if(!httpClient.equals(newHttpClient)) {
-            this.httpClient = newHttpClient;
-        }
+        this.httpClient = Objects.requireNonNull(newHttpClient, "HttpClient must not be null!");
         return this;
     }
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
@@ -177,16 +177,7 @@ public class ApiClient {
      */
     public ApiClient setHttpClient(OkHttpClient newHttpClient) {
         if(!httpClient.equals(newHttpClient)) {
-            OkHttpClient.Builder builder = newHttpClient.newBuilder();
-            Iterator<Interceptor> networkInterceptorIterator = httpClient.networkInterceptors().iterator();
-            while(networkInterceptorIterator.hasNext()) {
-                builder.addNetworkInterceptor(networkInterceptorIterator.next());
-            }
-            Iterator<Interceptor> interceptorIterator = httpClient.interceptors().iterator();
-            while(interceptorIterator.hasNext()) {
-                builder.addInterceptor(interceptorIterator.next());
-            }
-            this.httpClient = builder.build();
+            this.httpClient = newHttpClient;
         }
         return this;
     }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
@@ -170,15 +170,14 @@ public class ApiClient {
     }
 
     /**
-     * Set HTTP client
+     * Set HTTP client, which must never be null.
      *
      * @param newHttpClient An instance of OkHttpClient
      * @return Api Client
+     * @throws NullPointerException when newHttpClient is null
      */
     public ApiClient setHttpClient(OkHttpClient newHttpClient) {
-        if(!httpClient.equals(newHttpClient)) {
-            this.httpClient = newHttpClient;
-        }
+        this.httpClient = Objects.requireNonNull(newHttpClient, "HttpClient must not be null!");
         return this;
     }
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -177,16 +177,7 @@ public class ApiClient {
      */
     public ApiClient setHttpClient(OkHttpClient newHttpClient) {
         if(!httpClient.equals(newHttpClient)) {
-            OkHttpClient.Builder builder = newHttpClient.newBuilder();
-            Iterator<Interceptor> networkInterceptorIterator = httpClient.networkInterceptors().iterator();
-            while(networkInterceptorIterator.hasNext()) {
-                builder.addNetworkInterceptor(networkInterceptorIterator.next());
-            }
-            Iterator<Interceptor> interceptorIterator = httpClient.interceptors().iterator();
-            while(interceptorIterator.hasNext()) {
-                builder.addInterceptor(interceptorIterator.next());
-            }
-            this.httpClient = builder.build();
+            this.httpClient = newHttpClient;
         }
         return this;
     }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -170,15 +170,14 @@ public class ApiClient {
     }
 
     /**
-     * Set HTTP client
+     * Set HTTP client, which must never be null.
      *
      * @param newHttpClient An instance of OkHttpClient
      * @return Api Client
+     * @throws NullPointerException when newHttpClient is null
      */
     public ApiClient setHttpClient(OkHttpClient newHttpClient) {
-        if(!httpClient.equals(newHttpClient)) {
-            this.httpClient = newHttpClient;
-        }
+        this.httpClient = Objects.requireNonNull(newHttpClient, "HttpClient must not be null!");
         return this;
     }
 

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -335,7 +335,7 @@ public class ApiClientTest {
         OkHttpClient oldClient = apiClient.getHttpClient();
         assertEquals(1, oldClient.networkInterceptors().size());
 
-        OkHttpClient newClient = new OkHttpClient();
+        OkHttpClient newClient = apiClient.getHttpClient().newBuilder().build();
         apiClient.setHttpClient(newClient);
         assertEquals(1, apiClient.getHttpClient().networkInterceptors().size());
         apiClient.setHttpClient(newClient);

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/ApiClientTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/ApiClientTest.java
@@ -10,6 +10,7 @@ import java.util.TimeZone;
 
 import org.junit.*;
 import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
 
 
 public class ApiClientTest {
@@ -329,24 +330,18 @@ public class ApiClientTest {
         assertEquals("sun.gif", apiClient.sanitizeFilename(".\\sun.gif"));
     }
 
-
     @Test
-    public void testInterceptorCleanupWithNewClient() {
+    public void testNewHttpClient() {
         OkHttpClient oldClient = apiClient.getHttpClient();
-        assertEquals(1, oldClient.networkInterceptors().size());
-
-        OkHttpClient newClient = apiClient.getHttpClient().newBuilder().build();
-        apiClient.setHttpClient(newClient);
-        assertEquals(1, apiClient.getHttpClient().networkInterceptors().size());
-        apiClient.setHttpClient(newClient);
-        assertEquals(1, apiClient.getHttpClient().networkInterceptors().size());
+        apiClient.setHttpClient(oldClient.newBuilder().build());
+        assertThat(apiClient.getHttpClient(), is(not(oldClient)));
     }
 
-    @Test
-    public void testInterceptorCleanupWithSameClient() {
-        OkHttpClient oldClient = apiClient.getHttpClient();
-        assertEquals(1, oldClient.networkInterceptors().size());
-        apiClient.setHttpClient(oldClient);
-        assertEquals(1, apiClient.getHttpClient().networkInterceptors().size());
+    /**
+     * Tests the invariant that the HttpClient for the ApiClient must never be null
+     */
+    @Test(expected = NullPointerException.class)
+    public void testNullHttpClient() {
+        apiClient.setHttpClient(null);
     }
 }


### PR DESCRIPTION
ApiClient for Okhttp3 must not copy the interceptors when setting the HttpClient.

fixes #3497 