### PR TITLE
Fix kotlin templates

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -1191,7 +1191,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
         for (String key : definitions.keySet()) {
             Schema schema = definitions.get(key);
             if (schema == null)
-                throw new RuntimeException("schema cannot be null in processMoels");
+                throw new RuntimeException("schema cannot be null in processModels");
             CodegenModel cm = config.fromModel(key, schema);
             Map<String, Object> mo = new HashMap<String, Object>();
             mo.put("model", cm);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -176,7 +176,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         typeMapping.put("binary", "kotlin.Array<kotlin.Byte>");
         typeMapping.put("Date", "java.time.LocalDate");
         typeMapping.put("DateTime", "java.time.LocalDateTime");
-        typeMapping.put("ref", "kotlin.Any");
 
         instantiationTypes.put("array", "kotlin.arrayOf");
         instantiationTypes.put("list", "kotlin.arrayOf");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -176,6 +176,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         typeMapping.put("binary", "kotlin.Array<kotlin.Byte>");
         typeMapping.put("Date", "java.time.LocalDate");
         typeMapping.put("DateTime", "java.time.LocalDateTime");
+        typeMapping.put("ref", "kotlin.Any");
 
         instantiationTypes.put("array", "kotlin.arrayOf");
         instantiationTypes.put("list", "kotlin.arrayOf");
@@ -612,6 +613,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         StringBuilder instantiationType = new StringBuilder(arrayType);
         Schema items = arr.getItems();
         String nestedType = getTypeDeclaration(items);
+        additionalProperties.put("nestedType", nestedType);
         // TODO: We may want to differentiate here between generics and primitive arrays.
         instantiationType.append("<").append(nestedType).append(">");
         return instantiationType.toString();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -149,6 +149,7 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
         if (CollectionType.LIST.value.equals(collectionType)) {
             typeMapping.put("array", "kotlin.collections.List");
             typeMapping.put("list", "kotlin.collections.List");
+            additionalProperties.put("isList", true);
         }
 
         supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));

--- a/modules/openapi-generator/src/main/resources/kotlin-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/README.mustache
@@ -2,7 +2,7 @@
 
 ## Requires
 
-* Kotlin 1.3.31
+* Kotlin 1.3.41
 * Gradle 4.9
 
 ## Build

--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.3.41'
 
     repositories {
         mavenCentral()
@@ -32,7 +32,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.8.0"
     compile "com.squareup.moshi:moshi-adapters:1.8.0"
-    compile "com.squareup.okhttp3:okhttp:3.14.2"
+    compile "com.squareup.okhttp3:okhttp:4.0.1"
     {{#threetenbp}}
     compile "org.threeten:threetenbp:1.3.8"
     {{/threetenbp}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -25,7 +25,7 @@ data class {{classname}} (
     * {{{description}}}
     * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
     */
-    enum class {{nameInCamelCase}}(val value: {{dataType}}){
+    enum class {{{nameInCamelCase}}}(val value: {{#isListContainer}}{{{ nestedType }}}{{/isListContainer}}{{^isListContainer}}{{{dataType}}}{{/isListContainer}}){
     {{#allowableValues}}{{#enumVars}}
         @Json(name = {{{value}}})
         {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_opt_var.mustache
@@ -2,4 +2,4 @@
     /* {{{description}}} */
 {{/description}}
     @Json(name = "{{{baseName}}}")
-    val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}
+    val {{{name}}}: {{#isEnum}}{{#isListContainer}}{{#isList}}kotlin.collections.List{{/isList}}{{^isList}}kotlin.Array{{/isList}}<{{classname}}.{{{nameInCamelCase}}}>{{/isListContainer}}{{^isListContainer}}{{classname}}.{{{nameInCamelCase}}}{{/isListContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{#defaultvalue}}{{defaultvalue}}{{/defaultvalue}}{{^defaultvalue}}null{{/defaultvalue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class_req_var.mustache
@@ -2,4 +2,4 @@
     /* {{{description}}} */
 {{/description}}
     @Json(name = "{{{baseName}}}")
-    val {{{name}}}: {{#isEnum}}{{classname}}.{{nameInCamelCase}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}
+    val {{{name}}}: {{#isEnum}}{{#isListContainer}}{{#isList}}kotlin.collections.List{{/isList}}{{^isList}}kotlin.Array{{/isList}}<{{classname}}.{{{nameInCamelCase}}}>{{/isListContainer}}{{^isListContainer}}{{classname}}.{{{nameInCamelCase}}}{{/isListContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -4,9 +4,21 @@ import com.squareup.moshi.Json
 * {{{description}}}
 * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
 */
-enum class {{classname}}(val value: {{dataType}}){
+enum class {{classname}}(val value: {{{dataType}}}){
+
 {{#allowableValues}}{{#enumVars}}
     @Json(name = {{^isString}}"{{/isString}}{{{value}}}{{^isString}}"{{/isString}})
+    {{#isListContainer}}
+    {{#isList}}
+    {{&name}}(listOf({{{value}}})){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{/isList}}
+    {{^isList}}
+    {{&name}}(arrayOf({{{value}}})){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{/isList}}
+    {{/isListContainer}}
+    {{^isListContainer}}
     {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{/isListContainer}}
+
 {{/enumVars}}{{/allowableValues}}
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiClient.kt.mustache
@@ -2,10 +2,12 @@ package {{packageName}}.infrastructure
 
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
-import okhttp3.MediaType
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.FormBody
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.ResponseBody
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import java.io.File
 
@@ -29,8 +31,8 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> RequestBody.create(
-                MediaType.parse(mediaType), content
+            content is File -> content.asRequestBody(
+                mediaType.toMediaTypeOrNull()
             )
             mediaType == FormDataMediaType || mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
@@ -41,8 +43,8 @@ open class ApiClient(val baseUrl: String) {
                     }
                 }.build()
             }
-            mediaType == JsonMediaType -> RequestBody.create(
-                MediaType.parse(mediaType), Serializer.moshi.adapter(T::class.java).toJson(content)
+            mediaType == JsonMediaType -> Serializer.moshi.adapter(T::class.java).toJson(content).toRequestBody(
+                mediaType.toMediaTypeOrNull()
             )
             mediaType == XmlMediaType -> TODO("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -64,7 +66,7 @@ open class ApiClient(val baseUrl: String) {
     }
 
     protected inline fun <reified T: Any?> request(requestConfig: RequestConfig, body : Any? = null): ApiInfrastructureResponse<T?> {
-        val httpUrl = HttpUrl.parse(baseUrl) ?: throw IllegalStateException("baseUrl is invalid.")
+        val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         val url = httpUrl.newBuilder()
             .addPathSegments(requestConfig.path.trimStart('/'))
@@ -114,29 +116,29 @@ open class ApiClient(val baseUrl: String) {
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         when {
             response.isRedirect -> return Redirection(
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isInformational -> return Informational(
-                    response.message(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.message,
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isSuccessful -> return Success(
-                    responseBody(response.body(), accept),
-                    response.code(),
-                    response.headers().toMultimap()
+                    responseBody(response.body, accept),
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isClientError -> return ClientError(
-                    response.body()?.string(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.body?.string(),
+                    response.code,
+                    response.headers.toMultimap()
             )
             else -> return ServerError(
                     null,
-                    response.body()?.string(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.body?.string(),
+                    response.code,
+                    response.headers.toMultimap()
             )
         }
     }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ResponseExtensions.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ResponseExtensions.kt.mustache
@@ -5,19 +5,19 @@ import okhttp3.Response
 /**
  * Provides an extension to evaluation whether the response is a 1xx code
  */
-val Response.isInformational : Boolean get() = this.code() in 100..199
+val Response.isInformational : Boolean get() = this.code in 100..199
 
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
-val Response.isRedirect : Boolean get() = this.code() in 300..399
+val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**
  * Provides an extension to evaluation whether the response is a 4xx code
  */
-val Response.isClientError : Boolean get() = this.code() in 400..499
+val Response.isClientError : Boolean get() = this.code in 400..499
 
 /**
  * Provides an extension to evaluation whether the response is a 5xx (Standard) through 999 (non-standard) code
  */
-val Response.isServerError : Boolean get() = this.code() in 500..999
+val Response.isServerError : Boolean get() = this.code in 500..999

--- a/modules/openapi-generator/src/main/resources/kotlin-client/model.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/model.mustache
@@ -6,6 +6,6 @@ package {{modelPackage}}
 
 {{#models}}
 {{#model}}
-{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{#isAlias}}typealias {{classname}} = {{dataType}}{{/isAlias}}{{^isAlias}}{{>data_class}}{{/isAlias}}{{/isEnum}}
+{{#isEnum}}{{>enum_class}}{{/isEnum}}{{^isEnum}}{{#isAlias}}typealias {{classname}} = {{{dataType}}}{{/isAlias}}{{^isAlias}}{{>data_class}}{{/isAlias}}{{/isEnum}}
 {{/model}}
 {{/models}}

--- a/samples/client/petstore/kotlin-string/README.md
+++ b/samples/client/petstore/kotlin-string/README.md
@@ -2,7 +2,7 @@
 
 ## Requires
 
-* Kotlin 1.3.31
+* Kotlin 1.3.41
 * Gradle 4.9
 
 ## Build

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.3.41'
 
     repositories {
         mavenCentral()
@@ -32,6 +32,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.8.0"
     compile "com.squareup.moshi:moshi-adapters:1.8.0"
-    compile "com.squareup.okhttp3:okhttp:3.14.2"
+    compile "com.squareup.okhttp3:okhttp:4.0.1"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -2,10 +2,12 @@ package org.openapitools.client.infrastructure
 
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
-import okhttp3.MediaType
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.FormBody
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.ResponseBody
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import java.io.File
 
@@ -29,8 +31,8 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> RequestBody.create(
-                MediaType.parse(mediaType), content
+            content is File -> content.asRequestBody(
+                mediaType.toMediaTypeOrNull()
             )
             mediaType == FormDataMediaType || mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
@@ -41,8 +43,8 @@ open class ApiClient(val baseUrl: String) {
                     }
                 }.build()
             }
-            mediaType == JsonMediaType -> RequestBody.create(
-                MediaType.parse(mediaType), Serializer.moshi.adapter(T::class.java).toJson(content)
+            mediaType == JsonMediaType -> Serializer.moshi.adapter(T::class.java).toJson(content).toRequestBody(
+                mediaType.toMediaTypeOrNull()
             )
             mediaType == XmlMediaType -> TODO("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -64,7 +66,7 @@ open class ApiClient(val baseUrl: String) {
     }
 
     protected inline fun <reified T: Any?> request(requestConfig: RequestConfig, body : Any? = null): ApiInfrastructureResponse<T?> {
-        val httpUrl = HttpUrl.parse(baseUrl) ?: throw IllegalStateException("baseUrl is invalid.")
+        val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         val url = httpUrl.newBuilder()
             .addPathSegments(requestConfig.path.trimStart('/'))
@@ -114,29 +116,29 @@ open class ApiClient(val baseUrl: String) {
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         when {
             response.isRedirect -> return Redirection(
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isInformational -> return Informational(
-                    response.message(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.message,
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isSuccessful -> return Success(
-                    responseBody(response.body(), accept),
-                    response.code(),
-                    response.headers().toMultimap()
+                    responseBody(response.body, accept),
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isClientError -> return ClientError(
-                    response.body()?.string(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.body?.string(),
+                    response.code,
+                    response.headers.toMultimap()
             )
             else -> return ServerError(
                     null,
-                    response.body()?.string(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.body?.string(),
+                    response.code,
+                    response.headers.toMultimap()
             )
         }
     }

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -5,19 +5,19 @@ import okhttp3.Response
 /**
  * Provides an extension to evaluation whether the response is a 1xx code
  */
-val Response.isInformational : Boolean get() = this.code() in 100..199
+val Response.isInformational : Boolean get() = this.code in 100..199
 
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
-val Response.isRedirect : Boolean get() = this.code() in 300..399
+val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**
  * Provides an extension to evaluation whether the response is a 4xx code
  */
-val Response.isClientError : Boolean get() = this.code() in 400..499
+val Response.isClientError : Boolean get() = this.code in 400..499
 
 /**
  * Provides an extension to evaluation whether the response is a 5xx (Standard) through 999 (non-standard) code
  */
-val Response.isServerError : Boolean get() = this.code() in 500..999
+val Response.isServerError : Boolean get() = this.code in 500..999

--- a/samples/client/petstore/kotlin-threetenbp/README.md
+++ b/samples/client/petstore/kotlin-threetenbp/README.md
@@ -2,7 +2,7 @@
 
 ## Requires
 
-* Kotlin 1.3.31
+* Kotlin 1.3.41
 * Gradle 4.9
 
 ## Build

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.3.41'
 
     repositories {
         mavenCentral()
@@ -32,7 +32,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.8.0"
     compile "com.squareup.moshi:moshi-adapters:1.8.0"
-    compile "com.squareup.okhttp3:okhttp:3.14.2"
+    compile "com.squareup.okhttp3:okhttp:4.0.1"
     compile "org.threeten:threetenbp:1.3.8"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -2,10 +2,12 @@ package org.openapitools.client.infrastructure
 
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
-import okhttp3.MediaType
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.FormBody
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.ResponseBody
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import java.io.File
 
@@ -29,8 +31,8 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> RequestBody.create(
-                MediaType.parse(mediaType), content
+            content is File -> content.asRequestBody(
+                mediaType.toMediaTypeOrNull()
             )
             mediaType == FormDataMediaType || mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
@@ -41,8 +43,8 @@ open class ApiClient(val baseUrl: String) {
                     }
                 }.build()
             }
-            mediaType == JsonMediaType -> RequestBody.create(
-                MediaType.parse(mediaType), Serializer.moshi.adapter(T::class.java).toJson(content)
+            mediaType == JsonMediaType -> Serializer.moshi.adapter(T::class.java).toJson(content).toRequestBody(
+                mediaType.toMediaTypeOrNull()
             )
             mediaType == XmlMediaType -> TODO("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -64,7 +66,7 @@ open class ApiClient(val baseUrl: String) {
     }
 
     protected inline fun <reified T: Any?> request(requestConfig: RequestConfig, body : Any? = null): ApiInfrastructureResponse<T?> {
-        val httpUrl = HttpUrl.parse(baseUrl) ?: throw IllegalStateException("baseUrl is invalid.")
+        val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         val url = httpUrl.newBuilder()
             .addPathSegments(requestConfig.path.trimStart('/'))
@@ -114,29 +116,29 @@ open class ApiClient(val baseUrl: String) {
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         when {
             response.isRedirect -> return Redirection(
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isInformational -> return Informational(
-                    response.message(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.message,
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isSuccessful -> return Success(
-                    responseBody(response.body(), accept),
-                    response.code(),
-                    response.headers().toMultimap()
+                    responseBody(response.body, accept),
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isClientError -> return ClientError(
-                    response.body()?.string(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.body?.string(),
+                    response.code,
+                    response.headers.toMultimap()
             )
             else -> return ServerError(
                     null,
-                    response.body()?.string(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.body?.string(),
+                    response.code,
+                    response.headers.toMultimap()
             )
         }
     }

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -5,19 +5,19 @@ import okhttp3.Response
 /**
  * Provides an extension to evaluation whether the response is a 1xx code
  */
-val Response.isInformational : Boolean get() = this.code() in 100..199
+val Response.isInformational : Boolean get() = this.code in 100..199
 
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
-val Response.isRedirect : Boolean get() = this.code() in 300..399
+val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**
  * Provides an extension to evaluation whether the response is a 4xx code
  */
-val Response.isClientError : Boolean get() = this.code() in 400..499
+val Response.isClientError : Boolean get() = this.code in 400..499
 
 /**
  * Provides an extension to evaluation whether the response is a 5xx (Standard) through 999 (non-standard) code
  */
-val Response.isServerError : Boolean get() = this.code() in 500..999
+val Response.isServerError : Boolean get() = this.code in 500..999

--- a/samples/client/petstore/kotlin/README.md
+++ b/samples/client/petstore/kotlin/README.md
@@ -2,7 +2,7 @@
 
 ## Requires
 
-* Kotlin 1.3.31
+* Kotlin 1.3.41
 * Gradle 4.9
 
 ## Build

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -7,7 +7,7 @@ wrapper {
 }
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.3.41'
 
     repositories {
         mavenCentral()
@@ -32,6 +32,6 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "com.squareup.moshi:moshi-kotlin:1.8.0"
     compile "com.squareup.moshi:moshi-adapters:1.8.0"
-    compile "com.squareup.okhttp3:okhttp:3.14.2"
+    compile "com.squareup.okhttp3:okhttp:4.0.1"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.1.0"
 }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -2,10 +2,12 @@ package org.openapitools.client.infrastructure
 
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
-import okhttp3.MediaType
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.FormBody
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.ResponseBody
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import java.io.File
 
@@ -29,8 +31,8 @@ open class ApiClient(val baseUrl: String) {
 
     protected inline fun <reified T> requestBody(content: T, mediaType: String = JsonMediaType): RequestBody =
         when {
-            content is File -> RequestBody.create(
-                MediaType.parse(mediaType), content
+            content is File -> content.asRequestBody(
+                mediaType.toMediaTypeOrNull()
             )
             mediaType == FormDataMediaType || mediaType == FormUrlEncMediaType -> {
                 FormBody.Builder().apply {
@@ -41,8 +43,8 @@ open class ApiClient(val baseUrl: String) {
                     }
                 }.build()
             }
-            mediaType == JsonMediaType -> RequestBody.create(
-                MediaType.parse(mediaType), Serializer.moshi.adapter(T::class.java).toJson(content)
+            mediaType == JsonMediaType -> Serializer.moshi.adapter(T::class.java).toJson(content).toRequestBody(
+                mediaType.toMediaTypeOrNull()
             )
             mediaType == XmlMediaType -> TODO("xml not currently supported.")
             // TODO: this should be extended with other serializers
@@ -64,7 +66,7 @@ open class ApiClient(val baseUrl: String) {
     }
 
     protected inline fun <reified T: Any?> request(requestConfig: RequestConfig, body : Any? = null): ApiInfrastructureResponse<T?> {
-        val httpUrl = HttpUrl.parse(baseUrl) ?: throw IllegalStateException("baseUrl is invalid.")
+        val httpUrl = baseUrl.toHttpUrlOrNull() ?: throw IllegalStateException("baseUrl is invalid.")
 
         val url = httpUrl.newBuilder()
             .addPathSegments(requestConfig.path.trimStart('/'))
@@ -114,29 +116,29 @@ open class ApiClient(val baseUrl: String) {
         // TODO: handle specific mapping types. e.g. Map<int, Class<?>>
         when {
             response.isRedirect -> return Redirection(
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isInformational -> return Informational(
-                    response.message(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.message,
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isSuccessful -> return Success(
-                    responseBody(response.body(), accept),
-                    response.code(),
-                    response.headers().toMultimap()
+                    responseBody(response.body, accept),
+                    response.code,
+                    response.headers.toMultimap()
             )
             response.isClientError -> return ClientError(
-                    response.body()?.string(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.body?.string(),
+                    response.code,
+                    response.headers.toMultimap()
             )
             else -> return ServerError(
                     null,
-                    response.body()?.string(),
-                    response.code(),
-                    response.headers().toMultimap()
+                    response.body?.string(),
+                    response.code,
+                    response.headers.toMultimap()
             )
         }
     }

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ResponseExtensions.kt
@@ -5,19 +5,19 @@ import okhttp3.Response
 /**
  * Provides an extension to evaluation whether the response is a 1xx code
  */
-val Response.isInformational : Boolean get() = this.code() in 100..199
+val Response.isInformational : Boolean get() = this.code in 100..199
 
 /**
  * Provides an extension to evaluation whether the response is a 3xx code
  */
-val Response.isRedirect : Boolean get() = this.code() in 300..399
+val Response.isRedirect : Boolean get() = this.code in 300..399
 
 /**
  * Provides an extension to evaluation whether the response is a 4xx code
  */
-val Response.isClientError : Boolean get() = this.code() in 400..499
+val Response.isClientError : Boolean get() = this.code in 400..499
 
 /**
  * Provides an extension to evaluation whether the response is a 5xx (Standard) through 999 (non-standard) code
  */
-val Response.isServerError : Boolean get() = this.code() in 500..999
+val Response.isServerError : Boolean get() = this.code in 500..999


### PR DESCRIPTION
Fix escaping of dataType field.
Fix handling of arrays/lists of enums.
Update okhttp to 4.0.1
main issue was:
```val `data`: ApiResponseListString.`Data`? = null,
...
enum class `Data`(val value: kotlin.collection.List<kotlin.String>)```
instead of
```val `data`: kotlin.collection.List<ApiResponseListString.`Data`>? = null,`
`enum class `Data`(val value: kotlin.String)```