### PR TITLE
 [Rust Server] Generate valid Rustdocs for lazy_static items

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/mimetypes.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/mimetypes.mustache
@@ -4,8 +4,9 @@ pub mod responses {
     use hyper::mime::*;
 
     // The macro is called per-operation to beat the recursion limit
-{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#responses}}{{#produces}}{{#-first}}{{#dataType}}    /// Create Mime objects for the response content types for {{{operationId}}}
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#responses}}{{#produces}}{{#-first}}{{#dataType}}
     lazy_static! {
+        /// Create Mime objects for the response content types for {{{operationId}}}
         pub static ref {{#vendorExtensions}}{{{uppercase_operation_id}}}_{{x-uppercaseResponseId}}{{/vendorExtensions}}: Mime = "{{{mediaType}}}".parse().unwrap();
     }
 {{/dataType}}{{/-first}}{{/produces}}{{/responses}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
@@ -13,12 +14,14 @@ pub mod responses {
 
 pub mod requests {
     use hyper::mime::*;
-{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#bodyParam}}   /// Create Mime objects for the request content types for {{{operationId}}}
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#bodyParam}}
     lazy_static! {
+        /// Create Mime objects for the request content types for {{{operationId}}}
         pub static ref {{#vendorExtensions}}{{{uppercase_operation_id}}}{{/vendorExtensions}}: Mime = "{{#consumes}}{{#-first}}{{{mediaType}}}{{/-first}}{{/consumes}}{{^consumes}}application/json{{/consumes}}".parse().unwrap();
     }
-{{/bodyParam}}{{^bodyParam}}{{#vendorExtensions}}{{#formParams}}{{#-first}}   /// Create Mime objects for the request content types for {{{operationId}}}
+{{/bodyParam}}{{^bodyParam}}{{#vendorExtensions}}{{#formParams}}{{#-first}}
     lazy_static! {
+        /// Create Mime objects for the request content types for {{{operationId}}}
         pub static ref {{#vendorExtensions}}{{{uppercase_operation_id}}}{{/vendorExtensions}}: Mime = "{{#consumes}}{{#-first}}{{{mediaType}}}{{/-first}}{{/consumes}}{{^consumes}}application/x-www-form-urlencoded{{/consumes}}".parse().unwrap();
     }
 {{/-first}}{{/formParams}}{{/vendorExtensions}}{{/bodyParam}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/mimetypes.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/mimetypes.rs
@@ -9,8 +9,9 @@ pub mod responses {
 
 pub mod requests {
     use hyper::mime::*;
-   /// Create Mime objects for the request content types for MultipartRequestPost
+
     lazy_static! {
+        /// Create Mime objects for the request content types for MultipartRequestPost
         pub static ref MULTIPART_REQUEST_POST: Mime = "multipart/form-data".parse().unwrap();
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/mimetypes.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/mimetypes.rs
@@ -4,8 +4,9 @@ pub mod responses {
     use hyper::mime::*;
 
     // The macro is called per-operation to beat the recursion limit
-    /// Create Mime objects for the response content types for UuidGet
+
     lazy_static! {
+        /// Create Mime objects for the response content types for UuidGet
         pub static ref UUID_GET_DUPLICATE_RESPONSE_LONG_TEXT: Mime = "application/json".parse().unwrap();
     }
 
@@ -13,28 +14,34 @@ pub mod responses {
 
 pub mod requests {
     use hyper::mime::*;
-   /// Create Mime objects for the request content types for RequiredOctetStreamPut
+
     lazy_static! {
+        /// Create Mime objects for the request content types for RequiredOctetStreamPut
         pub static ref REQUIRED_OCTET_STREAM_PUT: Mime = "application/octet-stream".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for XmlExtraPost
+
     lazy_static! {
+        /// Create Mime objects for the request content types for XmlExtraPost
         pub static ref XML_EXTRA_POST: Mime = "application/xml".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for XmlOtherPost
+
     lazy_static! {
+        /// Create Mime objects for the request content types for XmlOtherPost
         pub static ref XML_OTHER_POST: Mime = "application/xml".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for XmlOtherPut
+
     lazy_static! {
+        /// Create Mime objects for the request content types for XmlOtherPut
         pub static ref XML_OTHER_PUT: Mime = "application/xml".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for XmlPost
+
     lazy_static! {
+        /// Create Mime objects for the request content types for XmlPost
         pub static ref XML_POST: Mime = "application/xml".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for XmlPut
+
     lazy_static! {
+        /// Create Mime objects for the request content types for XmlPut
         pub static ref XML_PUT: Mime = "application/xml".parse().unwrap();
     }
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/mimetypes.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/mimetypes.rs
@@ -4,68 +4,84 @@ pub mod responses {
     use hyper::mime::*;
 
     // The macro is called per-operation to beat the recursion limit
-    /// Create Mime objects for the response content types for TestSpecialTags
+
     lazy_static! {
+        /// Create Mime objects for the response content types for TestSpecialTags
         pub static ref TEST_SPECIAL_TAGS_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for FakeOuterBooleanSerialize
+
     lazy_static! {
+        /// Create Mime objects for the response content types for FakeOuterBooleanSerialize
         pub static ref FAKE_OUTER_BOOLEAN_SERIALIZE_OUTPUT_BOOLEAN: Mime = "*/*".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for FakeOuterCompositeSerialize
+
     lazy_static! {
+        /// Create Mime objects for the response content types for FakeOuterCompositeSerialize
         pub static ref FAKE_OUTER_COMPOSITE_SERIALIZE_OUTPUT_COMPOSITE: Mime = "*/*".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for FakeOuterNumberSerialize
+
     lazy_static! {
+        /// Create Mime objects for the response content types for FakeOuterNumberSerialize
         pub static ref FAKE_OUTER_NUMBER_SERIALIZE_OUTPUT_NUMBER: Mime = "*/*".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for FakeOuterStringSerialize
+
     lazy_static! {
+        /// Create Mime objects for the response content types for FakeOuterStringSerialize
         pub static ref FAKE_OUTER_STRING_SERIALIZE_OUTPUT_STRING: Mime = "*/*".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for TestClientModel
+
     lazy_static! {
+        /// Create Mime objects for the response content types for TestClientModel
         pub static ref TEST_CLIENT_MODEL_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for TestClassname
+
     lazy_static! {
+        /// Create Mime objects for the response content types for TestClassname
         pub static ref TEST_CLASSNAME_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for FindPetsByStatus
+
     lazy_static! {
+        /// Create Mime objects for the response content types for FindPetsByStatus
         pub static ref FIND_PETS_BY_STATUS_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for FindPetsByTags
+
     lazy_static! {
+        /// Create Mime objects for the response content types for FindPetsByTags
         pub static ref FIND_PETS_BY_TAGS_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for GetPetById
+
     lazy_static! {
+        /// Create Mime objects for the response content types for GetPetById
         pub static ref GET_PET_BY_ID_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for UploadFile
+
     lazy_static! {
+        /// Create Mime objects for the response content types for UploadFile
         pub static ref UPLOAD_FILE_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for GetInventory
+
     lazy_static! {
+        /// Create Mime objects for the response content types for GetInventory
         pub static ref GET_INVENTORY_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for GetOrderById
+
     lazy_static! {
+        /// Create Mime objects for the response content types for GetOrderById
         pub static ref GET_ORDER_BY_ID_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for PlaceOrder
+
     lazy_static! {
+        /// Create Mime objects for the response content types for PlaceOrder
         pub static ref PLACE_ORDER_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for GetUserByName
+
     lazy_static! {
+        /// Create Mime objects for the response content types for GetUserByName
         pub static ref GET_USER_BY_NAME_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for LoginUser
+
     lazy_static! {
+        /// Create Mime objects for the response content types for LoginUser
         pub static ref LOGIN_USER_SUCCESSFUL_OPERATION: Mime = "application/json".parse().unwrap();
     }
 
@@ -73,88 +89,109 @@ pub mod responses {
 
 pub mod requests {
     use hyper::mime::*;
-   /// Create Mime objects for the request content types for TestSpecialTags
+
     lazy_static! {
+        /// Create Mime objects for the request content types for TestSpecialTags
         pub static ref TEST_SPECIAL_TAGS: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for FakeOuterBooleanSerialize
+
     lazy_static! {
+        /// Create Mime objects for the request content types for FakeOuterBooleanSerialize
         pub static ref FAKE_OUTER_BOOLEAN_SERIALIZE: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for FakeOuterCompositeSerialize
+
     lazy_static! {
+        /// Create Mime objects for the request content types for FakeOuterCompositeSerialize
         pub static ref FAKE_OUTER_COMPOSITE_SERIALIZE: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for FakeOuterNumberSerialize
+
     lazy_static! {
+        /// Create Mime objects for the request content types for FakeOuterNumberSerialize
         pub static ref FAKE_OUTER_NUMBER_SERIALIZE: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for FakeOuterStringSerialize
+
     lazy_static! {
+        /// Create Mime objects for the request content types for FakeOuterStringSerialize
         pub static ref FAKE_OUTER_STRING_SERIALIZE: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for TestBodyWithQueryParams
+
     lazy_static! {
+        /// Create Mime objects for the request content types for TestBodyWithQueryParams
         pub static ref TEST_BODY_WITH_QUERY_PARAMS: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for TestClientModel
+
     lazy_static! {
+        /// Create Mime objects for the request content types for TestClientModel
         pub static ref TEST_CLIENT_MODEL: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for TestEndpointParameters
+
     lazy_static! {
+        /// Create Mime objects for the request content types for TestEndpointParameters
         pub static ref TEST_ENDPOINT_PARAMETERS: Mime = "application/x-www-form-urlencoded".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for TestEnumParameters
+
     lazy_static! {
+        /// Create Mime objects for the request content types for TestEnumParameters
         pub static ref TEST_ENUM_PARAMETERS: Mime = "application/x-www-form-urlencoded".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for TestInlineAdditionalProperties
+
     lazy_static! {
+        /// Create Mime objects for the request content types for TestInlineAdditionalProperties
         pub static ref TEST_INLINE_ADDITIONAL_PROPERTIES: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for TestJsonFormData
+
     lazy_static! {
+        /// Create Mime objects for the request content types for TestJsonFormData
         pub static ref TEST_JSON_FORM_DATA: Mime = "application/x-www-form-urlencoded".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for TestClassname
+
     lazy_static! {
+        /// Create Mime objects for the request content types for TestClassname
         pub static ref TEST_CLASSNAME: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for AddPet
+
     lazy_static! {
+        /// Create Mime objects for the request content types for AddPet
         pub static ref ADD_PET: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for UpdatePet
+
     lazy_static! {
+        /// Create Mime objects for the request content types for UpdatePet
         pub static ref UPDATE_PET: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for UpdatePetWithForm
+
     lazy_static! {
+        /// Create Mime objects for the request content types for UpdatePetWithForm
         pub static ref UPDATE_PET_WITH_FORM: Mime = "application/x-www-form-urlencoded".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for UploadFile
+
     lazy_static! {
+        /// Create Mime objects for the request content types for UploadFile
         pub static ref UPLOAD_FILE: Mime = "multipart/form-data".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for PlaceOrder
+
     lazy_static! {
+        /// Create Mime objects for the request content types for PlaceOrder
         pub static ref PLACE_ORDER: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for CreateUser
+
     lazy_static! {
+        /// Create Mime objects for the request content types for CreateUser
         pub static ref CREATE_USER: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for CreateUsersWithArrayInput
+
     lazy_static! {
+        /// Create Mime objects for the request content types for CreateUsersWithArrayInput
         pub static ref CREATE_USERS_WITH_ARRAY_INPUT: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for CreateUsersWithListInput
+
     lazy_static! {
+        /// Create Mime objects for the request content types for CreateUsersWithListInput
         pub static ref CREATE_USERS_WITH_LIST_INPUT: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for UpdateUser
+
     lazy_static! {
+        /// Create Mime objects for the request content types for UpdateUser
         pub static ref UPDATE_USER: Mime = "application/json".parse().unwrap();
     }
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/mimetypes.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/mimetypes.rs
@@ -4,16 +4,19 @@ pub mod responses {
     use hyper::mime::*;
 
     // The macro is called per-operation to beat the recursion limit
-    /// Create Mime objects for the response content types for FileResponseGet
+
     lazy_static! {
+        /// Create Mime objects for the response content types for FileResponseGet
         pub static ref FILE_RESPONSE_GET_SUCCESS: Mime = "application/json".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for HtmlPost
+
     lazy_static! {
+        /// Create Mime objects for the response content types for HtmlPost
         pub static ref HTML_POST_SUCCESS: Mime = "text/html".parse().unwrap();
     }
-    /// Create Mime objects for the response content types for RawJsonGet
+
     lazy_static! {
+        /// Create Mime objects for the response content types for RawJsonGet
         pub static ref RAW_JSON_GET_SUCCESS: Mime = "*/*".parse().unwrap();
     }
 
@@ -21,12 +24,14 @@ pub mod responses {
 
 pub mod requests {
     use hyper::mime::*;
-   /// Create Mime objects for the request content types for DummyPut
+
     lazy_static! {
+        /// Create Mime objects for the request content types for DummyPut
         pub static ref DUMMY_PUT: Mime = "application/json".parse().unwrap();
     }
-   /// Create Mime objects for the request content types for HtmlPost
+
     lazy_static! {
+        /// Create Mime objects for the request content types for HtmlPost
         pub static ref HTML_POST: Mime = "text/html".parse().unwrap();
     }
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
  - @frol, @farcaller, @bjgill 

### Description of the PR

Generate valid Rustdocs for lazy_static items

Currently compiling a generated crate produced by rust-server produces warnings such as the follows:

```
warning: unused doc comment
  --> output/rust-server-test/src/mimetypes.rs:15:5
   |
15 |       /// Create Mime objects for the response content types for RawJsonGet
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
16 | /     lazy_static! {
17 | |         pub static ref RAW_JSON_GET_SUCCESS: Mime = "*/*".parse().unwrap();
18 | |     }
   | |_____- rustdoc does not generate documentation for macro expansions
   |
   = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
```

This fixes that. This work was contributed by @mthebridge 