### PR TITLE
[Typescript] Fix typescript-inversify compiler errors

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-inversify/HttpClient.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-inversify/HttpClient.mustache
@@ -40,7 +40,7 @@ class HttpClient implements IHttpClient {
         return !(body instanceof FormData) ? JSON.stringify(body) : body;
     }
 
-    private addJsonHeaders(headers: Headers) {
+    private addJsonHeaders(headers?: Headers) {
         return Object.assign({}, {
             "Accept": "application/json",
             "Content-Type": "application/json"

--- a/samples/client/petstore/typescript-inversify/HttpClient.ts
+++ b/samples/client/petstore/typescript-inversify/HttpClient.ts
@@ -35,7 +35,7 @@ class HttpClient implements IHttpClient {
         return !(body instanceof FormData) ? JSON.stringify(body) : body;
     }
 
-    private addJsonHeaders(headers: Headers) {
+    private addJsonHeaders(headers?: Headers) {
         return Object.assign({}, {
             "Accept": "application/json",
             "Content-Type": "application/json"


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07)

### Description of the PR

Currently the typescript-inversify generator doesn't produce code that compiles, when using the “strict: true” compilerOptions in tsconfig.json - as the addJsonHeaders method requires a non-nullable instance of Headers, however the get/put/post etc. methods accept a nullable instance, this PR fixes this issue in the generator template

