### PR TITLE
Use javax.annotation.processing.Generated for Java 11 native client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/generatedAnnotation.mustache
@@ -1,0 +1,1 @@
+{{^hideGenerationTimestamp}}@javax.annotation.processing.Generated(value = "{{generatorClass}}", date = "{{generatedDate}}"){{/hideGenerationTimestamp}}


### PR DESCRIPTION
Before Java 9, the `Generated` annotation was part of JEE and in the
`javax.annotation` package. Starting with Java 9, it is now part
of the standard SDK, under the new `javax.annotation.processing`
package.

This change creates a custom Generated annotation template for the
native clientlib, since it is guaranteed to be run in Java 11+.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Adds a new custom `generatedAnnotation.mustache` template for the native HttpClient library with the correct `Generated` package name for Java 9+.

Fixes #3636