### PR TITLE
[maven] Support user overrides for serverVariables (carryover from #3363)

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -282,7 +282,7 @@ public class CodeGenMojo extends AbstractMojo {
      * A map of server variable overrides for specs that support server URL templating
      */
     @Parameter(name = "serverVariableOverrides", property = "openapi.generator.maven.plugin.serverVariableOverrides")
-    private List<String> serverVariables;
+    private List<String> serverVariableOverrides;
 
     /**
      * A map of reserved names and how they should be escaped
@@ -610,7 +610,7 @@ public class CodeGenMojo extends AbstractMojo {
                             configurator);
                 }
 
-                if (serverVariables == null && configOptions.containsKey("server-variables")) {
+                if (serverVariableOverrides == null && configOptions.containsKey("server-variables")) {
                     applyServerVariablesKvp(configOptions.get("server-variables").toString(), configurator);
                 }
 
@@ -647,8 +647,8 @@ public class CodeGenMojo extends AbstractMojo {
                 applyAdditionalPropertiesKvpList(additionalProperties, configurator);
             }
 
-            if (serverVariables != null && (configOptions == null || !configOptions.containsKey("server-variables"))) {
-                applyServerVariablesKvpList(serverVariables, configurator);
+            if (serverVariableOverrides != null && (configOptions == null || !configOptions.containsKey("server-variables"))) {
+                applyServerVariablesKvpList(serverVariableOverrides, configurator);
             }
 
             // Apply Reserved Words Mappings

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -17,19 +17,8 @@
 
 package org.openapitools.codegen.plugin;
 
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyAdditionalPropertiesKvp;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyImportMappingsKvp;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyInstantiationTypesKvp;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyLanguageSpecificPrimitivesCsv;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyTypeMappingsKvp;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyReservedWordsMappingsKvp;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyAdditionalPropertiesKvpList;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyImportMappingsKvpList;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyInstantiationTypesKvpList;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyLanguageSpecificPrimitivesCsvList;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyTypeMappingsKvpList;
-import static org.openapitools.codegen.config.CodegenConfiguratorUtils.applyReservedWordsMappingsKvpList;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.openapitools.codegen.config.CodegenConfiguratorUtils.*;
 
 import java.io.File;
 import java.util.HashMap;
@@ -288,6 +277,12 @@ public class CodeGenMojo extends AbstractMojo {
      */
     @Parameter(name = "additionalProperties", property = "openapi.generator.maven.plugin.additionalProperties")
     private List<String> additionalProperties;
+
+    /**
+     * A map of server variable overrides for specs that support server URL templating
+     */
+    @Parameter(name = "serverVariableOverrides", property = "openapi.generator.maven.plugin.serverVariableOverrides")
+    private List<String> serverVariables;
 
     /**
      * A map of reserved names and how they should be escaped
@@ -615,6 +610,10 @@ public class CodeGenMojo extends AbstractMojo {
                             configurator);
                 }
 
+                if (serverVariables == null && configOptions.containsKey("server-variables")) {
+                    applyServerVariablesKvp(configOptions.get("server-variables").toString(), configurator);
+                }
+
                 // Retained for backwards-compataibility with configOptions -> reserved-words-mappings
                 if (reservedWordsMappings == null && configOptions.containsKey("reserved-words-mappings")) {
                     applyReservedWordsMappingsKvp(configOptions.get("reserved-words-mappings")
@@ -646,6 +645,10 @@ public class CodeGenMojo extends AbstractMojo {
             // Apply Additional Properties
             if (additionalProperties != null && (configOptions == null || !configOptions.containsKey("additional-properties"))) {
                 applyAdditionalPropertiesKvpList(additionalProperties, configurator);
+            }
+
+            if (serverVariables != null && (configOptions == null || !configOptions.containsKey("server-variables"))) {
+                applyServerVariablesKvpList(serverVariables, configurator);
             }
 
             // Apply Reserved Words Mappings
@@ -698,10 +701,10 @@ public class CodeGenMojo extends AbstractMojo {
             // Store a checksum of the input spec
             File storedInputSpecHashFile = getHashFile(inputSpecFile);
             ByteSource inputSpecByteSource =
-                    inputSpecFile.exists()
-                            ? Files.asByteSource(inputSpecFile)
-                            : CharSource.wrap(ClasspathHelper.loadFileFromClasspath(inputSpecFile.toString().replaceAll("\\\\","/")))
-                            .asByteSource(Charsets.UTF_8);
+                inputSpecFile.exists()
+                    ? Files.asByteSource(inputSpecFile)
+                    : CharSource.wrap(ClasspathHelper.loadFileFromClasspath(inputSpecFile.toString().replaceAll("\\\\","/")))
+                        .asByteSource(Charsets.UTF_8);
             String  inputSpecHash =inputSpecByteSource.hash(Hashing.sha256()).toString();
 
             if (storedInputSpecHashFile.getParent() != null && !new File(storedInputSpecHashFile.getParent()).exists()) {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This should be merged after #3363, and after the core feature is published as a snapshot. There's an issue with consuming core changes in the maven plugin within the same build during a SNAPSHOT build, likely due to how we do the samples verification using a different profile from the original/cached build. 
