### PR TITLE
[java][client][jax-rs] Add a constant for Jackson @JsonProperty

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -20,7 +20,8 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     {{/isContainer}}
     {{/isEnum}}
   {{#jackson}}
-  @JsonProperty("{{baseName}}")
+  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
+  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
   {{#withXml}}
     {{^isContainer}}
   @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
@@ -16,10 +16,12 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     {{/isContainer}}
     {{/isEnum}}
   {{#jackson}}
-  @JsonProperty("{{baseName}}")
+  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
+  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
   {{/jackson}}
   {{#gson}}
-  @SerializedName("{{baseName}}")
+  public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
+  @SerializedName(SERIALIZED_NAME_{{nameInSnakeCase}})
   {{/gson}}
   {{#isContainer}}
   private {{{datatypeWithEnum}}} {{name}}{{#required}} = {{{defaultValue}}}{{/required}}{{^required}} = null{{/required}};

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<String, String>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<String, BigDecimal>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<String, Integer>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<String, Boolean>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<String, List<Integer>>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<List<BigDecimal>>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<BigDecimal>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<String>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<java.io.File>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<String, Boolean>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<String, Boolean>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<Tag>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<Integer>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<String, String>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<String, BigDecimal>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<String, Integer>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<String, Boolean>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<String, List<Integer>>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<List<BigDecimal>>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<BigDecimal>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<String>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<java.io.File>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<String, Boolean>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<String, Boolean>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<Tag>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<Integer>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<String, String>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<String, BigDecimal>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<String, Integer>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<String, Boolean>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<String, List<Integer>>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<List<BigDecimal>>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<BigDecimal>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<String>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<java.io.File>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<String, Boolean>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<String, Boolean>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<Tag>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<Integer>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<String, String>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<String, BigDecimal>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<String, Integer>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<String, Boolean>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<String, List<Integer>>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<List<BigDecimal>>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<BigDecimal>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<String>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<java.io.File>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<String, Boolean>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<String, Boolean>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<Tag>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<Integer>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -27,7 +27,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -27,7 +27,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -29,37 +29,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<String, String>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<String, BigDecimal>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<String, Integer>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<String, Boolean>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<String, List<Integer>>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -27,7 +27,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -27,7 +27,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -27,7 +27,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Animal.java
@@ -33,10 +33,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -28,7 +28,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<List<BigDecimal>>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -28,7 +28,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<BigDecimal>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -28,13 +28,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<String>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -25,22 +25,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Cat.java
@@ -27,7 +27,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -25,7 +25,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Category.java
@@ -25,10 +25,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Client.java
@@ -25,7 +25,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Dog.java
@@ -27,7 +27,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -25,7 +25,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -62,7 +62,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -100,7 +101,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -63,7 +63,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -103,7 +104,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -141,7 +143,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -179,10 +182,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -27,10 +27,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<java.io.File>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -30,43 +30,56 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -25,10 +25,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MapTest.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
 
   /**
@@ -66,13 +67,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<String, Boolean>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<String, Boolean>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -31,13 +31,16 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -25,13 +25,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Name.java
@@ -26,16 +26,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -26,7 +26,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Order.java
@@ -26,16 +26,20 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -75,10 +79,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -26,13 +26,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Pet.java
@@ -29,19 +29,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<Tag>();
 
   /**
@@ -81,7 +86,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -25,10 +25,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -25,7 +25,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Tag.java
@@ -25,10 +25,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -28,19 +28,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -28,19 +28,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/User.java
@@ -25,28 +25,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -28,91 +28,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<Integer>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import java.util.UUID;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.openapitools.client.model.Animal;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import java.time.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<String, String>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<String, BigDecimal>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<String, Integer>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<String, Boolean>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<String, List<Integer>>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<List<BigDecimal>>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<BigDecimal>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<String>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<java.io.File>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<String, Boolean>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<String, Boolean>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<Tag>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<Integer>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import java.util.UUID;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.openapitools.client.model.Animal;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import java.time.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<String, String>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<String, BigDecimal>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<String, Integer>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<String, Boolean>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<String, List<Integer>>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<List<BigDecimal>>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<BigDecimal>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<String>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<java.io.File>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<String, Boolean>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<String, Boolean>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<Tag>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<Integer>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -33,7 +33,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesAnyType")
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private String name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -34,7 +34,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesArray")
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private String name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -33,7 +33,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesBoolean")
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private String name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -35,73 +35,84 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesClass")
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "inner")
   private Map<String, String> mapString = new HashMap<String, String>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=BigDecimal
   @XmlElement(name = "inner")
   private Map<String, BigDecimal> mapNumber = new HashMap<String, BigDecimal>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "inner")
   private Map<String, Integer> mapInteger = new HashMap<String, Integer>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Boolean
   @XmlElement(name = "inner")
   private Map<String, Boolean> mapBoolean = new HashMap<String, Boolean>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;Integer&gt;
   @XmlElement(name = "inner")
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<String, List<Integer>>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;Object&gt;
   @XmlElement(name = "inner")
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Map&lt;String, String&gt;
   @XmlElement(name = "inner")
   private Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Map&lt;String, Object&gt;
   @XmlElement(name = "inner")
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   @JacksonXmlProperty(localName = "anytype_1")
   @XmlElement(name = "anytype_1")
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   @JacksonXmlProperty(localName = "anytype_2")
   @XmlElement(name = "anytype_2")
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   @JacksonXmlProperty(localName = "anytype_3")
   @XmlElement(name = "anytype_3")
   private Object anytype3 = null;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -33,7 +33,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesInteger")
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private String name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -34,7 +34,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesNumber")
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private String name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -33,7 +33,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesObject")
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private String name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -33,7 +33,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesString")
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private String name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
@@ -39,12 +39,14 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Animal")
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   @JacksonXmlProperty(localName = "className")
   @XmlElement(name = "className")
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   @JacksonXmlProperty(localName = "color")
   @XmlElement(name = "color")
   private String color = "red";

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -34,7 +34,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ArrayOfArrayOfNumberOnly")
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   // Is a container wrapped=false
   // items.name=arrayArrayNumber items.baseName=arrayArrayNumber items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;BigDecimal&gt;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -34,7 +34,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ArrayOfNumberOnly")
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   // Is a container wrapped=false
   // items.name=arrayNumber items.baseName=arrayNumber items.xmlName= items.xmlNamespace=
   // items.example= items.type=BigDecimal

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -34,21 +34,24 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ArrayTest")
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   // Is a container wrapped=false
   // items.name=arrayOfString items.baseName=arrayOfString items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "arrayOfString")
   private List<String> arrayOfString = new ArrayList<String>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   // Is a container wrapped=false
   // items.name=arrayArrayOfInteger items.baseName=arrayArrayOfInteger items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;Long&gt;
   @XmlElement(name = "arrayArrayOfInteger")
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   // Is a container wrapped=false
   // items.name=arrayArrayOfModel items.baseName=arrayArrayOfModel items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;ReadOnlyFirst&gt;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -31,32 +31,38 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Capitalization")
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   @JacksonXmlProperty(localName = "smallCamel")
   @XmlElement(name = "smallCamel")
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   @JacksonXmlProperty(localName = "CapitalCamel")
   @XmlElement(name = "CapitalCamel")
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   @JacksonXmlProperty(localName = "small_Snake")
   @XmlElement(name = "small_Snake")
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   @JacksonXmlProperty(localName = "Capital_Snake")
   @XmlElement(name = "Capital_Snake")
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   @JacksonXmlProperty(localName = "SCA_ETH_Flow_Points")
   @XmlElement(name = "SCA_ETH_Flow_Points")
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   @JacksonXmlProperty(localName = "ATT_NAME")
   @XmlElement(name = "ATT_NAME")
   private String ATT_NAME;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
@@ -33,7 +33,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Cat")
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   @JacksonXmlProperty(localName = "declawed")
   @XmlElement(name = "declawed")
   private Boolean declawed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -31,7 +31,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "CatAllOf")
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   @JacksonXmlProperty(localName = "declawed")
   @XmlElement(name = "declawed")
   private Boolean declawed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
@@ -31,12 +31,14 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Category")
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   @JacksonXmlProperty(localName = "id")
   @XmlElement(name = "id")
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private String name = "default-name";

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -32,7 +32,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ClassModel")
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   @JacksonXmlProperty(localName = "_class")
   @XmlElement(name = "_class")
   private String propertyClass;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
@@ -31,7 +31,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Client")
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   @JacksonXmlProperty(localName = "client")
   @XmlElement(name = "client")
   private String client;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
@@ -33,7 +33,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Dog")
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   @JacksonXmlProperty(localName = "breed")
   @XmlElement(name = "breed")
   private String breed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -31,7 +31,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "DogAllOf")
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   @JacksonXmlProperty(localName = "breed")
   @XmlElement(name = "breed")
   private String breed;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -68,7 +68,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   @JacksonXmlProperty(localName = "just_symbol")
   @XmlElement(name = "just_symbol")
   private JustSymbolEnum justSymbol;
@@ -108,7 +109,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   // Is a container wrapped=false
   // items.name=arrayEnum items.baseName=arrayEnum items.xmlName= items.xmlNamespace=
   // items.example= items.type=String

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -69,7 +69,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   @JacksonXmlProperty(localName = "enum_string")
   @XmlElement(name = "enum_string")
   private EnumStringEnum enumString;
@@ -111,7 +112,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   @JacksonXmlProperty(localName = "enum_string_required")
   @XmlElement(name = "enum_string_required")
   private EnumStringRequiredEnum enumStringRequired;
@@ -151,7 +153,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   @JacksonXmlProperty(localName = "enum_integer")
   @XmlElement(name = "enum_integer")
   private EnumIntegerEnum enumInteger;
@@ -191,12 +194,14 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   @JacksonXmlProperty(localName = "enum_number")
   @XmlElement(name = "enum_number")
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   @JacksonXmlProperty(localName = "outerEnum")
   @XmlElement(name = "outerEnum")
   private OuterEnum outerEnum;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -33,12 +33,14 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "FileSchemaTestClass")
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   @JacksonXmlProperty(localName = "file")
   @XmlElement(name = "file")
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   // Is a container wrapped=false
   // items.name=files items.baseName=files items.xmlName= items.xmlNamespace=
   // items.example= items.type=java.io.File

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -36,67 +36,80 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "FormatTest")
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   @JacksonXmlProperty(localName = "integer")
   @XmlElement(name = "integer")
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   @JacksonXmlProperty(localName = "int32")
   @XmlElement(name = "int32")
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   @JacksonXmlProperty(localName = "int64")
   @XmlElement(name = "int64")
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   @JacksonXmlProperty(localName = "number")
   @XmlElement(name = "number")
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   @JacksonXmlProperty(localName = "float")
   @XmlElement(name = "float")
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   @JacksonXmlProperty(localName = "double")
   @XmlElement(name = "double")
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   @JacksonXmlProperty(localName = "string")
   @XmlElement(name = "string")
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   @JacksonXmlProperty(localName = "byte")
   @XmlElement(name = "byte")
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   @JacksonXmlProperty(localName = "binary")
   @XmlElement(name = "binary")
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   @JacksonXmlProperty(localName = "date")
   @XmlElement(name = "date")
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   @JacksonXmlProperty(localName = "dateTime")
   @XmlElement(name = "dateTime")
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   @JacksonXmlProperty(localName = "uuid")
   @XmlElement(name = "uuid")
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   @JacksonXmlProperty(localName = "password")
   @XmlElement(name = "password")
   private String password;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -31,12 +31,14 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "HasOnlyReadOnly")
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   @JacksonXmlProperty(localName = "bar")
   @XmlElement(name = "bar")
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   @JacksonXmlProperty(localName = "foo")
   @XmlElement(name = "foo")
   private String foo;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
@@ -34,7 +34,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "MapTest")
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Map&lt;String, String&gt;
@@ -76,21 +77,24 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "inner")
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Boolean
   @XmlElement(name = "inner")
   private Map<String, Boolean> directMap = new HashMap<String, Boolean>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Boolean

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -37,17 +37,20 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "MixedPropertiesAndAdditionalPropertiesClass")
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   @JacksonXmlProperty(localName = "uuid")
   @XmlElement(name = "uuid")
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   @JacksonXmlProperty(localName = "dateTime")
   @XmlElement(name = "dateTime")
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Animal

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -32,12 +32,14 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Name")
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   @JacksonXmlProperty(localName = "class")
   @XmlElement(name = "class")
   private String propertyClass;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -31,17 +31,20 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ModelApiResponse")
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   @JacksonXmlProperty(localName = "code")
   @XmlElement(name = "code")
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   @JacksonXmlProperty(localName = "type")
   @XmlElement(name = "type")
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JacksonXmlProperty(localName = "message")
   @XmlElement(name = "message")
   private String message;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -32,7 +32,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Return")
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   @JacksonXmlProperty(localName = "return")
   @XmlElement(name = "return")
   private Integer _return;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
@@ -32,22 +32,26 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Name")
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   @JacksonXmlProperty(localName = "snake_case")
   @XmlElement(name = "snake_case")
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   @JacksonXmlProperty(localName = "property")
   @XmlElement(name = "property")
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   @JacksonXmlProperty(localName = "123Number")
   @XmlElement(name = "123Number")
   private Integer _123number;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -32,7 +32,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "NumberOnly")
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   @JacksonXmlProperty(localName = "JustNumber")
   @XmlElement(name = "JustNumber")
   private BigDecimal justNumber;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
@@ -32,22 +32,26 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Order")
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   @JacksonXmlProperty(localName = "id")
   @XmlElement(name = "id")
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   @JacksonXmlProperty(localName = "petId")
   @XmlElement(name = "petId")
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   @JacksonXmlProperty(localName = "quantity")
   @XmlElement(name = "quantity")
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   @JacksonXmlProperty(localName = "shipDate")
   @XmlElement(name = "shipDate")
   private OffsetDateTime shipDate;
@@ -89,12 +93,14 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   @JacksonXmlProperty(localName = "status")
   @XmlElement(name = "status")
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   @JacksonXmlProperty(localName = "complete")
   @XmlElement(name = "complete")
   private Boolean complete = false;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -32,17 +32,20 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "OuterComposite")
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   @JacksonXmlProperty(localName = "my_number")
   @XmlElement(name = "my_number")
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   @JacksonXmlProperty(localName = "my_string")
   @XmlElement(name = "my_string")
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   @JacksonXmlProperty(localName = "my_boolean")
   @XmlElement(name = "my_boolean")
   private Boolean myBoolean;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
@@ -35,22 +35,26 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Pet")
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   @JacksonXmlProperty(localName = "id")
   @XmlElement(name = "id")
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   @JacksonXmlProperty(localName = "category")
   @XmlElement(name = "category")
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   // items.xmlName=
   @JacksonXmlElementWrapper(useWrapping = true, localName = "photoUrls")
   // Is a container wrapped=true
@@ -60,7 +64,8 @@ public class Pet {
   @XmlElementWrapper(name = "photoUrl")
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   // items.xmlName=
   @JacksonXmlElementWrapper(useWrapping = true, localName = "tags")
   // Is a container wrapped=true
@@ -107,7 +112,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   @JacksonXmlProperty(localName = "status")
   @XmlElement(name = "status")
   private StatusEnum status;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -31,12 +31,14 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ReadOnlyFirst")
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   @JacksonXmlProperty(localName = "bar")
   @XmlElement(name = "bar")
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   @JacksonXmlProperty(localName = "baz")
   @XmlElement(name = "baz")
   private String baz;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -31,7 +31,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "$special[model.name]")
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "$special[property.name]")
   @XmlElement(name = "$special[property.name]")
   private Long $specialPropertyName;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
@@ -31,12 +31,14 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Tag")
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   @JacksonXmlProperty(localName = "id")
   @XmlElement(name = "id")
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   @JacksonXmlProperty(localName = "name")
   @XmlElement(name = "name")
   private String name;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -34,27 +34,32 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "TypeHolderDefault")
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   @JacksonXmlProperty(localName = "string_item")
   @XmlElement(name = "string_item")
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   @JacksonXmlProperty(localName = "number_item")
   @XmlElement(name = "number_item")
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   @JacksonXmlProperty(localName = "integer_item")
   @XmlElement(name = "integer_item")
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   @JacksonXmlProperty(localName = "bool_item")
   @XmlElement(name = "bool_item")
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   // Is a container wrapped=false
   // items.name=arrayItem items.baseName=arrayItem items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -34,27 +34,32 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "TypeHolderExample")
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   @JacksonXmlProperty(localName = "string_item")
   @XmlElement(name = "string_item")
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   @JacksonXmlProperty(localName = "number_item")
   @XmlElement(name = "number_item")
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   @JacksonXmlProperty(localName = "integer_item")
   @XmlElement(name = "integer_item")
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   @JacksonXmlProperty(localName = "bool_item")
   @XmlElement(name = "bool_item")
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   // Is a container wrapped=false
   // items.name=arrayItem items.baseName=arrayItem items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
@@ -31,42 +31,50 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "User")
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   @JacksonXmlProperty(localName = "id")
   @XmlElement(name = "id")
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   @JacksonXmlProperty(localName = "username")
   @XmlElement(name = "username")
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   @JacksonXmlProperty(localName = "firstName")
   @XmlElement(name = "firstName")
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   @JacksonXmlProperty(localName = "lastName")
   @XmlElement(name = "lastName")
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   @JacksonXmlProperty(localName = "email")
   @XmlElement(name = "email")
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   @JacksonXmlProperty(localName = "password")
   @XmlElement(name = "password")
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   @JacksonXmlProperty(localName = "phone")
   @XmlElement(name = "phone")
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   @JacksonXmlProperty(localName = "userStatus")
   @XmlElement(name = "userStatus")
   private Integer userStatus;

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -34,27 +34,32 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(namespace="http://a.com/schema", localName = "XmlItem")
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   @JacksonXmlProperty(isAttribute = true, localName = "attribute_string")
   @XmlAttribute(name = "attribute_string")
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   @JacksonXmlProperty(isAttribute = true, localName = "attribute_number")
   @XmlAttribute(name = "attribute_number")
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   @JacksonXmlProperty(isAttribute = true, localName = "attribute_integer")
   @XmlAttribute(name = "attribute_integer")
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   @JacksonXmlProperty(isAttribute = true, localName = "attribute_boolean")
   @XmlAttribute(name = "attribute_boolean")
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   // items.xmlName=
   @JacksonXmlElementWrapper(useWrapping = true, localName = "wrappedArray")
   // Is a container wrapped=true
@@ -64,34 +69,40 @@ public class XmlItem {
   @XmlElementWrapper(name = "wrapped_array")
   private List<Integer> wrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   @JacksonXmlProperty(localName = "xml_name_string")
   @XmlElement(name = "xml_name_string")
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   @JacksonXmlProperty(localName = "xml_name_number")
   @XmlElement(name = "xml_name_number")
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   @JacksonXmlProperty(localName = "xml_name_integer")
   @XmlElement(name = "xml_name_integer")
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   @JacksonXmlProperty(localName = "xml_name_boolean")
   @XmlElement(name = "xml_name_boolean")
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   // Is a container wrapped=false
   // items.name=nameArray items.baseName=nameArray items.xmlName=xml_name_array_item items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "xml_name_array_item")
   private List<Integer> nameArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   // items.xmlName=xml_name_wrapped_array_item
   @JacksonXmlElementWrapper(useWrapping = true, localName = "xml_name_wrapped_array_item")
   // Is a container wrapped=true
@@ -101,34 +112,40 @@ public class XmlItem {
   @XmlElementWrapper(name = "xml_name_wrapped_array")
   private List<Integer> nameWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   @JacksonXmlProperty(localName = "prefix_string")
   @XmlElement(name = "prefix_string")
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   @JacksonXmlProperty(localName = "prefix_number")
   @XmlElement(name = "prefix_number")
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   @JacksonXmlProperty(localName = "prefix_integer")
   @XmlElement(name = "prefix_integer")
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   @JacksonXmlProperty(localName = "prefix_boolean")
   @XmlElement(name = "prefix_boolean")
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   // Is a container wrapped=false
   // items.name=prefixArray items.baseName=prefixArray items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "prefixArray")
   private List<Integer> prefixArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   // items.xmlName=
   @JacksonXmlElementWrapper(useWrapping = true, localName = "prefixWrappedArray")
   // Is a container wrapped=true
@@ -138,34 +155,40 @@ public class XmlItem {
   @XmlElementWrapper(name = "prefix_wrapped_array")
   private List<Integer> prefixWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   @JacksonXmlProperty(namespace="http://a.com/schema", localName = "namespace_string")
   @XmlElement(namespace="http://a.com/schema", name = "namespace_string")
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   @JacksonXmlProperty(namespace="http://b.com/schema", localName = "namespace_number")
   @XmlElement(namespace="http://b.com/schema", name = "namespace_number")
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   @JacksonXmlProperty(namespace="http://c.com/schema", localName = "namespace_integer")
   @XmlElement(namespace="http://c.com/schema", name = "namespace_integer")
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   @JacksonXmlProperty(namespace="http://d.com/schema", localName = "namespace_boolean")
   @XmlElement(namespace="http://d.com/schema", name = "namespace_boolean")
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   // Is a container wrapped=false
   // items.name=namespaceArray items.baseName=namespaceArray items.xmlName= items.xmlNamespace=http://e.com/schema
   // items.example= items.type=Integer
   @XmlElement(namespace="http://e.com/schema", name = "namespaceArray")
   private List<Integer> namespaceArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   // items.xmlName=
   @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "namespaceWrappedArray")
   // Is a container wrapped=true
@@ -175,34 +198,40 @@ public class XmlItem {
   @XmlElementWrapper(namespace="http://f.com/schema", name = "namespace_wrapped_array")
   private List<Integer> namespaceWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   @JacksonXmlProperty(namespace="http://a.com/schema", localName = "prefix_ns_string")
   @XmlElement(namespace="http://a.com/schema", name = "prefix_ns_string")
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   @JacksonXmlProperty(namespace="http://b.com/schema", localName = "prefix_ns_number")
   @XmlElement(namespace="http://b.com/schema", name = "prefix_ns_number")
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   @JacksonXmlProperty(namespace="http://c.com/schema", localName = "prefix_ns_integer")
   @XmlElement(namespace="http://c.com/schema", name = "prefix_ns_integer")
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   @JacksonXmlProperty(namespace="http://d.com/schema", localName = "prefix_ns_boolean")
   @XmlElement(namespace="http://d.com/schema", name = "prefix_ns_boolean")
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   // Is a container wrapped=false
   // items.name=prefixNsArray items.baseName=prefixNsArray items.xmlName= items.xmlNamespace=http://e.com/schema
   // items.example= items.type=Integer
   @XmlElement(namespace="http://e.com/schema", name = "prefixNsArray")
   private List<Integer> prefixNsArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   // items.xmlName=
   @JacksonXmlElementWrapper(useWrapping = true, namespace="http://f.com/schema", localName = "prefixNsWrappedArray")
   // Is a container wrapped=true

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<String, String>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<String, BigDecimal>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<String, Integer>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<String, Boolean>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<String, List<Integer>>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<String, List<Object>>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<String, Map<String, String>>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<String, Map<String, Object>>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<List<BigDecimal>>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<BigDecimal>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<String>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<List<Long>>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<List<ReadOnlyFirst>>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<ArrayEnumEnum>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<java.io.File>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<String, Map<String, String>>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<String, InnerEnum>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<String, Boolean>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<String, Boolean>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<String, Animal>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import org.threeten.bp.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<Tag>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<Integer>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<Integer>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<Integer>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<Integer>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -32,37 +32,48 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Animal.java
@@ -36,10 +36,12 @@ import javax.validation.Valid;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -31,13 +31,16 @@ import javax.validation.Valid;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -28,22 +28,28 @@ import javax.validation.Valid;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Cat.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Category.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Client.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Dog.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -65,7 +65,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,7 +104,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -66,7 +66,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +107,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -144,7 +146,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -182,10 +185,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -30,10 +30,12 @@ import javax.validation.Valid;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -33,43 +33,56 @@ import javax.validation.Valid;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MapTest.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<>();
 
   /**
@@ -69,13 +70,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -34,13 +34,16 @@ import javax.validation.Valid;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -29,10 +29,12 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -28,13 +28,16 @@ import javax.validation.Valid;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Name.java
@@ -29,16 +29,20 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
@@ -29,16 +29,20 @@ import javax.validation.Valid;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -78,10 +82,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -29,13 +29,16 @@ import javax.validation.Valid;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Pet.java
@@ -32,19 +32,24 @@ import javax.validation.Valid;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<>();
 
   /**
@@ -84,7 +89,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Tag.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/User.java
@@ -28,28 +28,36 @@ import javax.validation.Valid;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -31,91 +31,120 @@ import javax.validation.Valid;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -32,37 +32,48 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Animal.java
@@ -36,10 +36,12 @@ import javax.validation.Valid;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -31,13 +31,16 @@ import javax.validation.Valid;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -28,22 +28,28 @@ import javax.validation.Valid;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Cat.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Category.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Client.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Dog.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -65,7 +65,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,7 +104,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -66,7 +66,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +107,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -144,7 +146,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -182,10 +185,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -30,10 +30,12 @@ import javax.validation.Valid;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -33,43 +33,56 @@ import javax.validation.Valid;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MapTest.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<>();
 
   /**
@@ -69,13 +70,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -34,13 +34,16 @@ import javax.validation.Valid;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -29,10 +29,12 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -28,13 +28,16 @@ import javax.validation.Valid;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Name.java
@@ -29,16 +29,20 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
@@ -29,16 +29,20 @@ import javax.validation.Valid;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -78,10 +82,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -29,13 +29,16 @@ import javax.validation.Valid;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Pet.java
@@ -32,19 +32,24 @@ import javax.validation.Valid;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<>();
 
   /**
@@ -84,7 +89,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Tag.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/User.java
@@ -28,28 +28,36 @@ import javax.validation.Valid;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -31,91 +31,120 @@ import javax.validation.Valid;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -32,37 +32,48 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
@@ -36,10 +36,12 @@ import javax.validation.Valid;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -31,13 +31,16 @@ import javax.validation.Valid;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -28,22 +28,28 @@ import javax.validation.Valid;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -65,7 +65,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -103,7 +104,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -66,7 +66,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -106,7 +107,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -144,7 +146,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -182,10 +185,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -30,10 +30,12 @@ import javax.validation.Valid;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -33,43 +33,56 @@ import javax.validation.Valid;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<>();
 
   /**
@@ -69,13 +70,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -34,13 +34,16 @@ import javax.validation.Valid;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -29,10 +29,12 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -28,13 +28,16 @@ import javax.validation.Valid;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
@@ -29,16 +29,20 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
@@ -29,16 +29,20 @@ import javax.validation.Valid;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -78,10 +82,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -29,13 +29,16 @@ import javax.validation.Valid;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
@@ -32,19 +32,24 @@ import javax.validation.Valid;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<>();
 
   /**
@@ -84,7 +89,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
@@ -28,28 +28,36 @@ import javax.validation.Valid;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -31,91 +31,120 @@ import javax.validation.Valid;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import java.util.UUID;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private AsyncFile binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.openapitools.client.model.Animal;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import java.time.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesClass {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = new HashMap<>();
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = new HashMap<>();
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = new HashMap<>();
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = new HashMap<>();
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = new HashMap<>();
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = new HashMap<>();
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import java.util.Map;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
@@ -34,10 +34,12 @@ import io.swagger.annotations.ApiModelProperty;
 })
 
 public class Animal {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfArrayOfNumberOnly {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = new ArrayList<>();
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import java.util.List;
  */
 
 public class ArrayOfNumberOnly {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = new ArrayList<>();
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -29,13 +29,16 @@ import org.openapitools.client.model.ReadOnlyFirst;
  */
 
 public class ArrayTest {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = new ArrayList<>();
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = new ArrayList<>();
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = new ArrayList<>();
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -26,22 +26,28 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Capitalization {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.CatAllOf;
  */
 
 public class Cat extends Animal {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class CatAllOf {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Category {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Client {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
@@ -28,7 +28,8 @@ import org.openapitools.client.model.DogAllOf;
  */
 
 public class Dog extends Animal {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class DogAllOf {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -63,7 +63,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -101,7 +102,8 @@ public class EnumArrays {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = new ArrayList<>();
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -104,7 +105,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -142,7 +144,8 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -180,10 +183,12 @@ public class EnumTest {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import java.util.List;
  */
 
 public class FileSchemaTestClass {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = new ArrayList<>();
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -31,43 +31,56 @@ import java.util.UUID;
  */
 
 public class FormatTest {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class HasOnlyReadOnly {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
    /**

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
  */
 
 public class MapTest {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = new HashMap<>();
 
   /**
@@ -67,13 +68,16 @@ public class MapTest {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = new HashMap<>();
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = new HashMap<>();
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = new HashMap<>();
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import org.openapitools.client.model.Animal;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = new HashMap<>();
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -27,10 +27,12 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ModelApiResponse {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -27,7 +27,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
@@ -27,16 +27,20 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -27,7 +27,8 @@ import java.math.BigDecimal;
  */
 
 public class NumberOnly {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
@@ -27,16 +27,20 @@ import java.time.OffsetDateTime;
  */
 
 public class Order {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -76,10 +80,12 @@ public class Order {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -27,13 +27,16 @@ import java.math.BigDecimal;
  */
 
 public class OuterComposite {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
@@ -30,19 +30,24 @@ import org.openapitools.client.model.Tag;
  */
 
 public class Pet {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = new ArrayList<>();
 
   /**
@@ -82,7 +87,8 @@ public class Pet {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class ReadOnlyFirst {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
    /**

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
@@ -26,10 +26,12 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class Tag {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderDefault {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import java.util.List;
  */
 
 public class TypeHolderExample {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
@@ -26,28 +26,36 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class User {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -29,91 +29,120 @@ import java.util.List;
  */
 
 public class XmlItem {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = new ArrayList<>();
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = new ArrayList<>();
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = new ArrayList<>();
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = new ArrayList<>();
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = new ArrayList<>();
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = new ArrayList<>();
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -31,37 +31,48 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesClass  implements Serializable {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Animal.java
@@ -34,10 +34,12 @@ import javax.validation.Valid;
 })
 
 public class Animal  implements Serializable {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfArrayOfNumberOnly  implements Serializable {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfNumberOnly  implements Serializable {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -30,13 +30,16 @@ import javax.validation.Valid;
  */
 
 public class ArrayTest  implements Serializable {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Capitalization.java
@@ -27,22 +27,28 @@ import javax.validation.Valid;
  */
 
 public class Capitalization  implements Serializable {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Cat.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class Cat extends Animal implements Serializable {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/CatAllOf.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
  */
 
 public class CatAllOf  implements Serializable {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Category.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
  */
 
 public class Category  implements Serializable {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ClassModel.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel  implements Serializable {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Client.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
  */
 
 public class Client  implements Serializable {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Dog.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class Dog extends Animal implements Serializable {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/DogAllOf.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
  */
 
 public class DogAllOf  implements Serializable {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -61,7 +61,8 @@ public class EnumArrays  implements Serializable {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -95,7 +96,8 @@ public class EnumArrays  implements Serializable {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/EnumTest.java
@@ -62,7 +62,8 @@ public class EnumTest  implements Serializable {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -98,7 +99,8 @@ public class EnumTest  implements Serializable {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -132,7 +134,8 @@ public class EnumTest  implements Serializable {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -166,10 +169,12 @@ public class EnumTest  implements Serializable {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -29,10 +29,12 @@ import javax.validation.Valid;
  */
 
 public class FileSchemaTestClass  implements Serializable {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FormatTest.java
@@ -32,43 +32,56 @@ import javax.validation.Valid;
  */
 
 public class FormatTest  implements Serializable {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private LocalDate date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
  */
 
 public class HasOnlyReadOnly  implements Serializable {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
   public HasOnlyReadOnly bar(String bar) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MapTest.java
@@ -31,7 +31,8 @@ import javax.validation.Valid;
  */
 
 public class MapTest  implements Serializable {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -65,13 +66,16 @@ public class MapTest  implements Serializable {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -33,13 +33,16 @@ import javax.validation.Valid;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializable {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private OffsetDateTime dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Model200Response.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response  implements Serializable {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -27,13 +27,16 @@ import javax.validation.Valid;
  */
 
 public class ModelApiResponse  implements Serializable {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn  implements Serializable {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Name.java
@@ -28,16 +28,20 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name  implements Serializable {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class NumberOnly  implements Serializable {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Order.java
@@ -29,16 +29,20 @@ import javax.validation.Valid;
  */
 
 public class Order  implements Serializable {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private OffsetDateTime shipDate;
 
   /**
@@ -74,10 +78,12 @@ public class Order  implements Serializable {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -28,13 +28,16 @@ import javax.validation.Valid;
  */
 
 public class OuterComposite  implements Serializable {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Pet.java
@@ -32,19 +32,24 @@ import javax.validation.Valid;
  */
 
 public class Pet  implements Serializable {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -80,7 +85,8 @@ public class Pet  implements Serializable {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
  */
 
 public class ReadOnlyFirst  implements Serializable {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
   public ReadOnlyFirst bar(String bar) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName  implements Serializable {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/Tag.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
  */
 
 public class Tag  implements Serializable {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -30,19 +30,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderDefault  implements Serializable {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -30,19 +30,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderExample  implements Serializable {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/User.java
@@ -27,28 +27,36 @@ import javax.validation.Valid;
  */
 
 public class User  implements Serializable {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/XmlItem.java
@@ -30,91 +30,120 @@ import javax.validation.Valid;
  */
 
 public class XmlItem  implements Serializable {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -29,10 +29,12 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesClass   {
-  @JsonProperty("map_property")
+  public static final String JSON_PROPERTY_MAP_PROPERTY = "map_property";
+  @JsonProperty(JSON_PROPERTY_MAP_PROPERTY)
   private Map<String, String> mapProperty = null;
 
-  @JsonProperty("map_of_map_property")
+  public static final String JSON_PROPERTY_MAP_OF_MAP_PROPERTY = "map_of_map_property";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_MAP_PROPERTY)
   private Map<String, Map<String, String>> mapOfMapProperty = null;
 
   public AdditionalPropertiesClass mapProperty(Map<String, String> mapProperty) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Animal.java
@@ -33,10 +33,12 @@ import javax.validation.Valid;
 })
 
 public class Animal   {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfArrayOfNumberOnly   {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfNumberOnly   {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -29,13 +29,16 @@ import javax.validation.Valid;
  */
 
 public class ArrayTest   {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Capitalization.java
@@ -26,22 +26,28 @@ import javax.validation.Valid;
  */
 
 public class Capitalization   {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Cat.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Cat extends Animal  {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/CatAllOf.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class CatAllOf   {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Category.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class Category   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ClassModel.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel   {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Client.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class Client   {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Dog.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Dog extends Animal  {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/DogAllOf.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class DogAllOf   {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -60,7 +60,8 @@ public class EnumArrays   {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -94,7 +95,8 @@ public class EnumArrays   {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/EnumTest.java
@@ -64,7 +64,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -100,7 +101,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -134,7 +136,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -168,19 +171,24 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
-  @JsonProperty("outerEnumInteger")
+  public static final String JSON_PROPERTY_OUTER_ENUM_INTEGER = "outerEnumInteger";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM_INTEGER)
   private OuterEnumInteger outerEnumInteger;
 
-  @JsonProperty("outerEnumDefaultValue")
+  public static final String JSON_PROPERTY_OUTER_ENUM_DEFAULT_VALUE = "outerEnumDefaultValue";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM_DEFAULT_VALUE)
   private OuterEnumDefaultValue outerEnumDefaultValue = OuterEnumDefaultValue.PLACED;
 
-  @JsonProperty("outerEnumIntegerDefaultValue")
+  public static final String JSON_PROPERTY_OUTER_ENUM_INTEGER_DEFAULT_VALUE = "outerEnumIntegerDefaultValue";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM_INTEGER_DEFAULT_VALUE)
   private OuterEnumIntegerDefaultValue outerEnumIntegerDefaultValue = OuterEnumIntegerDefaultValue.NUMBER_0;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class FileSchemaTestClass   {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Foo.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Foo.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class Foo   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar = "bar";
 
   public Foo bar(String bar) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/FormatTest.java
@@ -30,49 +30,64 @@ import javax.validation.Valid;
  */
 
 public class FormatTest   {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private Date date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("pattern_with_digits")
+  public static final String JSON_PROPERTY_PATTERN_WITH_DIGITS = "pattern_with_digits";
+  @JsonProperty(JSON_PROPERTY_PATTERN_WITH_DIGITS)
   private String patternWithDigits;
 
-  @JsonProperty("pattern_with_digits_and_delimiter")
+  public static final String JSON_PROPERTY_PATTERN_WITH_DIGITS_AND_DELIMITER = "pattern_with_digits_and_delimiter";
+  @JsonProperty(JSON_PROPERTY_PATTERN_WITH_DIGITS_AND_DELIMITER)
   private String patternWithDigitsAndDelimiter;
 
   public FormatTest integer(Integer integer) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class HasOnlyReadOnly   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
   public HasOnlyReadOnly bar(String bar) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/HealthCheckResult.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/HealthCheckResult.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.")
 
 public class HealthCheckResult   {
-  @JsonProperty("NullableMessage")
+  public static final String JSON_PROPERTY_NULLABLE_MESSAGE = "NullableMessage";
+  @JsonProperty(JSON_PROPERTY_NULLABLE_MESSAGE)
   private String nullableMessage;
 
   public HealthCheckResult nullableMessage(String nullableMessage) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class InlineObject   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private String status;
 
   public InlineObject name(String name) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject1.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject1.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
  */
 
 public class InlineObject1   {
-  @JsonProperty("additionalMetadata")
+  public static final String JSON_PROPERTY_ADDITIONAL_METADATA = "additionalMetadata";
+  @JsonProperty(JSON_PROPERTY_ADDITIONAL_METADATA)
   private String additionalMetadata;
 
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private File file;
 
   public InlineObject1 additionalMetadata(String additionalMetadata) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject2.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject2.java
@@ -60,7 +60,8 @@ public class InlineObject2   {
     }
   }
 
-  @JsonProperty("enum_form_string_array")
+  public static final String JSON_PROPERTY_ENUM_FORM_STRING_ARRAY = "enum_form_string_array";
+  @JsonProperty(JSON_PROPERTY_ENUM_FORM_STRING_ARRAY)
   private List<EnumFormStringArrayEnum> enumFormStringArray = null;
 
   /**
@@ -96,7 +97,8 @@ public class InlineObject2   {
     }
   }
 
-  @JsonProperty("enum_form_string")
+  public static final String JSON_PROPERTY_ENUM_FORM_STRING = "enum_form_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_FORM_STRING)
   private EnumFormStringEnum enumFormString = EnumFormStringEnum._EFG;
 
   public InlineObject2 enumFormStringArray(List<EnumFormStringArrayEnum> enumFormStringArray) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject3.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject3.java
@@ -29,46 +29,60 @@ import javax.validation.Valid;
  */
 
 public class InlineObject3   {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("pattern_without_delimiter")
+  public static final String JSON_PROPERTY_PATTERN_WITHOUT_DELIMITER = "pattern_without_delimiter";
+  @JsonProperty(JSON_PROPERTY_PATTERN_WITHOUT_DELIMITER)
   private String patternWithoutDelimiter;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private Date date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("callback")
+  public static final String JSON_PROPERTY_CALLBACK = "callback";
+  @JsonProperty(JSON_PROPERTY_CALLBACK)
   private String callback;
 
   public InlineObject3 integer(Integer integer) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject4.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject4.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class InlineObject4   {
-  @JsonProperty("param")
+  public static final String JSON_PROPERTY_PARAM = "param";
+  @JsonProperty(JSON_PROPERTY_PARAM)
   private String param;
 
-  @JsonProperty("param2")
+  public static final String JSON_PROPERTY_PARAM2 = "param2";
+  @JsonProperty(JSON_PROPERTY_PARAM2)
   private String param2;
 
   public InlineObject4 param(String param) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject5.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineObject5.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
  */
 
 public class InlineObject5   {
-  @JsonProperty("additionalMetadata")
+  public static final String JSON_PROPERTY_ADDITIONAL_METADATA = "additionalMetadata";
+  @JsonProperty(JSON_PROPERTY_ADDITIONAL_METADATA)
   private String additionalMetadata;
 
-  @JsonProperty("requiredFile")
+  public static final String JSON_PROPERTY_REQUIRED_FILE = "requiredFile";
+  @JsonProperty(JSON_PROPERTY_REQUIRED_FILE)
   private File requiredFile;
 
   public InlineObject5 additionalMetadata(String additionalMetadata) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineResponseDefault.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/InlineResponseDefault.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
  */
 
 public class InlineResponseDefault   {
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private Foo string = null;
 
   public InlineResponseDefault string(Foo string) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/MapTest.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class MapTest   {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -64,13 +65,16 @@ public class MapTest   {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import javax.validation.Valid;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Model200Response.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import javax.validation.Valid;
  */
 
 public class ModelApiResponse   {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn   {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Name.java
@@ -27,16 +27,20 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/NullableClass.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/NullableClass.java
@@ -32,40 +32,52 @@ import javax.validation.Valid;
  */
 
 public class NullableClass extends HashMap<String, Object>  {
-  @JsonProperty("integer_prop")
+  public static final String JSON_PROPERTY_INTEGER_PROP = "integer_prop";
+  @JsonProperty(JSON_PROPERTY_INTEGER_PROP)
   private Integer integerProp;
 
-  @JsonProperty("number_prop")
+  public static final String JSON_PROPERTY_NUMBER_PROP = "number_prop";
+  @JsonProperty(JSON_PROPERTY_NUMBER_PROP)
   private BigDecimal numberProp;
 
-  @JsonProperty("boolean_prop")
+  public static final String JSON_PROPERTY_BOOLEAN_PROP = "boolean_prop";
+  @JsonProperty(JSON_PROPERTY_BOOLEAN_PROP)
   private Boolean booleanProp;
 
-  @JsonProperty("string_prop")
+  public static final String JSON_PROPERTY_STRING_PROP = "string_prop";
+  @JsonProperty(JSON_PROPERTY_STRING_PROP)
   private String stringProp;
 
-  @JsonProperty("date_prop")
+  public static final String JSON_PROPERTY_DATE_PROP = "date_prop";
+  @JsonProperty(JSON_PROPERTY_DATE_PROP)
   private Date dateProp;
 
-  @JsonProperty("datetime_prop")
+  public static final String JSON_PROPERTY_DATETIME_PROP = "datetime_prop";
+  @JsonProperty(JSON_PROPERTY_DATETIME_PROP)
   private Date datetimeProp;
 
-  @JsonProperty("array_nullable_prop")
+  public static final String JSON_PROPERTY_ARRAY_NULLABLE_PROP = "array_nullable_prop";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NULLABLE_PROP)
   private List<Object> arrayNullableProp = null;
 
-  @JsonProperty("array_and_items_nullable_prop")
+  public static final String JSON_PROPERTY_ARRAY_AND_ITEMS_NULLABLE_PROP = "array_and_items_nullable_prop";
+  @JsonProperty(JSON_PROPERTY_ARRAY_AND_ITEMS_NULLABLE_PROP)
   private List<Object> arrayAndItemsNullableProp = null;
 
-  @JsonProperty("array_items_nullable")
+  public static final String JSON_PROPERTY_ARRAY_ITEMS_NULLABLE = "array_items_nullable";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEMS_NULLABLE)
   private List<Object> arrayItemsNullable = null;
 
-  @JsonProperty("object_nullable_prop")
+  public static final String JSON_PROPERTY_OBJECT_NULLABLE_PROP = "object_nullable_prop";
+  @JsonProperty(JSON_PROPERTY_OBJECT_NULLABLE_PROP)
   private Map<String, Object> objectNullableProp = null;
 
-  @JsonProperty("object_and_items_nullable_prop")
+  public static final String JSON_PROPERTY_OBJECT_AND_ITEMS_NULLABLE_PROP = "object_and_items_nullable_prop";
+  @JsonProperty(JSON_PROPERTY_OBJECT_AND_ITEMS_NULLABLE_PROP)
   private Map<String, Object> objectAndItemsNullableProp = null;
 
-  @JsonProperty("object_items_nullable")
+  public static final String JSON_PROPERTY_OBJECT_ITEMS_NULLABLE = "object_items_nullable";
+  @JsonProperty(JSON_PROPERTY_OBJECT_ITEMS_NULLABLE)
   private Map<String, Object> objectItemsNullable = null;
 
   public NullableClass integerProp(Integer integerProp) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
  */
 
 public class NumberOnly   {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Order.java
@@ -28,16 +28,20 @@ import javax.validation.Valid;
  */
 
 public class Order   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private Date shipDate;
 
   /**
@@ -73,10 +77,12 @@ public class Order   {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -27,13 +27,16 @@ import javax.validation.Valid;
  */
 
 public class OuterComposite   {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Pet.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class Pet   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -79,7 +84,8 @@ public class Pet   {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class ReadOnlyFirst   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
   public ReadOnlyFirst bar(String bar) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName   {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/Tag.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class Tag   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/User.java
@@ -26,28 +26,36 @@ import javax.validation.Valid;
  */
 
 public class User   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesClass   {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Animal.java
@@ -33,10 +33,12 @@ import javax.validation.Valid;
 })
 
 public class Animal   {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfArrayOfNumberOnly   {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfNumberOnly   {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -29,13 +29,16 @@ import javax.validation.Valid;
  */
 
 public class ArrayTest   {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Capitalization.java
@@ -26,22 +26,28 @@ import javax.validation.Valid;
  */
 
 public class Capitalization   {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Cat.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Cat extends Animal  {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/CatAllOf.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class CatAllOf   {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Category.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class Category   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ClassModel.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel   {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Client.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class Client   {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Dog.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Dog extends Animal  {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/DogAllOf.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class DogAllOf   {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -60,7 +60,8 @@ public class EnumArrays   {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -94,7 +95,8 @@ public class EnumArrays   {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/EnumTest.java
@@ -61,7 +61,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -97,7 +98,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -131,7 +133,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -165,10 +168,12 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class FileSchemaTestClass   {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FormatTest.java
@@ -30,43 +30,56 @@ import javax.validation.Valid;
  */
 
 public class FormatTest   {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private Date date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class HasOnlyReadOnly   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
   public HasOnlyReadOnly bar(String bar) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MapTest.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class MapTest   {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -64,13 +65,16 @@ public class MapTest   {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import javax.validation.Valid;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Model200Response.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import javax.validation.Valid;
  */
 
 public class ModelApiResponse   {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn   {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Name.java
@@ -27,16 +27,20 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
  */
 
 public class NumberOnly   {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Order.java
@@ -28,16 +28,20 @@ import javax.validation.Valid;
  */
 
 public class Order   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private Date shipDate;
 
   /**
@@ -73,10 +77,12 @@ public class Order   {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -27,13 +27,16 @@ import javax.validation.Valid;
  */
 
 public class OuterComposite   {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Pet.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class Pet   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -79,7 +84,8 @@ public class Pet   {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class ReadOnlyFirst   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
   public ReadOnlyFirst bar(String bar) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName   {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/Tag.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class Tag   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderDefault   {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderExample   {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/User.java
@@ -26,28 +26,36 @@ import javax.validation.Valid;
  */
 
 public class User   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/XmlItem.java
@@ -29,91 +29,120 @@ import javax.validation.Valid;
  */
 
 public class XmlItem   {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesClass   {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Animal.java
@@ -33,10 +33,12 @@ import javax.validation.Valid;
 })
 
 public class Animal   {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfArrayOfNumberOnly   {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfNumberOnly   {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -29,13 +29,16 @@ import javax.validation.Valid;
  */
 
 public class ArrayTest   {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Capitalization.java
@@ -26,22 +26,28 @@ import javax.validation.Valid;
  */
 
 public class Capitalization   {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Cat.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Cat extends Animal  {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/CatAllOf.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class CatAllOf   {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Category.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class Category   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ClassModel.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel   {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Client.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class Client   {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Dog.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Dog extends Animal  {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/DogAllOf.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class DogAllOf   {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -60,7 +60,8 @@ public class EnumArrays   {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -94,7 +95,8 @@ public class EnumArrays   {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/EnumTest.java
@@ -61,7 +61,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -97,7 +98,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -131,7 +133,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -165,10 +168,12 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class FileSchemaTestClass   {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FormatTest.java
@@ -30,43 +30,56 @@ import javax.validation.Valid;
  */
 
 public class FormatTest   {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private Date date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class HasOnlyReadOnly   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
   public HasOnlyReadOnly bar(String bar) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MapTest.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class MapTest   {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -64,13 +65,16 @@ public class MapTest   {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import javax.validation.Valid;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Model200Response.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import javax.validation.Valid;
  */
 
 public class ModelApiResponse   {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn   {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Name.java
@@ -27,16 +27,20 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
  */
 
 public class NumberOnly   {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Order.java
@@ -28,16 +28,20 @@ import javax.validation.Valid;
  */
 
 public class Order   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private Date shipDate;
 
   /**
@@ -73,10 +77,12 @@ public class Order   {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -27,13 +27,16 @@ import javax.validation.Valid;
  */
 
 public class OuterComposite   {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Pet.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class Pet   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -79,7 +84,8 @@ public class Pet   {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class ReadOnlyFirst   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
   public ReadOnlyFirst bar(String bar) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName   {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/Tag.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class Tag   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderDefault   {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderExample   {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/User.java
@@ -26,28 +26,36 @@ import javax.validation.Valid;
  */
 
 public class User   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/XmlItem.java
@@ -29,91 +29,120 @@ import javax.validation.Valid;
  */
 
 public class XmlItem   {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesClass   {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Animal.java
@@ -33,10 +33,12 @@ import javax.validation.Valid;
 })
 
 public class Animal   {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfArrayOfNumberOnly   {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfNumberOnly   {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -29,13 +29,16 @@ import javax.validation.Valid;
  */
 
 public class ArrayTest   {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Capitalization.java
@@ -26,22 +26,28 @@ import javax.validation.Valid;
  */
 
 public class Capitalization   {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Cat.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Cat extends Animal  {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/CatAllOf.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class CatAllOf   {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Category.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class Category   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ClassModel.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel   {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Client.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class Client   {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Dog.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Dog extends Animal  {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/DogAllOf.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class DogAllOf   {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -60,7 +60,8 @@ public class EnumArrays   {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -94,7 +95,8 @@ public class EnumArrays   {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/EnumTest.java
@@ -61,7 +61,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -97,7 +98,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -131,7 +133,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -165,10 +168,12 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class FileSchemaTestClass   {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FormatTest.java
@@ -30,43 +30,56 @@ import javax.validation.Valid;
  */
 
 public class FormatTest   {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private Date date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class HasOnlyReadOnly   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
   public HasOnlyReadOnly bar(String bar) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MapTest.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class MapTest   {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -64,13 +65,16 @@ public class MapTest   {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import javax.validation.Valid;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Model200Response.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import javax.validation.Valid;
  */
 
 public class ModelApiResponse   {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn   {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Name.java
@@ -27,16 +27,20 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
  */
 
 public class NumberOnly   {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Order.java
@@ -28,16 +28,20 @@ import javax.validation.Valid;
  */
 
 public class Order   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private Date shipDate;
 
   /**
@@ -73,10 +77,12 @@ public class Order   {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -27,13 +27,16 @@ import javax.validation.Valid;
  */
 
 public class OuterComposite   {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Pet.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class Pet   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -79,7 +84,8 @@ public class Pet   {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class ReadOnlyFirst   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
   public ReadOnlyFirst bar(String bar) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName   {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/Tag.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class Tag   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderDefault   {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderExample   {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/User.java
@@ -26,28 +26,36 @@ import javax.validation.Valid;
  */
 
 public class User   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/XmlItem.java
@@ -29,91 +29,120 @@ import javax.validation.Valid;
  */
 
 public class XmlItem   {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
   public XmlItem attributeString(String attributeString) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesAnyType extends HashMap<String, Object>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesAnyType name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesArray extends HashMap<String, List>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesArray name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesBoolean name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -30,37 +30,48 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesClass   {
-  @JsonProperty("map_string")
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_STRING)
   private Map<String, String> mapString = null;
 
-  @JsonProperty("map_number")
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
+  @JsonProperty(JSON_PROPERTY_MAP_NUMBER)
   private Map<String, BigDecimal> mapNumber = null;
 
-  @JsonProperty("map_integer")
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_INTEGER)
   private Map<String, Integer> mapInteger = null;
 
-  @JsonProperty("map_boolean")
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
+  @JsonProperty(JSON_PROPERTY_MAP_BOOLEAN)
   private Map<String, Boolean> mapBoolean = null;
 
-  @JsonProperty("map_array_integer")
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_INTEGER)
   private Map<String, List<Integer>> mapArrayInteger = null;
 
-  @JsonProperty("map_array_anytype")
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_ARRAY_ANYTYPE)
   private Map<String, List<Object>> mapArrayAnytype = null;
 
-  @JsonProperty("map_map_string")
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_STRING)
   private Map<String, Map<String, String>> mapMapString = null;
 
-  @JsonProperty("map_map_anytype")
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_ANYTYPE)
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
-  @JsonProperty("anytype_1")
+  public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE1)
   private Object anytype1 = null;
 
-  @JsonProperty("anytype_2")
+  public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE2)
   private Object anytype2 = null;
 
-  @JsonProperty("anytype_3")
+  public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @JsonProperty(JSON_PROPERTY_ANYTYPE3)
   private Object anytype3 = null;
 
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesInteger extends HashMap<String, Integer>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesInteger name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesNumber name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesObject extends HashMap<String, Map>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesObject name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class AdditionalPropertiesString extends HashMap<String, String>  {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public AdditionalPropertiesString name(String name) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Animal.java
@@ -33,10 +33,12 @@ import javax.validation.Valid;
 })
 
 public class Animal   {
-  @JsonProperty("className")
+  public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @JsonProperty(JSON_PROPERTY_CLASS_NAME)
   private String className;
 
-  @JsonProperty("color")
+  public static final String JSON_PROPERTY_COLOR = "color";
+  @JsonProperty(JSON_PROPERTY_COLOR)
   private String color = "red";
 
   public Animal className(String className) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfArrayOfNumberOnly   {
-  @JsonProperty("ArrayArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_NUMBER)
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -29,7 +29,8 @@ import javax.validation.Valid;
  */
 
 public class ArrayOfNumberOnly   {
-  @JsonProperty("ArrayNumber")
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
+  @JsonProperty(JSON_PROPERTY_ARRAY_NUMBER)
   private List<BigDecimal> arrayNumber = null;
 
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -29,13 +29,16 @@ import javax.validation.Valid;
  */
 
 public class ArrayTest   {
-  @JsonProperty("array_of_string")
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
+  @JsonProperty(JSON_PROPERTY_ARRAY_OF_STRING)
   private List<String> arrayOfString = null;
 
-  @JsonProperty("array_array_of_integer")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER)
   private List<List<Long>> arrayArrayOfInteger = null;
 
-  @JsonProperty("array_array_of_model")
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL)
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
   public ArrayTest arrayOfString(List<String> arrayOfString) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Capitalization.java
@@ -26,22 +26,28 @@ import javax.validation.Valid;
  */
 
 public class Capitalization   {
-  @JsonProperty("smallCamel")
+  public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @JsonProperty(JSON_PROPERTY_SMALL_CAMEL)
   private String smallCamel;
 
-  @JsonProperty("CapitalCamel")
+  public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_CAMEL)
   private String capitalCamel;
 
-  @JsonProperty("small_Snake")
+  public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @JsonProperty(JSON_PROPERTY_SMALL_SNAKE)
   private String smallSnake;
 
-  @JsonProperty("Capital_Snake")
+  public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @JsonProperty(JSON_PROPERTY_CAPITAL_SNAKE)
   private String capitalSnake;
 
-  @JsonProperty("SCA_ETH_Flow_Points")
+  public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @JsonProperty(JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS)
   private String scAETHFlowPoints;
 
-  @JsonProperty("ATT_NAME")
+  public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @JsonProperty(JSON_PROPERTY_A_T_T_N_A_M_E)
   private String ATT_NAME;
 
   public Capitalization smallCamel(String smallCamel) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Cat.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Cat extends Animal  {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public Cat declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/CatAllOf.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/CatAllOf.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class CatAllOf   {
-  @JsonProperty("declawed")
+  public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @JsonProperty(JSON_PROPERTY_DECLAWED)
   private Boolean declawed;
 
   public CatAllOf declawed(Boolean declawed) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Category.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class Category   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name = "default-name";
 
   public Category id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ClassModel.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model with \"_class\" property")
 
 public class ClassModel   {
-  @JsonProperty("_class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public ClassModel propertyClass(String propertyClass) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Client.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class Client   {
-  @JsonProperty("client")
+  public static final String JSON_PROPERTY_CLIENT = "client";
+  @JsonProperty(JSON_PROPERTY_CLIENT)
   private String client;
 
   public Client client(String client) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Dog.java
@@ -28,7 +28,8 @@ import javax.validation.Valid;
  */
 
 public class Dog extends Animal  {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public Dog breed(String breed) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/DogAllOf.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/DogAllOf.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class DogAllOf   {
-  @JsonProperty("breed")
+  public static final String JSON_PROPERTY_BREED = "breed";
+  @JsonProperty(JSON_PROPERTY_BREED)
   private String breed;
 
   public DogAllOf breed(String breed) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -60,7 +60,8 @@ public class EnumArrays   {
     }
   }
 
-  @JsonProperty("just_symbol")
+  public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @JsonProperty(JSON_PROPERTY_JUST_SYMBOL)
   private JustSymbolEnum justSymbol;
 
   /**
@@ -94,7 +95,8 @@ public class EnumArrays   {
     }
   }
 
-  @JsonProperty("array_enum")
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ENUM)
   private List<ArrayEnumEnum> arrayEnum = null;
 
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/EnumTest.java
@@ -61,7 +61,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_string")
+  public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING)
   private EnumStringEnum enumString;
 
   /**
@@ -97,7 +98,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_string_required")
+  public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @JsonProperty(JSON_PROPERTY_ENUM_STRING_REQUIRED)
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -131,7 +133,8 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_integer")
+  public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @JsonProperty(JSON_PROPERTY_ENUM_INTEGER)
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -165,10 +168,12 @@ public class EnumTest   {
     }
   }
 
-  @JsonProperty("enum_number")
+  public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @JsonProperty(JSON_PROPERTY_ENUM_NUMBER)
   private EnumNumberEnum enumNumber;
 
-  @JsonProperty("outerEnum")
+  public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @JsonProperty(JSON_PROPERTY_OUTER_ENUM)
   private OuterEnum outerEnum;
 
   public EnumTest enumString(EnumStringEnum enumString) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -28,10 +28,12 @@ import javax.validation.Valid;
  */
 
 public class FileSchemaTestClass   {
-  @JsonProperty("file")
+  public static final String JSON_PROPERTY_FILE = "file";
+  @JsonProperty(JSON_PROPERTY_FILE)
   private java.io.File file = null;
 
-  @JsonProperty("files")
+  public static final String JSON_PROPERTY_FILES = "files";
+  @JsonProperty(JSON_PROPERTY_FILES)
   private List<java.io.File> files = null;
 
   public FileSchemaTestClass file(java.io.File file) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FormatTest.java
@@ -30,43 +30,56 @@ import javax.validation.Valid;
  */
 
 public class FormatTest   {
-  @JsonProperty("integer")
+  public static final String JSON_PROPERTY_INTEGER = "integer";
+  @JsonProperty(JSON_PROPERTY_INTEGER)
   private Integer integer;
 
-  @JsonProperty("int32")
+  public static final String JSON_PROPERTY_INT32 = "int32";
+  @JsonProperty(JSON_PROPERTY_INT32)
   private Integer int32;
 
-  @JsonProperty("int64")
+  public static final String JSON_PROPERTY_INT64 = "int64";
+  @JsonProperty(JSON_PROPERTY_INT64)
   private Long int64;
 
-  @JsonProperty("number")
+  public static final String JSON_PROPERTY_NUMBER = "number";
+  @JsonProperty(JSON_PROPERTY_NUMBER)
   private BigDecimal number;
 
-  @JsonProperty("float")
+  public static final String JSON_PROPERTY_FLOAT = "float";
+  @JsonProperty(JSON_PROPERTY_FLOAT)
   private Float _float;
 
-  @JsonProperty("double")
+  public static final String JSON_PROPERTY_DOUBLE = "double";
+  @JsonProperty(JSON_PROPERTY_DOUBLE)
   private Double _double;
 
-  @JsonProperty("string")
+  public static final String JSON_PROPERTY_STRING = "string";
+  @JsonProperty(JSON_PROPERTY_STRING)
   private String string;
 
-  @JsonProperty("byte")
+  public static final String JSON_PROPERTY_BYTE = "byte";
+  @JsonProperty(JSON_PROPERTY_BYTE)
   private byte[] _byte;
 
-  @JsonProperty("binary")
+  public static final String JSON_PROPERTY_BINARY = "binary";
+  @JsonProperty(JSON_PROPERTY_BINARY)
   private File binary;
 
-  @JsonProperty("date")
+  public static final String JSON_PROPERTY_DATE = "date";
+  @JsonProperty(JSON_PROPERTY_DATE)
   private Date date;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
   public FormatTest integer(Integer integer) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class HasOnlyReadOnly   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("foo")
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonProperty(JSON_PROPERTY_FOO)
   private String foo;
 
   public HasOnlyReadOnly bar(String bar) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MapTest.java
@@ -30,7 +30,8 @@ import javax.validation.Valid;
  */
 
 public class MapTest   {
-  @JsonProperty("map_map_of_string")
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
+  @JsonProperty(JSON_PROPERTY_MAP_MAP_OF_STRING)
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -64,13 +65,16 @@ public class MapTest   {
     }
   }
 
-  @JsonProperty("map_of_enum_string")
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
+  @JsonProperty(JSON_PROPERTY_MAP_OF_ENUM_STRING)
   private Map<String, InnerEnum> mapOfEnumString = null;
 
-  @JsonProperty("direct_map")
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
+  @JsonProperty(JSON_PROPERTY_DIRECT_MAP)
   private Map<String, Boolean> directMap = null;
 
-  @JsonProperty("indirect_map")
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
+  @JsonProperty(JSON_PROPERTY_INDIRECT_MAP)
   private Map<String, Boolean> indirectMap = null;
 
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -32,13 +32,16 @@ import javax.validation.Valid;
  */
 
 public class MixedPropertiesAndAdditionalPropertiesClass   {
-  @JsonProperty("uuid")
+  public static final String JSON_PROPERTY_UUID = "uuid";
+  @JsonProperty(JSON_PROPERTY_UUID)
   private UUID uuid;
 
-  @JsonProperty("dateTime")
+  public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @JsonProperty(JSON_PROPERTY_DATE_TIME)
   private Date dateTime;
 
-  @JsonProperty("map")
+  public static final String JSON_PROPERTY_MAP = "map";
+  @JsonProperty(JSON_PROPERTY_MAP)
   private Map<String, Animal> map = null;
 
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Model200Response.java
@@ -27,10 +27,12 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name starting with number")
 
 public class Model200Response   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("class")
+  public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @JsonProperty(JSON_PROPERTY_PROPERTY_CLASS)
   private String propertyClass;
 
   public Model200Response name(Integer name) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -26,13 +26,16 @@ import javax.validation.Valid;
  */
 
 public class ModelApiResponse   {
-  @JsonProperty("code")
+  public static final String JSON_PROPERTY_CODE = "code";
+  @JsonProperty(JSON_PROPERTY_CODE)
   private Integer code;
 
-  @JsonProperty("type")
+  public static final String JSON_PROPERTY_TYPE = "type";
+  @JsonProperty(JSON_PROPERTY_TYPE)
   private String type;
 
-  @JsonProperty("message")
+  public static final String JSON_PROPERTY_MESSAGE = "message";
+  @JsonProperty(JSON_PROPERTY_MESSAGE)
   private String message;
 
   public ModelApiResponse code(Integer code) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing reserved words")
 
 public class ModelReturn   {
-  @JsonProperty("return")
+  public static final String JSON_PROPERTY_RETURN = "return";
+  @JsonProperty(JSON_PROPERTY_RETURN)
   private Integer _return;
 
   public ModelReturn _return(Integer _return) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Name.java
@@ -27,16 +27,20 @@ import javax.validation.Valid;
 @ApiModel(description = "Model for testing model name same as property name")
 
 public class Name   {
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private Integer name;
 
-  @JsonProperty("snake_case")
+  public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @JsonProperty(JSON_PROPERTY_SNAKE_CASE)
   private Integer snakeCase;
 
-  @JsonProperty("property")
+  public static final String JSON_PROPERTY_PROPERTY = "property";
+  @JsonProperty(JSON_PROPERTY_PROPERTY)
   private String property;
 
-  @JsonProperty("123Number")
+  public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @JsonProperty(JSON_PROPERTY_123NUMBER)
   private Integer _123number;
 
   public Name name(Integer name) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -27,7 +27,8 @@ import javax.validation.Valid;
  */
 
 public class NumberOnly   {
-  @JsonProperty("JustNumber")
+  public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @JsonProperty(JSON_PROPERTY_JUST_NUMBER)
   private BigDecimal justNumber;
 
   public NumberOnly justNumber(BigDecimal justNumber) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Order.java
@@ -28,16 +28,20 @@ import javax.validation.Valid;
  */
 
 public class Order   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("petId")
+  public static final String JSON_PROPERTY_PET_ID = "petId";
+  @JsonProperty(JSON_PROPERTY_PET_ID)
   private Long petId;
 
-  @JsonProperty("quantity")
+  public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @JsonProperty(JSON_PROPERTY_QUANTITY)
   private Integer quantity;
 
-  @JsonProperty("shipDate")
+  public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @JsonProperty(JSON_PROPERTY_SHIP_DATE)
   private Date shipDate;
 
   /**
@@ -73,10 +77,12 @@ public class Order   {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
-  @JsonProperty("complete")
+  public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @JsonProperty(JSON_PROPERTY_COMPLETE)
   private Boolean complete = false;
 
   public Order id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -27,13 +27,16 @@ import javax.validation.Valid;
  */
 
 public class OuterComposite   {
-  @JsonProperty("my_number")
+  public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @JsonProperty(JSON_PROPERTY_MY_NUMBER)
   private BigDecimal myNumber;
 
-  @JsonProperty("my_string")
+  public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @JsonProperty(JSON_PROPERTY_MY_STRING)
   private String myString;
 
-  @JsonProperty("my_boolean")
+  public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @JsonProperty(JSON_PROPERTY_MY_BOOLEAN)
   private Boolean myBoolean;
 
   public OuterComposite myNumber(BigDecimal myNumber) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Pet.java
@@ -31,19 +31,24 @@ import javax.validation.Valid;
  */
 
 public class Pet   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("category")
+  public static final String JSON_PROPERTY_CATEGORY = "category";
+  @JsonProperty(JSON_PROPERTY_CATEGORY)
   private Category category = null;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
-  @JsonProperty("photoUrls")
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
+  @JsonProperty(JSON_PROPERTY_PHOTO_URLS)
   private List<String> photoUrls = new ArrayList<String>();
 
-  @JsonProperty("tags")
+  public static final String JSON_PROPERTY_TAGS = "tags";
+  @JsonProperty(JSON_PROPERTY_TAGS)
   private List<Tag> tags = null;
 
   /**
@@ -79,7 +84,8 @@ public class Pet   {
     }
   }
 
-  @JsonProperty("status")
+  public static final String JSON_PROPERTY_STATUS = "status";
+  @JsonProperty(JSON_PROPERTY_STATUS)
   private StatusEnum status;
 
   public Pet id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class ReadOnlyFirst   {
-  @JsonProperty("bar")
+  public static final String JSON_PROPERTY_BAR = "bar";
+  @JsonProperty(JSON_PROPERTY_BAR)
   private String bar;
 
-  @JsonProperty("baz")
+  public static final String JSON_PROPERTY_BAZ = "baz";
+  @JsonProperty(JSON_PROPERTY_BAZ)
   private String baz;
 
   public ReadOnlyFirst bar(String bar) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -26,7 +26,8 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName   {
-  @JsonProperty("$special[property.name]")
+  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/Tag.java
@@ -26,10 +26,12 @@ import javax.validation.Valid;
  */
 
 public class Tag   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("name")
+  public static final String JSON_PROPERTY_NAME = "name";
+  @JsonProperty(JSON_PROPERTY_NAME)
   private String name;
 
   public Tag id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -29,19 +29,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderDefault   {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem = "what";
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem = true;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderDefault stringItem(String stringItem) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -29,19 +29,24 @@ import javax.validation.Valid;
  */
 
 public class TypeHolderExample   {
-  @JsonProperty("string_item")
+  public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @JsonProperty(JSON_PROPERTY_STRING_ITEM)
   private String stringItem;
 
-  @JsonProperty("number_item")
+  public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @JsonProperty(JSON_PROPERTY_NUMBER_ITEM)
   private BigDecimal numberItem;
 
-  @JsonProperty("integer_item")
+  public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @JsonProperty(JSON_PROPERTY_INTEGER_ITEM)
   private Integer integerItem;
 
-  @JsonProperty("bool_item")
+  public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @JsonProperty(JSON_PROPERTY_BOOL_ITEM)
   private Boolean boolItem;
 
-  @JsonProperty("array_item")
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
+  @JsonProperty(JSON_PROPERTY_ARRAY_ITEM)
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
   public TypeHolderExample stringItem(String stringItem) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/User.java
@@ -26,28 +26,36 @@ import javax.validation.Valid;
  */
 
 public class User   {
-  @JsonProperty("id")
+  public static final String JSON_PROPERTY_ID = "id";
+  @JsonProperty(JSON_PROPERTY_ID)
   private Long id;
 
-  @JsonProperty("username")
+  public static final String JSON_PROPERTY_USERNAME = "username";
+  @JsonProperty(JSON_PROPERTY_USERNAME)
   private String username;
 
-  @JsonProperty("firstName")
+  public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   private String firstName;
 
-  @JsonProperty("lastName")
+  public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @JsonProperty(JSON_PROPERTY_LAST_NAME)
   private String lastName;
 
-  @JsonProperty("email")
+  public static final String JSON_PROPERTY_EMAIL = "email";
+  @JsonProperty(JSON_PROPERTY_EMAIL)
   private String email;
 
-  @JsonProperty("password")
+  public static final String JSON_PROPERTY_PASSWORD = "password";
+  @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
 
-  @JsonProperty("phone")
+  public static final String JSON_PROPERTY_PHONE = "phone";
+  @JsonProperty(JSON_PROPERTY_PHONE)
   private String phone;
 
-  @JsonProperty("userStatus")
+  public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @JsonProperty(JSON_PROPERTY_USER_STATUS)
   private Integer userStatus;
 
   public User id(Long id) {

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/XmlItem.java
@@ -29,91 +29,120 @@ import javax.validation.Valid;
  */
 
 public class XmlItem   {
-  @JsonProperty("attribute_string")
+  public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_STRING)
   private String attributeString;
 
-  @JsonProperty("attribute_number")
+  public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_NUMBER)
   private BigDecimal attributeNumber;
 
-  @JsonProperty("attribute_integer")
+  public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_INTEGER)
   private Integer attributeInteger;
 
-  @JsonProperty("attribute_boolean")
+  public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @JsonProperty(JSON_PROPERTY_ATTRIBUTE_BOOLEAN)
   private Boolean attributeBoolean;
 
-  @JsonProperty("wrapped_array")
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
+  @JsonProperty(JSON_PROPERTY_WRAPPED_ARRAY)
   private List<Integer> wrappedArray = null;
 
-  @JsonProperty("name_string")
+  public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @JsonProperty(JSON_PROPERTY_NAME_STRING)
   private String nameString;
 
-  @JsonProperty("name_number")
+  public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @JsonProperty(JSON_PROPERTY_NAME_NUMBER)
   private BigDecimal nameNumber;
 
-  @JsonProperty("name_integer")
+  public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @JsonProperty(JSON_PROPERTY_NAME_INTEGER)
   private Integer nameInteger;
 
-  @JsonProperty("name_boolean")
+  public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @JsonProperty(JSON_PROPERTY_NAME_BOOLEAN)
   private Boolean nameBoolean;
 
-  @JsonProperty("name_array")
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
+  @JsonProperty(JSON_PROPERTY_NAME_ARRAY)
   private List<Integer> nameArray = null;
 
-  @JsonProperty("name_wrapped_array")
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAME_WRAPPED_ARRAY)
   private List<Integer> nameWrappedArray = null;
 
-  @JsonProperty("prefix_string")
+  public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_STRING)
   private String prefixString;
 
-  @JsonProperty("prefix_number")
+  public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NUMBER)
   private BigDecimal prefixNumber;
 
-  @JsonProperty("prefix_integer")
+  public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_INTEGER)
   private Integer prefixInteger;
 
-  @JsonProperty("prefix_boolean")
+  public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_BOOLEAN)
   private Boolean prefixBoolean;
 
-  @JsonProperty("prefix_array")
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_ARRAY)
   private List<Integer> prefixArray = null;
 
-  @JsonProperty("prefix_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_WRAPPED_ARRAY)
   private List<Integer> prefixWrappedArray = null;
 
-  @JsonProperty("namespace_string")
+  public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_STRING)
   private String namespaceString;
 
-  @JsonProperty("namespace_number")
+  public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_NUMBER)
   private BigDecimal namespaceNumber;
 
-  @JsonProperty("namespace_integer")
+  public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_INTEGER)
   private Integer namespaceInteger;
 
-  @JsonProperty("namespace_boolean")
+  public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_BOOLEAN)
   private Boolean namespaceBoolean;
 
-  @JsonProperty("namespace_array")
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_ARRAY)
   private List<Integer> namespaceArray = null;
 
-  @JsonProperty("namespace_wrapped_array")
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY)
   private List<Integer> namespaceWrappedArray = null;
 
-  @JsonProperty("prefix_ns_string")
+  public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_STRING)
   private String prefixNsString;
 
-  @JsonProperty("prefix_ns_number")
+  public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_NUMBER)
   private BigDecimal prefixNsNumber;
 
-  @JsonProperty("prefix_ns_integer")
+  public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_INTEGER)
   private Integer prefixNsInteger;
 
-  @JsonProperty("prefix_ns_boolean")
+  public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_BOOLEAN)
   private Boolean prefixNsBoolean;
 
-  @JsonProperty("prefix_ns_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_ARRAY)
   private List<Integer> prefixNsArray = null;
 
-  @JsonProperty("prefix_ns_wrapped_array")
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
+  @JsonProperty(JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY)
   private List<Integer> prefixNsWrappedArray = null;
 
   public XmlItem attributeString(String attributeString) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. Java @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)

### Description of the PR

With PR #42, the generator in the `gson` case for java-client was changed to add a constant corresponding to the `@SerializedName` value. This is useful when some other code (such as an error message) says:

> Please check the value of the `'firstName'` property in `'User'`.

Instead of hard-coding the name of the property (`firstName` in the example) in the code, referring to the constant like this:
```java
String errorMessage = "Please check the value of the `'" + User.JSON_PROPERTY_FIRST_NAME + "'` property";
```

This ensures that the code will be updated when there are changes to the generated model.

---

This PR add similar constants:
* in the Jackson case for:
** Java-client
** JaxRS-Server
* in the Gson case for the JaxRS-Server.