### PR TITLE
#2956 [typescript] change accessToken name parameter to optional

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/configuration.mustache
@@ -5,7 +5,7 @@ export interface ConfigurationParameters {
     apiKey?: string | ((name: string) => string);
     username?: string;
     password?: string;
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     basePath?: string;
     baseOptions?: any;
 }
@@ -37,7 +37,7 @@ export class Configuration {
      * @param scopes oauth2 scope
      * @memberof Configuration
      */
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     /**
      * override base path
      * 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -120,7 +120,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/runtime.mustache
@@ -12,7 +12,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {

--- a/samples/client/petstore/typescript-axios/builds/default/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/configuration.ts
@@ -16,7 +16,7 @@ export interface ConfigurationParameters {
     apiKey?: string | ((name: string) => string);
     username?: string;
     password?: string;
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     basePath?: string;
     baseOptions?: any;
 }
@@ -48,7 +48,7 @@ export class Configuration {
      * @param scopes oauth2 scope
      * @memberof Configuration
      */
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     /**
      * override base path
      * 

--- a/samples/client/petstore/typescript-axios/builds/es6-target/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/configuration.ts
@@ -16,7 +16,7 @@ export interface ConfigurationParameters {
     apiKey?: string | ((name: string) => string);
     username?: string;
     password?: string;
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     basePath?: string;
     baseOptions?: any;
 }
@@ -48,7 +48,7 @@ export class Configuration {
      * @param scopes oauth2 scope
      * @memberof Configuration
      */
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     /**
      * override base path
      * 

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/configuration.ts
@@ -16,7 +16,7 @@ export interface ConfigurationParameters {
     apiKey?: string | ((name: string) => string);
     username?: string;
     password?: string;
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     basePath?: string;
     baseOptions?: any;
 }
@@ -48,7 +48,7 @@ export class Configuration {
      * @param scopes oauth2 scope
      * @memberof Configuration
      */
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     /**
      * override base path
      * 

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/configuration.ts
@@ -16,7 +16,7 @@ export interface ConfigurationParameters {
     apiKey?: string | ((name: string) => string);
     username?: string;
     password?: string;
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     basePath?: string;
     baseOptions?: any;
 }
@@ -48,7 +48,7 @@ export class Configuration {
      * @param scopes oauth2 scope
      * @memberof Configuration
      */
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     /**
      * override base path
      * 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/configuration.ts
@@ -16,7 +16,7 @@ export interface ConfigurationParameters {
     apiKey?: string | ((name: string) => string);
     username?: string;
     password?: string;
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     basePath?: string;
     baseOptions?: any;
 }
@@ -48,7 +48,7 @@ export class Configuration {
      * @param scopes oauth2 scope
      * @memberof Configuration
      */
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     /**
      * override base path
      * 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/configuration.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/configuration.ts
@@ -16,7 +16,7 @@ export interface ConfigurationParameters {
     apiKey?: string | ((name: string) => string);
     username?: string;
     password?: string;
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     basePath?: string;
     baseOptions?: any;
 }
@@ -48,7 +48,7 @@ export class Configuration {
      * @param scopes oauth2 scope
      * @memberof Configuration
      */
-    accessToken?: string | ((name: string, scopes?: string[]) => string);
+    accessToken?: string | ((name?: string, scopes?: string[]) => string);
     /**
      * override base path
      * 

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -131,7 +131,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/runtime.ts
@@ -131,7 +131,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -131,7 +131,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -131,7 +131,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/runtime.ts
@@ -131,7 +131,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {

--- a/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/runtime.ts
@@ -23,7 +23,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/runtime.ts
@@ -23,7 +23,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {

--- a/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-interfaces/runtime.ts
@@ -23,7 +23,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/runtime.ts
@@ -23,7 +23,7 @@ export interface ConfigurationParameters {
     username?: string; // parameter for basic security
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | ((name: string, scopes?: string[]) => string); // parameter for oauth2 security
+    accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
 }
 
 export class Configuration {


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

fixes #2956
Iif you generate an axios API, you get a compilation error if tsconfig is set to 'strict' 

because `configuration.accessToken()` requires name as paramater (not optional) but here in the code generated  it calls `configuration.accessToken()` without passing any parameters.

I just made name an optional parameter.
I don't know if this is the right way to solve the issue, i would like to have some feedback about this. 

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07)

