### PR TITLE
[C++][Qt5] Remove QRandomGenerator

### DIFF
--- a/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.cpp
@@ -1,10 +1,11 @@
 #include "UserApiTests.h"
 
+#include <stdlib.h>
 #include <QJsonDocument>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QDebug>
-#include <QRandomGenerator>
+
 UserApiTests::UserApiTests () {}
 
 UserApiTests::~UserApiTests () {
@@ -32,7 +33,7 @@ OAIUser UserApiTests::createRandomUser() {
     user.setPhone(QString("123456789"));
     user.setUsername(QString("janedoe"));
     user.setPassword(QString("secretPassword"));
-    user.setUserStatus(static_cast<int>(QRandomGenerator::system()->generate()));
+    user.setUserStatus(static_cast<int>(rand()));
     return user;
 }
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Remove `QRandomGenerator` from the tests.
It adds unneeded dependency to `Qt 5.10` which can be done by a simple `rand()` function

`cc`

@MartinDelille 

