### PR TITLE
typescript-fetch: allow configuration of headers and credentials

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -52,10 +52,13 @@ export class BaseAPI {
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
+
+        const headers = Object.assign(context.headers, this.configuration.headers);
         const init = {
             method: context.method,
-            headers: context.headers,
+            headers: headers,
             body,
+            credentials: this.configuration.credentials
         };
         return { url, init };
     }
@@ -121,6 +124,8 @@ export interface ConfigurationParameters {
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
     accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
@@ -164,6 +169,14 @@ export class Configuration {
             return typeof accessToken === 'function' ? accessToken : () => accessToken;
         }
         return undefined;
+    }
+
+    get headers():  HTTPHeaders {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials {
+        return this.configuration.credentials;
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -53,7 +53,7 @@ export class BaseAPI {
 	    ? context.body
 	    : JSON.stringify(context.body);
 
-        const headers = Object.assign(context.headers, this.configuration.headers);
+        const headers = Object.assign({}, this.configuration.headers, context.headers);
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/default/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/src/runtime.ts
@@ -63,10 +63,13 @@ export class BaseAPI {
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
+
+        const headers = Object.assign(context.headers, this.configuration.headers);
         const init = {
             method: context.method,
-            headers: context.headers,
+            headers: headers,
             body,
+            credentials: this.configuration.credentials
         };
         return { url, init };
     }
@@ -132,6 +135,8 @@ export interface ConfigurationParameters {
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
     accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
@@ -175,6 +180,14 @@ export class Configuration {
             return typeof accessToken === 'function' ? accessToken : () => accessToken;
         }
         return undefined;
+    }
+
+    get headers():  HTTPHeaders {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials {
+        return this.configuration.credentials;
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/src/runtime.ts
@@ -64,7 +64,7 @@ export class BaseAPI {
 	    ? context.body
 	    : JSON.stringify(context.body);
 
-        const headers = Object.assign(context.headers, this.configuration.headers);
+        const headers = Object.assign({}, this.configuration.headers, context.headers);
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -63,10 +63,13 @@ export class BaseAPI {
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
+
+        const headers = Object.assign(context.headers, this.configuration.headers);
         const init = {
             method: context.method,
-            headers: context.headers,
+            headers: headers,
             body,
+            credentials: this.configuration.credentials
         };
         return { url, init };
     }
@@ -132,6 +135,8 @@ export interface ConfigurationParameters {
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
     accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
@@ -175,6 +180,14 @@ export class Configuration {
             return typeof accessToken === 'function' ? accessToken : () => accessToken;
         }
         return undefined;
+    }
+
+    get headers():  HTTPHeaders {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials {
+        return this.configuration.credentials;
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -64,7 +64,7 @@ export class BaseAPI {
 	    ? context.body
 	    : JSON.stringify(context.body);
 
-        const headers = Object.assign(context.headers, this.configuration.headers);
+        const headers = Object.assign({}, this.configuration.headers, context.headers);
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/runtime.ts
@@ -63,10 +63,13 @@ export class BaseAPI {
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
+
+        const headers = Object.assign(context.headers, this.configuration.headers);
         const init = {
             method: context.method,
-            headers: context.headers,
+            headers: headers,
             body,
+            credentials: this.configuration.credentials
         };
         return { url, init };
     }
@@ -132,6 +135,8 @@ export interface ConfigurationParameters {
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
     accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
@@ -175,6 +180,14 @@ export class Configuration {
             return typeof accessToken === 'function' ? accessToken : () => accessToken;
         }
         return undefined;
+    }
+
+    get headers():  HTTPHeaders {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials {
+        return this.configuration.credentials;
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/runtime.ts
@@ -64,7 +64,7 @@ export class BaseAPI {
 	    ? context.body
 	    : JSON.stringify(context.body);
 
-        const headers = Object.assign(context.headers, this.configuration.headers);
+        const headers = Object.assign({}, this.configuration.headers, context.headers);
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/runtime.ts
@@ -63,10 +63,13 @@ export class BaseAPI {
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
+
+        const headers = Object.assign(context.headers, this.configuration.headers);
         const init = {
             method: context.method,
-            headers: context.headers,
+            headers: headers,
             body,
+            credentials: this.configuration.credentials
         };
         return { url, init };
     }
@@ -132,6 +135,8 @@ export interface ConfigurationParameters {
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
     accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
@@ -175,6 +180,14 @@ export class Configuration {
             return typeof accessToken === 'function' ? accessToken : () => accessToken;
         }
         return undefined;
+    }
+
+    get headers():  HTTPHeaders {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials {
+        return this.configuration.credentials;
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/runtime.ts
@@ -64,7 +64,7 @@ export class BaseAPI {
 	    ? context.body
 	    : JSON.stringify(context.body);
 
-        const headers = Object.assign(context.headers, this.configuration.headers);
+        const headers = Object.assign({}, this.configuration.headers, context.headers);
         const init = {
             method: context.method,
             headers: headers,

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -63,10 +63,13 @@ export class BaseAPI {
         const body = (context.body instanceof FormData || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
+
+        const headers = Object.assign(context.headers, this.configuration.headers);
         const init = {
             method: context.method,
-            headers: context.headers,
+            headers: headers,
             body,
+            credentials: this.configuration.credentials
         };
         return { url, init };
     }
@@ -132,6 +135,8 @@ export interface ConfigurationParameters {
     password?: string; // parameter for basic security
     apiKey?: string | ((name: string) => string); // parameter for apiKey security
     accessToken?: string | ((name?: string, scopes?: string[]) => string); // parameter for oauth2 security
+    headers?: HTTPHeaders; //header params we want to use on every request
+    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
 }
 
 export class Configuration {
@@ -175,6 +180,14 @@ export class Configuration {
             return typeof accessToken === 'function' ? accessToken : () => accessToken;
         }
         return undefined;
+    }
+
+    get headers():  HTTPHeaders {
+        return this.configuration.headers;
+    }
+
+    get credentials(): RequestCredentials {
+        return this.configuration.credentials;
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -64,7 +64,7 @@ export class BaseAPI {
 	    ? context.body
 	    : JSON.stringify(context.body);
 
-        const headers = Object.assign(context.headers, this.configuration.headers);
+        const headers = Object.assign({}, this.configuration.headers, context.headers);
         const init = {
             method: context.method,
             headers: headers,


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07)

### Description of the PR

I've change my mind on how to fix that "bug".  

In the bug itself, I was suggesting to do like in version 3.X.X and have an "option" parameter in each call but I realized that was no a very good design.

Once I understood how the code was refactored in 4.X.X, the only thing missing was to be able to provide additional `headers` with each Fetch query in the `Configuration` object. Also, the `credentials` option was missing, so I added it. Very simple PR with no breaking change and no risk :)



fixes #3402