### PR TITLE
Fix composed properties missing from allVars

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1822,6 +1822,7 @@ public class DefaultCodegen implements CodegenConfig {
                         } else {
                             // composition
                             addProperties(properties, required, refSchema);
+                            addProperties(allProperties, allRequired, refSchema);
                         }
                     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -534,6 +534,9 @@ public class RubyClientCodegenTest {
 
         // to test all properties
         Assert.assertEquals(superMan.getVars().size(), 6);
+        Assert.assertEquals(superMan.getAllVars().size(), 6);
+        Assert.assertEquals(superMan.getMandatory().size(), 3);
+        Assert.assertEquals(superMan.getAllMandatory().size(), 3);
 
         CodegenProperty cp0 = superMan.getVars().get(0);
         Assert.assertEquals(cp0.name, "id");
@@ -558,6 +561,30 @@ public class RubyClientCodegenTest {
         CodegenProperty cp5 = superMan.getVars().get(5);
         Assert.assertEquals(cp5.name, "level");
         Assert.assertTrue(cp5.required);
+
+        CodegenProperty cp6 = superMan.getAllVars().get(0);
+        Assert.assertEquals(cp6.name, "id");
+        Assert.assertTrue(cp6.required);
+
+        CodegenProperty cp7 = superMan.getAllVars().get(1);
+        Assert.assertEquals(cp7.name, "name");
+        Assert.assertFalse(cp7.required);
+
+        CodegenProperty cp8 = superMan.getAllVars().get(2);
+        Assert.assertEquals(cp8.name, "reward");
+        Assert.assertFalse(cp8.required);
+
+        CodegenProperty cp9 = superMan.getAllVars().get(3);
+        Assert.assertEquals(cp9.name, "origin");
+        Assert.assertTrue(cp9.required);
+
+        CodegenProperty cp10 = superMan.getAllVars().get(4);
+        Assert.assertEquals(cp10.name, "category");
+        Assert.assertFalse(cp10.required);
+
+        CodegenProperty cp11 = superMan.getAllVars().get(5);
+        Assert.assertEquals(cp11.name, "level");
+        Assert.assertTrue(cp11.required);
 
     }
 


### PR DESCRIPTION
### Description of the PR

Fixes #3613 

When a model includes properties by composition (`allOf`, without a discriminator), these properties end up in the `vars` template variable but they are missing from the `allVars` variable.