### PR TITLE
[Python] support api key refresh in configuration module

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -61,6 +61,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.api_key_prefix = api_key_prefix
         """dict to store API prefix (e.g. Bearer)
         """
+        self.refresh_api_key_hook = None
+        """function hook to refresh API key if expired
+        """
         self.username = username
         """Username for HTTP basic authentication
         """
@@ -238,6 +241,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
         """
+        if self.refresh_api_key_hook is not None:
+            self.refresh_api_key_hook(self)
         key = self.api_key.get(identifier)
         if key:
             prefix = self.api_key_prefix.get(identifier)

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -66,6 +66,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.api_key_prefix = api_key_prefix
         """dict to store API prefix (e.g. Bearer)
         """
+        self.refresh_api_key_hook = None
+        """function hook to refresh API key if expired
+        """
         self.username = username
         """Username for HTTP basic authentication
         """
@@ -223,6 +226,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
         """
+        if self.refresh_api_key_hook is not None:
+            self.refresh_api_key_hook(self)
         key = self.api_key.get(identifier)
         if key:
             prefix = self.api_key_prefix.get(identifier)

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -67,6 +67,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.api_key_prefix = api_key_prefix
         """dict to store API prefix (e.g. Bearer)
         """
+        self.refresh_api_key_hook = None
+        """function hook to refresh API key if expired
+        """
         self.username = username
         """Username for HTTP basic authentication
         """
@@ -227,6 +230,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
         """
+        if self.refresh_api_key_hook is not None:
+            self.refresh_api_key_hook(self)
         key = self.api_key.get(identifier)
         if key:
             prefix = self.api_key_prefix.get(identifier)

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -67,6 +67,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.api_key_prefix = api_key_prefix
         """dict to store API prefix (e.g. Bearer)
         """
+        self.refresh_api_key_hook = None
+        """function hook to refresh API key if expired
+        """
         self.username = username
         """Username for HTTP basic authentication
         """
@@ -227,6 +230,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
         """
+        if self.refresh_api_key_hook is not None:
+            self.refresh_api_key_hook(self)
         key = self.api_key.get(identifier)
         if key:
             prefix = self.api_key_prefix.get(identifier)

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -67,6 +67,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         self.api_key_prefix = api_key_prefix
         """dict to store API prefix (e.g. Bearer)
         """
+        self.refresh_api_key_hook = None
+        """function hook to refresh API key if expired
+        """
         self.username = username
         """Username for HTTP basic authentication
         """
@@ -227,6 +230,8 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
         """
+        if self.refresh_api_key_hook is not None:
+            self.refresh_api_key_hook(self)
         key = self.api_key.get(identifier)
         if key:
             prefix = self.api_key_prefix.get(identifier)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR adds a function hook to support refreshing expired api key. It is part of the fix for kubernetes-client/python#741.

