### PR TITLE
[C#][client][csharp-netcore] Fix csharp netcore defaultheaders

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -270,6 +270,14 @@ namespace {{packageName}}.Client
                 }
             }
 
+            if (configuration.DefaultHeader != null)
+            {
+                foreach (var headerParam in configuration.DefaultHeader)
+                {
+                    request.AddHeader(headerParam.Key, headerParam.Value);
+                }
+            }
+
             if (options.HeaderParameters != null)
             {
                 foreach (var headerParam in options.HeaderParameters)

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -270,9 +270,9 @@ namespace {{packageName}}.Client
                 }
             }
 
-            if (configuration.DefaultHeader != null)
+            if (configuration.DefaultHeaders != null)
             {
-                foreach (var headerParam in configuration.DefaultHeader)
+                foreach (var headerParam in configuration.DefaultHeaders)
                 {
                     request.AddHeader(headerParam.Key, headerParam.Value);
                 }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
@@ -35,7 +35,7 @@ namespace {{packageName}}.Client
         #endregion Constants
 
         #region Static Members
-        
+
         /// <summary>
         /// Default creation of exceptions for a given method name and response object
         /// </summary>
@@ -65,7 +65,7 @@ namespace {{packageName}}.Client
         /// Example: http://localhost:3000/v1/
         /// </summary>
         private String _basePath;
-        
+
         /// <summary>
         /// Gets or sets the API key based on the authentication name.
         /// This is the key and value comprising the "secret" for acessing an API.
@@ -94,7 +94,7 @@ namespace {{packageName}}.Client
         {
             UserAgent = "{{#httpUserAgent}}{{.}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{packageVersion}}/csharp{{/httpUserAgent}}";
             BasePath = "{{{basePath}}}";
-            DefaultHeader = new {{^net35}}Concurrent{{/net35}}Dictionary<string, string>();
+            DefaultHeaders = new {{^net35}}Concurrent{{/net35}}Dictionary<string, string>();
             ApiKey = new {{^net35}}Concurrent{{/net35}}Dictionary<string, string>();
             ApiKeyPrefix = new {{^net35}}Concurrent{{/net35}}Dictionary<string, string>();
 
@@ -107,15 +107,15 @@ namespace {{packageName}}.Client
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
         public Configuration(
-            IDictionary<string, string> defaultHeader,
+            IDictionary<string, string> defaultHeaders,
             IDictionary<string, string> apiKey,
             IDictionary<string, string> apiKeyPrefix,
             string basePath = "{{{basePath}}}") : this()
         {
             if (string.{{^net35}}IsNullOrWhiteSpace{{/net35}}{{#net35}}IsNullOrEmpty{{/net35}}(basePath))
                 throw new ArgumentException("The provided basePath is invalid.", "basePath");
-            if (defaultHeader == null)
-                throw new ArgumentNullException("defaultHeader");
+            if (defaultHeaders == null)
+                throw new ArgumentNullException("defaultHeaders");
             if (apiKey == null)
                 throw new ArgumentNullException("apiKey");
             if (apiKeyPrefix == null)
@@ -123,9 +123,9 @@ namespace {{packageName}}.Client
 
             BasePath = basePath;
 
-            foreach (var keyValuePair in defaultHeader)
+            foreach (var keyValuePair in defaultHeaders)
             {
-                DefaultHeader.Add(keyValuePair);
+                DefaultHeaders.Add(keyValuePair);
             }
 
             foreach (var keyValuePair in apiKey)
@@ -156,7 +156,23 @@ namespace {{packageName}}.Client
         /// <summary>
         /// Gets or sets the default header.
         /// </summary>
-        public virtual IDictionary<string, string> DefaultHeader { get; set; }
+        [Obsolete("Use DefaultHeaders instead.")]
+        public virtual IDictionary<string, string> DefaultHeader
+        {
+            get
+            {
+                return DefaultHeaders;
+            }
+            set
+            {
+                DefaultHeaders = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the default headers.
+        /// </summary>
+        public virtual IDictionary<string, string> DefaultHeaders { get; set; }
 
         /// <summary>
         /// Gets or sets the HTTP timeout (milliseconds) of ApiClient. Default to 100000 milliseconds.
@@ -374,17 +390,17 @@ namespace {{packageName}}.Client
             
             Dictionary<string, string> apiKey = first.ApiKey.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             Dictionary<string, string> apiKeyPrefix = first.ApiKeyPrefix.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-            Dictionary<string, string> defaultHeader = first.DefaultHeader.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Dictionary<string, string> defaultHeaders = first.DefaultHeaders.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             
             foreach (var kvp in second.ApiKey) apiKey[kvp.Key] = kvp.Value;
             foreach (var kvp in second.ApiKeyPrefix) apiKeyPrefix[kvp.Key] = kvp.Value;
-            foreach (var kvp in second.DefaultHeader) defaultHeader[kvp.Key] = kvp.Value;
+            foreach (var kvp in second.DefaultHeaders) defaultHeaders[kvp.Key] = kvp.Value;
 
             var config = new Configuration
             {
                 ApiKey = apiKey,
                 ApiKeyPrefix = apiKeyPrefix,
-                DefaultHeader = defaultHeader,
+                DefaultHeader = defaultHeaders,
                 BasePath = second.BasePath ?? first.BasePath,
                 Timeout = second.Timeout,
                 UserAgent = second.UserAgent ?? first.UserAgent,

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/IReadableConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/IReadableConfiguration.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+using System;
 using System.Collections.Generic;
 
 namespace {{packageName}}.Client
@@ -43,7 +44,14 @@ namespace {{packageName}}.Client
         /// Gets the default header.
         /// </summary>
         /// <value>Default header.</value>
+        [Obsolete("Use DefaultHeaders instead.")]
         IDictionary<string, string> DefaultHeader { get; }
+
+        /// <summary>
+        /// Gets the default headers.
+        /// </summary>
+        /// <value>Default headers.</value>
+        IDictionary<string, string> DefaultHeaders { get; }
 
         /// <summary>
         /// Gets the temp folder path.

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -273,9 +273,9 @@ namespace Org.OpenAPITools.Client
                 }
             }
 
-            if (configuration.DefaultHeader != null)
+            if (configuration.DefaultHeaders != null)
             {
-                foreach (var headerParam in configuration.DefaultHeader)
+                foreach (var headerParam in configuration.DefaultHeaders)
                 {
                     request.AddHeader(headerParam.Key, headerParam.Value);
                 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -273,6 +273,14 @@ namespace Org.OpenAPITools.Client
                 }
             }
 
+            if (configuration.DefaultHeader != null)
+            {
+                foreach (var headerParam in configuration.DefaultHeader)
+                {
+                    request.AddHeader(headerParam.Key, headerParam.Value);
+                }
+            }
+
             if (options.HeaderParameters != null)
             {
                 foreach (var headerParam in options.HeaderParameters)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
         #endregion Constants
 
         #region Static Members
-        
+
         /// <summary>
         /// Default creation of exceptions for a given method name and response object
         /// </summary>
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Client
         /// Example: http://localhost:3000/v1/
         /// </summary>
         private String _basePath;
-        
+
         /// <summary>
         /// Gets or sets the API key based on the authentication name.
         /// This is the key and value comprising the "secret" for acessing an API.
@@ -97,7 +97,7 @@ namespace Org.OpenAPITools.Client
         {
             UserAgent = "OpenAPI-Generator/1.0.0/csharp";
             BasePath = "http://petstore.swagger.io:80/v2";
-            DefaultHeader = new ConcurrentDictionary<string, string>();
+            DefaultHeaders = new ConcurrentDictionary<string, string>();
             ApiKey = new ConcurrentDictionary<string, string>();
             ApiKeyPrefix = new ConcurrentDictionary<string, string>();
 
@@ -110,15 +110,15 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
         public Configuration(
-            IDictionary<string, string> defaultHeader,
+            IDictionary<string, string> defaultHeaders,
             IDictionary<string, string> apiKey,
             IDictionary<string, string> apiKeyPrefix,
             string basePath = "http://petstore.swagger.io:80/v2") : this()
         {
             if (string.IsNullOrWhiteSpace(basePath))
                 throw new ArgumentException("The provided basePath is invalid.", "basePath");
-            if (defaultHeader == null)
-                throw new ArgumentNullException("defaultHeader");
+            if (defaultHeaders == null)
+                throw new ArgumentNullException("defaultHeaders");
             if (apiKey == null)
                 throw new ArgumentNullException("apiKey");
             if (apiKeyPrefix == null)
@@ -126,9 +126,9 @@ namespace Org.OpenAPITools.Client
 
             BasePath = basePath;
 
-            foreach (var keyValuePair in defaultHeader)
+            foreach (var keyValuePair in defaultHeaders)
             {
-                DefaultHeader.Add(keyValuePair);
+                DefaultHeaders.Add(keyValuePair);
             }
 
             foreach (var keyValuePair in apiKey)
@@ -159,7 +159,23 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Gets or sets the default header.
         /// </summary>
-        public virtual IDictionary<string, string> DefaultHeader { get; set; }
+        [Obsolete("Use DefaultHeaders instead.")]
+        public virtual IDictionary<string, string> DefaultHeader
+        {
+            get
+            {
+                return DefaultHeaders;
+            }
+            set
+            {
+                DefaultHeaders = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the default headers.
+        /// </summary>
+        public virtual IDictionary<string, string> DefaultHeaders { get; set; }
 
         /// <summary>
         /// Gets or sets the HTTP timeout (milliseconds) of ApiClient. Default to 100000 milliseconds.
@@ -369,17 +385,17 @@ namespace Org.OpenAPITools.Client
             
             Dictionary<string, string> apiKey = first.ApiKey.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             Dictionary<string, string> apiKeyPrefix = first.ApiKeyPrefix.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-            Dictionary<string, string> defaultHeader = first.DefaultHeader.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Dictionary<string, string> defaultHeaders = first.DefaultHeaders.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             
             foreach (var kvp in second.ApiKey) apiKey[kvp.Key] = kvp.Value;
             foreach (var kvp in second.ApiKeyPrefix) apiKeyPrefix[kvp.Key] = kvp.Value;
-            foreach (var kvp in second.DefaultHeader) defaultHeader[kvp.Key] = kvp.Value;
+            foreach (var kvp in second.DefaultHeaders) defaultHeaders[kvp.Key] = kvp.Value;
 
             var config = new Configuration
             {
                 ApiKey = apiKey,
                 ApiKeyPrefix = apiKeyPrefix,
-                DefaultHeader = defaultHeader,
+                DefaultHeader = defaultHeaders,
                 BasePath = second.BasePath ?? first.BasePath,
                 Timeout = second.Timeout,
                 UserAgent = second.UserAgent ?? first.UserAgent,

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/IReadableConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/IReadableConfiguration.cs
@@ -9,6 +9,7 @@
  */
 
 
+using System;
 using System.Collections.Generic;
 
 namespace Org.OpenAPITools.Client
@@ -52,7 +53,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the default header.
         /// </summary>
         /// <value>Default header.</value>
+        [Obsolete("Use DefaultHeaders instead.")]
         IDictionary<string, string> DefaultHeader { get; }
+
+        /// <summary>
+        /// Gets the default headers.
+        /// </summary>
+        /// <value>Default headers.</value>
+        IDictionary<string, string> DefaultHeaders { get; }
 
         /// <summary>
         /// Gets the temp folder path.

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -274,9 +274,9 @@ namespace Org.OpenAPITools.Client
                 }
             }
 
-            if (configuration.DefaultHeader != null)
+            if (configuration.DefaultHeaders != null)
             {
-                foreach (var headerParam in configuration.DefaultHeader)
+                foreach (var headerParam in configuration.DefaultHeaders)
                 {
                     request.AddHeader(headerParam.Key, headerParam.Value);
                 }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -274,6 +274,14 @@ namespace Org.OpenAPITools.Client
                 }
             }
 
+            if (configuration.DefaultHeader != null)
+            {
+                foreach (var headerParam in configuration.DefaultHeader)
+                {
+                    request.AddHeader(headerParam.Key, headerParam.Value);
+                }
+            }
+
             if (options.HeaderParameters != null)
             {
                 foreach (var headerParam in options.HeaderParameters)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Client
         #endregion Constants
 
         #region Static Members
-        
+
         /// <summary>
         /// Default creation of exceptions for a given method name and response object
         /// </summary>
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Client
         /// Example: http://localhost:3000/v1/
         /// </summary>
         private String _basePath;
-        
+
         /// <summary>
         /// Gets or sets the API key based on the authentication name.
         /// This is the key and value comprising the "secret" for acessing an API.
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Client
         {
             UserAgent = "OpenAPI-Generator/1.0.0/csharp";
             BasePath = "http://petstore.swagger.io:80/v2";
-            DefaultHeader = new ConcurrentDictionary<string, string>();
+            DefaultHeaders = new ConcurrentDictionary<string, string>();
             ApiKey = new ConcurrentDictionary<string, string>();
             ApiKeyPrefix = new ConcurrentDictionary<string, string>();
 
@@ -114,15 +114,15 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
         public Configuration(
-            IDictionary<string, string> defaultHeader,
+            IDictionary<string, string> defaultHeaders,
             IDictionary<string, string> apiKey,
             IDictionary<string, string> apiKeyPrefix,
             string basePath = "http://petstore.swagger.io:80/v2") : this()
         {
             if (string.IsNullOrWhiteSpace(basePath))
                 throw new ArgumentException("The provided basePath is invalid.", "basePath");
-            if (defaultHeader == null)
-                throw new ArgumentNullException("defaultHeader");
+            if (defaultHeaders == null)
+                throw new ArgumentNullException("defaultHeaders");
             if (apiKey == null)
                 throw new ArgumentNullException("apiKey");
             if (apiKeyPrefix == null)
@@ -130,9 +130,9 @@ namespace Org.OpenAPITools.Client
 
             BasePath = basePath;
 
-            foreach (var keyValuePair in defaultHeader)
+            foreach (var keyValuePair in defaultHeaders)
             {
-                DefaultHeader.Add(keyValuePair);
+                DefaultHeaders.Add(keyValuePair);
             }
 
             foreach (var keyValuePair in apiKey)
@@ -163,7 +163,23 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Gets or sets the default header.
         /// </summary>
-        public virtual IDictionary<string, string> DefaultHeader { get; set; }
+        [Obsolete("Use DefaultHeaders instead.")]
+        public virtual IDictionary<string, string> DefaultHeader
+        {
+            get
+            {
+                return DefaultHeaders;
+            }
+            set
+            {
+                DefaultHeaders = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the default headers.
+        /// </summary>
+        public virtual IDictionary<string, string> DefaultHeaders { get; set; }
 
         /// <summary>
         /// Gets or sets the HTTP timeout (milliseconds) of ApiClient. Default to 100000 milliseconds.
@@ -374,17 +390,17 @@ namespace Org.OpenAPITools.Client
             
             Dictionary<string, string> apiKey = first.ApiKey.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             Dictionary<string, string> apiKeyPrefix = first.ApiKeyPrefix.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-            Dictionary<string, string> defaultHeader = first.DefaultHeader.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            Dictionary<string, string> defaultHeaders = first.DefaultHeaders.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             
             foreach (var kvp in second.ApiKey) apiKey[kvp.Key] = kvp.Value;
             foreach (var kvp in second.ApiKeyPrefix) apiKeyPrefix[kvp.Key] = kvp.Value;
-            foreach (var kvp in second.DefaultHeader) defaultHeader[kvp.Key] = kvp.Value;
+            foreach (var kvp in second.DefaultHeaders) defaultHeaders[kvp.Key] = kvp.Value;
 
             var config = new Configuration
             {
                 ApiKey = apiKey,
                 ApiKeyPrefix = apiKeyPrefix,
-                DefaultHeader = defaultHeader,
+                DefaultHeader = defaultHeaders,
                 BasePath = second.BasePath ?? first.BasePath,
                 Timeout = second.Timeout,
                 UserAgent = second.UserAgent ?? first.UserAgent,

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/IReadableConfiguration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/IReadableConfiguration.cs
@@ -9,6 +9,7 @@
  */
 
 
+using System;
 using System.Collections.Generic;
 
 namespace Org.OpenAPITools.Client
@@ -52,7 +53,14 @@ namespace Org.OpenAPITools.Client
         /// Gets the default header.
         /// </summary>
         /// <value>Default header.</value>
+        [Obsolete("Use DefaultHeaders instead.")]
         IDictionary<string, string> DefaultHeader { get; }
+
+        /// <summary>
+        /// Gets the default headers.
+        /// </summary>
+        /// <value>Default headers.</value>
+        IDictionary<string, string> DefaultHeaders { get; }
 
         /// <summary>
         /// Gets the temp folder path.


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@mandrean (2017/08), @jimschubert (2017/09)

### Description of the PR

Fix #3561

Previously, the .NET Core SDK would not send configured default headers. This PR fixes this and also "fixes" the strange singular name of the property by marking it obsolete and redirecting to the new correctly-named plural form.

This second change is a separate commit and is less important so I'd drop it if need be.