### PR TITLE
Fix DateTimeOffset nullable issue

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -153,7 +153,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                         "DateTime?",
                         "DateTime",
                         "DateTimeOffset?",
-                        "DataTimeOffset",
+                        "DateTimeOffset",
                         "Boolean",
                         "Double",
                         "Int32",
@@ -192,7 +192,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
         // nullable type
         nullableType = new HashSet<String>(
-                Arrays.asList("decimal", "bool", "int", "float", "long", "double", "DateTime", "Guid")
+                Arrays.asList("decimal", "bool", "int", "float", "long", "double", "DateTime", "DateTimeOffset", "Guid")
         );
         // value Types
         valueTypes = new HashSet<String>(
@@ -226,9 +226,9 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
     public void useDateTimeOffset(boolean flag) {
         this.useDateTimeOffsetFlag = flag;
         if (flag) {
-            typeMapping.put("DateTime", "DateTimeOffset?");
+            typeMapping.put("DateTime", "DateTimeOffset");
         } else {
-            typeMapping.put("DateTime", "DateTime?");
+            typeMapping.put("DateTime", "DateTime");
         }
     }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix DateTimeOffset part of issue https://github.com/OpenAPITools/openapi-generator/issues/3528

@wing328 
@mandrean 
@jimschubert 
