### PR TITLE
Use partial for Ruby HTTP libraries

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -233,14 +233,14 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         supportingFiles.add(new SupportingFile("rubocop.mustache", "", ".rubocop.yml"));
         supportingFiles.add(new SupportingFile("travis.mustache", "", ".travis.yml"));
         supportingFiles.add(new SupportingFile("gemspec.mustache", "", gemName + ".gemspec"));
+        supportingFiles.add(new SupportingFile("configuration.mustache", gemFolder, "configuration.rb"));
 
         if (TYPHOEUS.equals(getLibrary())) {
             supportingFiles.add(new SupportingFile("api_client.mustache", gemFolder, "api_client.rb"));
-            supportingFiles.add(new SupportingFile("configuration.mustache", gemFolder, "configuration.rb"));
             supportingFiles.add(new SupportingFile("Gemfile.lock.mustache", "", "Gemfile.lock"));
         } else if (FARADAY.equals(getLibrary())) {
             supportingFiles.add(new SupportingFile("faraday_api_client.mustache", gemFolder, "api_client.rb"));
-            supportingFiles.add(new SupportingFile("faraday_configuration.mustache", gemFolder, "configuration.rb"));
+            additionalProperties.put("isFaraday", Boolean.TRUE);
         } else {
             throw new RuntimeException("Invalid HTTP library " +  getLibrary() + ". Only faraday, typhoeus are supported.");
         }

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -66,46 +66,19 @@ module {{moduleName}}
     # Default to 0 (never times out).
     attr_accessor :timeout
 
+    {{^isFaraday}}
     # Set this to false to skip client side validation in the operation.
     # Default to true.
     # @return [true, false]
     attr_accessor :client_side_validation
 
-    ### TLS/SSL setting
-    # Set this to false to skip verifying SSL certificate when calling API from https server.
-    # Default to true.
-    #
-    # @note Do NOT set it to false in production code, otherwise you would face multiple types of cryptographic attacks.
-    #
-    # @return [true, false]
-    attr_accessor :verify_ssl
-
-    ### TLS/SSL setting
-    # Set this to false to skip verifying SSL host name
-    # Default to true.
-    #
-    # @note Do NOT set it to false in production code, otherwise you would face multiple types of cryptographic attacks.
-    #
-    # @return [true, false]
-    attr_accessor :verify_ssl_host
-
-    ### TLS/SSL setting
-    # Set this to customize the certificate file to verify the peer.
-    #
-    # @return [String] the path to the certificate file
-    #
-    # @see The `cainfo` option of Typhoeus, `--cert` option of libcurl. Related source code:
-    # https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/easy_factory.rb#L145
-    attr_accessor :ssl_ca_cert
-
-    ### TLS/SSL setting
-    # Client certificate file (for client certificate)
-    attr_accessor :cert_file
-
-    ### TLS/SSL setting
-    # Client private key file (for client certificate)
-    attr_accessor :key_file
-
+    {{/isFaraday}}
+{{^isFaraday}}
+{{> configuration_tls_typhoeus_partial}}
+{{/isFaraday}}
+{{#isFaraday}}
+{{> configuration_tls_faraday_partial}}
+{{/isFaraday}}
     # Set this to customize parameters encoding of array parameter with multi collectionFormat.
     # Default to nil.
     #
@@ -125,11 +98,20 @@ module {{moduleName}}
       @api_key_prefix = {}
       @timeout = 0
       @client_side_validation = true
+      {{#isFaraday}}
+      @ssl_verify = true
+      @ssl_verify_mode = nil
+      @ssl_ca_file = nil
+      @ssl_client_cert = nil
+      @ssl_client_key = nil
+      {{/isFaraday}}
+      {{^isFaraday}}
       @verify_ssl = true
       @verify_ssl_host = true
       @params_encoding = nil
       @cert_file = nil
       @key_file = nil
+      {{/isFaraday}}
       @debugging = false
       @inject_format = false
       @force_ending_format = false

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -66,13 +66,11 @@ module {{moduleName}}
     # Default to 0 (never times out).
     attr_accessor :timeout
 
-    {{^isFaraday}}
     # Set this to false to skip client side validation in the operation.
     # Default to true.
     # @return [true, false]
     attr_accessor :client_side_validation
 
-    {{/isFaraday}}
 {{^isFaraday}}
 {{> configuration_tls_typhoeus_partial}}
 {{/isFaraday}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration_tls_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration_tls_faraday_partial.mustache
@@ -27,4 +27,3 @@
     ### TLS/SSL setting
     # Client private key file (for client certificate)
     attr_accessor :ssl_client_key
-

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration_tls_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration_tls_faraday_partial.mustache
@@ -1,0 +1,30 @@
+    ### TLS/SSL setting
+    # Set this to false to skip verifying SSL certificate when calling API from https server.
+    # Default to true.
+    #
+    # @note Do NOT set it to false in production code, otherwise you would face multiple types of cryptographic attacks.
+    #
+    # @return [true, false]
+    attr_accessor :ssl_verify
+
+    ### TLS/SSL setting
+    # Any `OpenSSL::SSL::` constant (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL.html)
+    #
+    # @note Do NOT set it to false in production code, otherwise you would face multiple types of cryptographic attacks.
+    #
+    attr_accessor :ssl_verify_mode
+
+    ### TLS/SSL setting
+    # Set this to customize the certificate file to verify the peer.
+    #
+    # @return [String] the path to the certificate file
+    attr_accessor :ssl_ca_file
+
+    ### TLS/SSL setting
+    # Client certificate file (for client certificate)
+    attr_accessor :ssl_client_cert
+
+    ### TLS/SSL setting
+    # Client private key file (for client certificate)
+    attr_accessor :ssl_client_key
+

--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration_tls_typhoeus_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration_tls_typhoeus_partial.mustache
@@ -1,0 +1,34 @@
+    ### TLS/SSL setting
+    # Set this to false to skip verifying SSL certificate when calling API from https server.
+    # Default to true.
+    #
+    # @note Do NOT set it to false in production code, otherwise you would face multiple types of cryptographic attacks.
+    #
+    # @return [true, false]
+    attr_accessor :verify_ssl
+
+    ### TLS/SSL setting
+    # Set this to false to skip verifying SSL host name
+    # Default to true.
+    #
+    # @note Do NOT set it to false in production code, otherwise you would face multiple types of cryptographic attacks.
+    #
+    # @return [true, false]
+    attr_accessor :verify_ssl_host
+
+    ### TLS/SSL setting
+    # Set this to customize the certificate file to verify the peer.
+    #
+    # @return [String] the path to the certificate file
+    #
+    # @see The `cainfo` option of Typhoeus, `--cert` option of libcurl. Related source code:
+    # https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/easy_factory.rb#L145
+    attr_accessor :ssl_ca_cert
+
+    ### TLS/SSL setting
+    # Client certificate file (for client certificate)
+    attr_accessor :cert_file
+
+    ### TLS/SSL setting
+    # Client private key file (for client certificate)
+    attr_accessor :key_file

--- a/modules/openapi-generator/src/main/resources/ruby-client/faraday_api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/faraday_api_client.mustache
@@ -107,8 +107,6 @@ module {{moduleName}}
 
       update_params_for_auth! header_params, query_params, opts[:auth_names]
 
-
-
       req_opts = {
         :method => http_method,
         :headers => header_params,
@@ -117,7 +115,6 @@ module {{moduleName}}
         :timeout => @config.timeout,
         :verbose => @config.debugging
       }
-
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])

--- a/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -115,8 +115,6 @@ module Petstore
 
       update_params_for_auth! header_params, query_params, opts[:auth_names]
 
-
-
       req_opts = {
         :method => http_method,
         :headers => header_params,
@@ -125,7 +123,6 @@ module Petstore
         :timeout => @config.timeout,
         :verbose => @config.debugging
       }
-
 
       if [:post, :patch, :put, :delete].include?(http_method)
         req_body = build_request_body(header_params, form_params, opts[:body])

--- a/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -74,6 +74,11 @@ module Petstore
     # Default to 0 (never times out).
     attr_accessor :timeout
 
+    # Set this to false to skip client side validation in the operation.
+    # Default to true.
+    # @return [true, false]
+    attr_accessor :client_side_validation
+
     ### TLS/SSL setting
     # Set this to false to skip verifying SSL certificate when calling API from https server.
     # Default to true.

--- a/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -74,16 +74,6 @@ module Petstore
     # Default to 0 (never times out).
     attr_accessor :timeout
 
-    # Set this to false to skip client side validation in the operation.
-    # Default to true.
-    # @return [true, false]
-    attr_accessor :client_side_validation
-
-    # Set this to false to skip client side validation in the operation.
-    # Default to true.
-    # @return [true, false]
-    attr_accessor :client_side_validation
-
     ### TLS/SSL setting
     # Set this to false to skip verifying SSL certificate when calling API from https server.
     # Default to true.
@@ -114,6 +104,7 @@ module Petstore
     # Client private key file (for client certificate)
     attr_accessor :ssl_client_key
 
+
     # Set this to customize parameters encoding of array parameter with multi collectionFormat.
     # Default to nil.
     #
@@ -127,11 +118,10 @@ module Petstore
 
     def initialize
       @scheme = 'http'
-      @host = 'localhost'
-      @base_path = ''
+      @host = 'petstore.swagger.io'
+      @base_path = '/v2'
       @api_key = {}
       @api_key_prefix = {}
-      @params_encoding = nil
       @timeout = 0
       @client_side_validation = true
       @ssl_verify = true

--- a/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -109,7 +109,6 @@ module Petstore
     # Client private key file (for client certificate)
     attr_accessor :ssl_client_key
 
-
     # Set this to customize parameters encoding of array parameter with multi collectionFormat.
     # Default to nil.
     #

--- a/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/configuration.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/configuration.rb
@@ -79,6 +79,11 @@ module Petstore
     # @return [true, false]
     attr_accessor :client_side_validation
 
+    # Set this to false to skip client side validation in the operation.
+    # Default to true.
+    # @return [true, false]
+    attr_accessor :client_side_validation
+
     ### TLS/SSL setting
     # Set this to false to skip verifying SSL certificate when calling API from https server.
     # Default to true.
@@ -86,33 +91,28 @@ module Petstore
     # @note Do NOT set it to false in production code, otherwise you would face multiple types of cryptographic attacks.
     #
     # @return [true, false]
-    attr_accessor :verify_ssl
+    attr_accessor :ssl_verify
 
     ### TLS/SSL setting
-    # Set this to false to skip verifying SSL host name
-    # Default to true.
+    # Any `OpenSSL::SSL::` constant (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL.html)
     #
     # @note Do NOT set it to false in production code, otherwise you would face multiple types of cryptographic attacks.
     #
-    # @return [true, false]
-    attr_accessor :verify_ssl_host
+    attr_accessor :ssl_verify_mode
 
     ### TLS/SSL setting
     # Set this to customize the certificate file to verify the peer.
     #
     # @return [String] the path to the certificate file
-    #
-    # @see The `cainfo` option of Typhoeus, `--cert` option of libcurl. Related source code:
-    # https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/easy_factory.rb#L145
-    attr_accessor :ssl_ca_cert
+    attr_accessor :ssl_ca_file
 
     ### TLS/SSL setting
     # Client certificate file (for client certificate)
-    attr_accessor :cert_file
+    attr_accessor :ssl_client_cert
 
     ### TLS/SSL setting
     # Client private key file (for client certificate)
-    attr_accessor :key_file
+    attr_accessor :ssl_client_key
 
     # Set this to customize parameters encoding of array parameter with multi collectionFormat.
     # Default to nil.
@@ -127,17 +127,18 @@ module Petstore
 
     def initialize
       @scheme = 'http'
-      @host = 'petstore.swagger.io'
-      @base_path = '/v2'
+      @host = 'localhost'
+      @base_path = ''
       @api_key = {}
       @api_key_prefix = {}
+      @params_encoding = nil
       @timeout = 0
       @client_side_validation = true
-      @verify_ssl = true
-      @verify_ssl_host = true
-      @params_encoding = nil
-      @cert_file = nil
-      @key_file = nil
+      @ssl_verify = true
+      @ssl_verify_mode = nil
+      @ssl_ca_file = nil
+      @ssl_client_cert = nil
+      @ssl_client_key = nil
       @debugging = false
       @inject_format = false
       @force_ending_format = false

--- a/samples/openapi3/client/petstore/ruby-faraday/petstore.gemspec
+++ b/samples/openapi3/client/petstore/ruby-faraday/petstore.gemspec
@@ -27,12 +27,16 @@ Gem::Specification.new do |s|
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 1.9"
 
-  s.add_runtime_dependency 'faraday', '>= 0.14.0'
+  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'
   s.add_development_dependency 'webmock', '~> 1.24', '>= 1.24.3'
+  s.add_development_dependency 'autotest', '~> 4.4', '>= 4.4.6'
+  s.add_development_dependency 'autotest-rails-pure', '~> 4.1', '>= 4.1.2'
+  s.add_development_dependency 'autotest-growl', '~> 0.2', '>= 0.2.16'
+  s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.12'
 
   s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
   s.test_files    = `find spec/*`.split("\n")

--- a/samples/openapi3/client/petstore/ruby-faraday/petstore.gemspec
+++ b/samples/openapi3/client/petstore/ruby-faraday/petstore.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 1.9"
 
-  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
+  s.add_runtime_dependency 'faraday', '>= 0.14.0'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'

--- a/samples/openapi3/client/petstore/ruby-faraday/spec/api_client_spec.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/spec/api_client_spec.rb
@@ -51,6 +51,44 @@ describe Petstore::ApiClient do
     end
   end
 
+  describe 'params_encoding in #build_request' do
+    let(:config) { Petstore::Configuration.new }
+    let(:api_client) { Petstore::ApiClient.new(config) }
+
+    it 'defaults to nil' do
+      expect(Petstore::Configuration.default.params_encoding).to eq(nil)
+      expect(config.params_encoding).to eq(nil)
+
+      request = api_client.build_request(:get, '/test')
+      expect(request.options[:params_encoding]).to eq(nil)
+    end
+
+    it 'can be customized' do
+      config.params_encoding = :multi
+      request = api_client.build_request(:get, '/test')
+      expect(request.options[:params_encoding]).to eq(:multi)
+    end
+  end
+
+  describe 'timeout in #build_request' do
+    let(:config) { Petstore::Configuration.new }
+    let(:api_client) { Petstore::ApiClient.new(config) }
+
+    it 'defaults to 0' do
+      expect(Petstore::Configuration.default.timeout).to eq(0)
+      expect(config.timeout).to eq(0)
+
+      request = api_client.build_request(:get, '/test')
+      expect(request.options[:timeout]).to eq(0)
+    end
+
+    it 'can be customized' do
+      config.timeout = 100
+      request = api_client.build_request(:get, '/test')
+      expect(request.options[:timeout]).to eq(100)
+    end
+  end
+
   describe '#deserialize' do
     it "handles Array<Integer>" do
       api_client = Petstore::ApiClient.new

--- a/samples/openapi3/client/petstore/ruby-faraday/spec/api_client_spec.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/spec/api_client_spec.rb
@@ -51,44 +51,6 @@ describe Petstore::ApiClient do
     end
   end
 
-  describe 'params_encoding in #build_request' do
-    let(:config) { Petstore::Configuration.new }
-    let(:api_client) { Petstore::ApiClient.new(config) }
-
-    it 'defaults to nil' do
-      expect(Petstore::Configuration.default.params_encoding).to eq(nil)
-      expect(config.params_encoding).to eq(nil)
-
-      request = api_client.build_request(:get, '/test')
-      expect(request.options[:params_encoding]).to eq(nil)
-    end
-
-    it 'can be customized' do
-      config.params_encoding = :multi
-      request = api_client.build_request(:get, '/test')
-      expect(request.options[:params_encoding]).to eq(:multi)
-    end
-  end
-
-  describe 'timeout in #build_request' do
-    let(:config) { Petstore::Configuration.new }
-    let(:api_client) { Petstore::ApiClient.new(config) }
-
-    it 'defaults to 0' do
-      expect(Petstore::Configuration.default.timeout).to eq(0)
-      expect(config.timeout).to eq(0)
-
-      request = api_client.build_request(:get, '/test')
-      expect(request.options[:timeout]).to eq(0)
-    end
-
-    it 'can be customized' do
-      config.timeout = 100
-      request = api_client.build_request(:get, '/test')
-      expect(request.options[:timeout]).to eq(100)
-    end
-  end
-
   describe '#deserialize' do
     it "handles Array<Integer>" do
       api_client = Petstore::ApiClient.new


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- bug fix: isFaraday
- use mustache partial for configuration.mustache

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)


