### PR TITLE
Problem: leading _ in name is removed by PythonClientCodegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -451,7 +451,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         // remove dollar sign
         name = name.replaceAll("$", "");
 
-        // if it's all uppper case, convert to lower case
+        // if it's all upper case, convert to lower case
         if (name.matches("^[A-Z_]*$")) {
             name = name.toLowerCase(Locale.ROOT);
         }
@@ -460,8 +460,14 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         // petId => pet_id
         name = underscore(name);
 
-        // remove leading underscore
-        name = name.replaceAll("^_*", "");
+        if (name.startsWith("_")) {
+            // Double leading underscores cause name mangling as described in PEP 8. Model
+            // implementation details create a conflict between setters of variables that
+            // differ only by a leading underscore. e.g.: 'name' and '_name'. Move the
+            // underscores to the end of the name to avoid both of these problems.
+            String[] name_parts = name.split("^_*");
+            name = name_parts[1] + name.replaceAll(name_parts[1], "");
+        }
 
         // for reserved word or word starting with number, append _
         if (isReservedWord(name) || name.matches("^\\d.*")) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Solution: move leading _ to the end of the name
    
Double leading underscores in Python attribute names cause them to have their names
mangled as described in PEP 8[0]. That's why they were being removed completely before
this patch.
    
Due to the implementation details of the python models that are generated, leaving a
single leading underscore causes a conflict between setters of variables name that differ
only by a leading underscore. e.g.: 'name' and '_name'.
    
This patch changes how leading underscores in variables and parameters are handled. All
leading underscores are moved to the end of the name.
    
[0] https://www.python.org/dev/peps/pep-0008/
