### PR TITLE
Fix PHP Symfony non-primitive return type being forced to be an array

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -406,7 +406,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
             // Create a variable to display the correct return type in comments for interfaces
             if (op.returnType != null) {
                 op.vendorExtensions.put("x-commentType", op.returnType);
-                if (!op.returnTypeIsPrimitive) {
+                if (op.returnContainer != null && op.returnContainer.equals("array")) {
                     op.vendorExtensions.put("x-commentType", op.returnType + "[]");
                 }
             } else {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
@@ -127,7 +127,7 @@ interface PetApiInterface
      * @param  integer $responseCode     The HTTP response code to return
      * @param  array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return OpenAPI\Server\Model\Pet[]
+     * @return OpenAPI\Server\Model\Pet
      *
      */
     public function getPetById($petId, &$responseCode, array &$responseHeaders);
@@ -173,7 +173,7 @@ interface PetApiInterface
      * @param  integer $responseCode     The HTTP response code to return
      * @param  array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return OpenAPI\Server\Model\ApiResponse[]
+     * @return OpenAPI\Server\Model\ApiResponse
      *
      */
     public function uploadFile($petId, $additionalMetadata = null, UploadedFile $file = null, &$responseCode, array &$responseHeaders);

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php
@@ -87,7 +87,7 @@ interface StoreApiInterface
      * @param  integer $responseCode     The HTTP response code to return
      * @param  array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return OpenAPI\Server\Model\Order[]
+     * @return OpenAPI\Server\Model\Order
      *
      */
     public function getOrderById($orderId, &$responseCode, array &$responseHeaders);
@@ -101,7 +101,7 @@ interface StoreApiInterface
      * @param  integer $responseCode     The HTTP response code to return
      * @param  array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return OpenAPI\Server\Model\Order[]
+     * @return OpenAPI\Server\Model\Order
      *
      */
     public function placeOrder(Order $body, &$responseCode, array &$responseHeaders);

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php
@@ -107,7 +107,7 @@ interface UserApiInterface
      * @param  integer $responseCode     The HTTP response code to return
      * @param  array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return OpenAPI\Server\Model\User[]
+     * @return OpenAPI\Server\Model\User
      *
      */
     public function getUserByName($username, &$responseCode, array &$responseHeaders);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Dear PHP technical committee, please review this PR
@jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon

### Description of the PR

This PR attempts to fix #3514 
Short description: the return type of PHP Symfony actions is forced to be an array, while should be an object.
