### PR TITLE
typescript-fetch: Fix type errors in generated code

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -171,11 +171,11 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders {
+    get headers():  HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 
-    get credentials(): RequestCredentials {
+    get credentials(): RequestCredentials | undefined {
         return this.configuration.credentials;
     }
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/src/runtime.ts
@@ -182,11 +182,11 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders {
+    get headers():  HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 
-    get credentials(): RequestCredentials {
+    get credentials(): RequestCredentials | undefined {
         return this.configuration.credentials;
     }
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -182,11 +182,11 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders {
+    get headers():  HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 
-    get credentials(): RequestCredentials {
+    get credentials(): RequestCredentials | undefined {
         return this.configuration.credentials;
     }
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/runtime.ts
@@ -182,11 +182,11 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders {
+    get headers():  HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 
-    get credentials(): RequestCredentials {
+    get credentials(): RequestCredentials | undefined {
         return this.configuration.credentials;
     }
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/runtime.ts
@@ -182,11 +182,11 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders {
+    get headers():  HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 
-    get credentials(): RequestCredentials {
+    get credentials(): RequestCredentials | undefined {
         return this.configuration.credentials;
     }
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -182,11 +182,11 @@ export class Configuration {
         return undefined;
     }
 
-    get headers():  HTTPHeaders {
+    get headers():  HTTPHeaders | undefined {
         return this.configuration.headers;
     }
 
-    get credentials(): RequestCredentials {
+    get credentials(): RequestCredentials | undefined {
         return this.configuration.credentials;
     }
 }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07)

### Description of the PR

Fixes an issue where typescript-fetch in 4.1.0 generates Typescript code which doesn't compile.

```
src/api/petstore/src/runtime.ts:186:9 - error TS2322: Type 'HTTPHeaders | undefined' is not assignable to type 'HTTPHeaders'.
  Type 'undefined' is not assignable to type 'HTTPHeaders'.

186         return this.configuration.headers;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/api/petstore/src/runtime.ts:190:9 - error TS2322: Type '"omit" | "same-origin" | "include" | undefined' is not assignable to type 'RequestCredentials'.
  Type 'undefined' is not assignable to type 'RequestCredentials'.

190         return this.configuration.credentials;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The solution is to simply add `undefined` as a potential return type to `headers` and `credentials` properties of the `Configuration`class in `runtime.ts`.

fixes #3604 

