### PR TITLE
[Slim] Distinction between basicBasic and basicBearer authentication

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim-server/SlimRouter.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim-server/SlimRouter.mustache
@@ -71,18 +71,29 @@ class SlimRouter
                 {{#hasAuthMethods}}
                 {{#authMethods}}
                 // {{type}} security schema named '{{name}}'
-                {{#isBasic}}
+                {{#isBasicBasic}}
                 [
                     'type' => '{{type}}',
                     'isBasic' => true,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => false,
                 ],
-                {{/isBasic}}
+                {{/isBasicBasic}}
+                {{#isBasicBearer}}
+                [
+                    'type' => '{{type}}',
+                    'isBasic' => true,
+                    'isBearer' => true,
+                    'isApiKey' => false,
+                    'isOAuth' => false,
+                ],
+                {{/isBasicBearer}}
                 {{#isApiKey}}
                 [
                     'type' => '{{type}}',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => true,
                     'isOAuth' => false,
                     'keyParamName' => '{{keyParamName}}',
@@ -95,6 +106,7 @@ class SlimRouter
                 [
                     'type' => '{{type}}',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => true,
                     'scopes' => [
@@ -167,7 +179,7 @@ class SlimRouter
 
                         $middlewares[] = new TokenAuthentication($this->getTokenAuthenticationOptions([
                             'authenticator' => $basicAuthenticator,
-                            'regex' => '/Basic\s+(.*)$/i',
+                            'regex' => $authMethod['isBearer'] ? '/Bearer\s+(.*)$/i' : '/Basic\s+(.*)$/i',
                             'header' => 'Authorization',
                             'parameter' => null,
                             'cookie' => null,

--- a/samples/server/petstore/php-slim/lib/SlimRouter.php
+++ b/samples/server/petstore/php-slim/lib/SlimRouter.php
@@ -160,6 +160,7 @@ class SlimRouter
                 [
                     'type' => 'http',
                     'isBasic' => true,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => false,
                 ],
@@ -222,6 +223,7 @@ class SlimRouter
                 [
                     'type' => 'apiKey',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => true,
                     'isOAuth' => false,
                     'keyParamName' => 'api_key_query',
@@ -244,6 +246,7 @@ class SlimRouter
                 [
                     'type' => 'oauth2',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => true,
                     'scopes' => [
@@ -266,6 +269,7 @@ class SlimRouter
                 [
                     'type' => 'oauth2',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => true,
                     'scopes' => [
@@ -288,6 +292,7 @@ class SlimRouter
                 [
                     'type' => 'oauth2',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => true,
                     'scopes' => [
@@ -310,6 +315,7 @@ class SlimRouter
                 [
                     'type' => 'oauth2',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => true,
                     'scopes' => [
@@ -332,6 +338,7 @@ class SlimRouter
                 [
                     'type' => 'oauth2',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => true,
                     'scopes' => [
@@ -354,6 +361,7 @@ class SlimRouter
                 [
                     'type' => 'apiKey',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => true,
                     'isOAuth' => false,
                     'keyParamName' => 'api_key',
@@ -376,6 +384,7 @@ class SlimRouter
                 [
                     'type' => 'oauth2',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => true,
                     'scopes' => [
@@ -398,6 +407,7 @@ class SlimRouter
                 [
                     'type' => 'oauth2',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => true,
                     'scopes' => [
@@ -420,6 +430,7 @@ class SlimRouter
                 [
                     'type' => 'oauth2',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => false,
                     'isOAuth' => true,
                     'scopes' => [
@@ -442,6 +453,7 @@ class SlimRouter
                 [
                     'type' => 'apiKey',
                     'isBasic' => false,
+                    'isBearer' => false,
                     'isApiKey' => true,
                     'isOAuth' => false,
                     'keyParamName' => 'api_key',
@@ -625,7 +637,7 @@ class SlimRouter
 
                         $middlewares[] = new TokenAuthentication($this->getTokenAuthenticationOptions([
                             'authenticator' => $basicAuthenticator,
-                            'regex' => '/Basic\s+(.*)$/i',
+                            'regex' => $authMethod['isBearer'] ? '/Bearer\s+(.*)$/i' : '/Basic\s+(.*)$/i',
                             'header' => 'Authorization',
                             'parameter' => null,
                             'cookie' => null,


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I changed the `SlimRouter.mustache` template to distinguish between basic and bearer authentications. Then I change the regex depending on that.