### PR TITLE
[Golang] support multi collection serialization for query params

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -132,11 +132,11 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx context.Context{{#hasParams}
 	{{#hasQueryParams}}
 	{{#queryParams}}
 	{{#required}}
-	localVarQueryParams.Add("{{baseName}}", parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	localVarQueryParams = addQueryParams(localVarQueryParams, "{{baseName}}", {{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
 	{{/required}}
 	{{^required}}
 	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-exportParamName}}.IsSet() {
-		localVarQueryParams.Add("{{baseName}}", parameterToString(localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+		localVarQueryParams = addQueryParams(localVarQueryParams, "{{baseName}}", localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
 	}
 	{{/required}}
 	{{/queryParams}}

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -111,6 +111,21 @@ func contains(haystack []string, needle string) bool {
 	return false
 }
 
+// addQueryParams adds a query params depending on collectionFormat
+// if collectionFormat == "multi" it will add multiple entries to query string e.g.
+// ["q1", "q2, "q3"] will be converted to `paramName=q1&paramName=q2&paramName=q3`
+func addQueryParams(q url.Values, paramName string, paramValue interface{}, collectionFormat string) url.Values {
+    if collectionFormat == "multi" && reflect.TypeOf(paramValue).Kind() == reflect.Slice {
+        paramSlice := reflect.ValueOf(paramValue)
+
+        for i := 0; i < paramSlice.Len(); i++ {
+            q.Add(paramName, parameterToString(paramSlice.Index(i).Interface(), ""))
+        }
+    }
+    q.Add(paramName, parameterToString(paramValue, collectionFormat))
+    return q
+}
+
 // Verify optional parameters are of the correct type.
 func typeCheckParameter(obj interface{}, expected string, name string) error {
 	// Make sure there is an object.


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR solves the same issue as https://github.com/OpenAPITools/openapi-generator/pull/3390
I think this is smaller and easier fix than the proposed one.

cc
@wing328 @antihax @bvwells @kemokemo