### PR TITLE
Add test cases to cover different collection formats

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -1065,13 +1065,14 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
             case "tsv":
                 return "TabSeparated";
             case "ssv":
+            case "space":
                 return "SpaceSeparated";
             case "pipes":
                 return "PipeSeparated";
             case "multi":
                 return "MultiParamArray";
             default:
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException(collectionFormat + " (collection format) not supported");
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -549,6 +549,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
                 return "(QueryList 'CommaSeparated (" + type + "))";
             case "tsv":
                 return "(QueryList 'TabSeparated (" + type + "))";
+            case "space":
             case "ssv":
                 return "(QueryList 'SpaceSeparated (" + type + "))";
             case "pipes":
@@ -556,7 +557,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
             case "multi":
                 return "(QueryList 'MultiParamArray (" + type + "))";
             default:
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException(collectionFormat + " (collection format) not supported");
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/api.mustache
@@ -104,8 +104,8 @@ public class {{classname}} {
             }
         }{{/queryParams}}{{/hasQueryParams}}
 
-        String url = uriBuilder{{#hasPathParams}}.buildFromMap(uriVariables).toString();{{/hasPathParams}}{{^hasPathParams}}.build().toString();{{/hasPathParams}}
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder{{#hasPathParams}}.buildFromMap(uriVariables).toString();{{/hasPathParams}}{{^hasPathParams}}.build().toString();{{/hasPathParams}}
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = {{#isBodyAllowed}}apiClient.new JacksonJsonHttpContent({{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}){{/isBodyAllowed}}{{^isBodyAllowed}}null{{/isBodyAllowed}};
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.{{httpMethod}}, genericUrl, content).execute();
@@ -135,8 +135,8 @@ public class {{classname}} {
                   }
               }{{/queryParams}}{{/hasQueryParams}}
 
-              String url = uriBuilder{{#hasPathParams}}.buildFromMap(uriVariables).toString();{{/hasPathParams}}{{^hasPathParams}}.build().toString();{{/hasPathParams}}
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder{{#hasPathParams}}.buildFromMap(uriVariables).toString();{{/hasPathParams}}{{^hasPathParams}}.build().toString();{{/hasPathParams}}
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = {{#bodyParam}}{{paramName}} == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -176,8 +176,8 @@ public class {{classname}} {
             }
         }
 
-        String url = uriBuilder{{#hasPathParams}}.buildFromMap(uriVariables).toString();{{/hasPathParams}}{{^hasPathParams}}.build().toString();{{/hasPathParams}}
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder{{#hasPathParams}}.buildFromMap(uriVariables).toString();{{/hasPathParams}}{{^hasPathParams}}.build().toString();{{/hasPathParams}}
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = {{#isBodyAllowed}}apiClient.new JacksonJsonHttpContent({{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}){{/isBodyAllowed}}{{^isBodyAllowed}}null{{/isBodyAllowed}};
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.{{httpMethod}}, genericUrl, content).execute();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/CollectionFormats.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/CollectionFormats.mustache
@@ -35,6 +35,10 @@ public class CollectionFormats {
         
     }
     
+    public static class SPACEParams extends SSVParams {
+
+    }
+
     public static class SSVParams extends CSVParams {
         
         public SSVParams() {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/CollectionFormats.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/CollectionFormats.mustache
@@ -35,6 +35,10 @@ public class CollectionFormats {
 
     }
 
+    public static class SPACEParams extends SSVParams {
+
+    }
+
     public static class SSVParams extends CSVParams {
 
         public SSVParams() {

--- a/modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1041,6 +1041,53 @@ paths:
       responses:
         '200':
           description: Success
+  /fake/test-query-paramters:
+    put:
+      tags:
+        - fake
+      description: 'To test the collection format in query parameters'
+      operationId: testQueryParameterCollectionFormat
+      parameters:
+        - name: pipe
+          in: query
+          required: true
+          type: array
+          items:
+            type: string
+          collectionFormat: pipe
+        - name: ioutil
+          in: query
+          required: true
+          type: array
+          items:
+            type: string
+          collectionFormat: tsv
+        - name: http
+          in: query
+          required: true
+          type: array
+          items:
+            type: string
+          collectionFormat: ssv
+        - name: url
+          in: query
+          required: true
+          type: array
+          items:
+            type: string
+          collectionFormat: csv
+        - name: context
+          in: query
+          required: true
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+      consumes:
+        - application/json
+      responses:
+        '200':
+          description: Success
   '/fake/{petId}/uploadImageWithRequiredFile':
     post:
       tags:

--- a/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -989,6 +989,57 @@ paths:
             schema:
               $ref: '#/components/schemas/FileSchemaTestClass'
         required: true
+  /fake/test-query-paramters:
+    put:
+      tags:
+        - fake
+      description: To test the collection format in query parameters
+      operationId: testQueryParameterCollectionFormat
+      parameters:
+        - name: pipe
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: ioutil
+          in: query
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: http
+          in: query
+          required: true
+          style: spaceDelimited
+          schema:
+            type: array
+            items:
+              type: string
+        - name: url
+          in: query
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: context
+          in: query
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: Success
   '/fake/{petId}/uploadImageWithRequiredFile':
     post:
       tags:

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/README.md
@@ -104,6 +104,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**TestGroupParameters**](docs/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**TestInlineAdditionalProperties**](docs/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**TestJsonFormData**](docs/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**TestQueryParameterCollectionFormat**](docs/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**TestClassname**](docs/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**AddPet**](docs/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**DeletePet**](docs/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**TestGroupParameters**](FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**TestInlineAdditionalProperties**](FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**TestJsonFormData**](FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+[**TestQueryParameterCollectionFormat**](FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
 
 
 <a name="createxmlitem"></a>
@@ -953,6 +954,81 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a name="testqueryparametercollectionformat"></a>
+# **TestQueryParameterCollectionFormat**
+> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class TestQueryParameterCollectionFormatExample
+    {
+        public static void Main()
+        {
+            Configuration.Default.BasePath = "http://petstore.swagger.io:80/v2";
+            var apiInstance = new FakeApi(Configuration.Default);
+            var pipe = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var url = new List<string>(); // List<string> | 
+            var context = new List<string>(); // List<string> | 
+
+            try
+            {
+                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling FakeApi.TestQueryParameterCollectionFormat: " + e.Message );
+                Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;string&gt;**](string.md)|  | 
+ **ioutil** | [**List&lt;string&gt;**](string.md)|  | 
+ **http** | [**List&lt;string&gt;**](string.md)|  | 
+ **url** | [**List&lt;string&gt;**](string.md)|  | 
+ **context** | [**List&lt;string&gt;**](string.md)|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -354,6 +354,35 @@ namespace Org.OpenAPITools.Api
         /// <param name="param2">field2</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> TestJsonFormDataWithHttpInfo (string param, string param2);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>ApiResponse of Object(void)</returns>
+        ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
         #endregion Synchronous Operations
     }
 
@@ -690,6 +719,35 @@ namespace Org.OpenAPITools.Api
         /// <param name="param2">field2</param>
         /// <returns>Task of ApiResponse</returns>
         System.Threading.Tasks.Task<ApiResponse<Object>> TestJsonFormDataAsyncWithHttpInfo (string param, string param2);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of void</returns>
+        System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of ApiResponse</returns>
+        System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatAsyncWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
         #endregion Asynchronous Operations
     }
 
@@ -2748,6 +2806,262 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception exception = this.ExceptionFactory("TestJsonFormData", response);
+                if (exception != null) throw exception;
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+             TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>ApiResponse of Object(void)</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+            // verify the required parameter 'pipe' is set
+            if (pipe == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'pipe' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'ioutil' is set
+            if (ioutil == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'ioutil' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'http' is set
+            if (http == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'http' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'url' is set
+            if (url == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'url' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'context' is set
+            if (context == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'context' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            String[] @contentTypes = new String[] {
+            };
+
+            // to determine the Accept header
+            String[] @accepts = new String[] {
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(@contentTypes);
+            if (localVarContentType != null) requestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(@accepts);
+            if (localVarAccept != null) requestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+            if (pipe != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "pipe", pipe))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (ioutil != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "ioutil", ioutil))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (http != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("space", "http", http))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (url != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "url", url))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (context != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("multi", "context", context))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+
+
+            // make the HTTP request
+
+            var response = this.Client.Put<Object>("/fake/test-query-paramters", requestOptions, this.Configuration);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception exception = this.ExceptionFactory("TestQueryParameterCollectionFormat", response);
+                if (exception != null) throw exception;
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of void</returns>
+        public async System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+             await TestQueryParameterCollectionFormatAsyncWithHttpInfo(pipe, ioutil, http, url, context);
+
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> TestQueryParameterCollectionFormatAsyncWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+            // verify the required parameter 'pipe' is set
+            if (pipe == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'pipe' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'ioutil' is set
+            if (ioutil == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'ioutil' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'http' is set
+            if (http == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'http' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'url' is set
+            if (url == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'url' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'context' is set
+            if (context == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'context' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+
+            Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            String[] @contentTypes = new String[] {
+            };
+
+            // to determine the Accept header
+            String[] @accepts = new String[] {
+            };
+            
+            foreach (var contentType in @contentTypes)
+                requestOptions.HeaderParameters.Add("Content-Type", contentType);
+            
+            foreach (var accept in @accepts)
+                requestOptions.HeaderParameters.Add("Accept", accept);
+            
+            if (pipe != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "pipe", pipe))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (ioutil != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "ioutil", ioutil))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (http != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("space", "http", http))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (url != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "url", url))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (context != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("multi", "context", context))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+
+
+            // make the HTTP request
+
+            var response = await this.AsynchronousClient.PutAsync<Object>("/fake/test-query-paramters", requestOptions, this.Configuration);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception exception = this.ExceptionFactory("TestQueryParameterCollectionFormat", response);
                 if (exception != null) throw exception;
             }
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/README.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/README.md
@@ -116,6 +116,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**TestGroupParameters**](docs/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**TestInlineAdditionalProperties**](docs/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**TestJsonFormData**](docs/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**TestQueryParameterCollectionFormat**](docs/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**TestClassname**](docs/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**AddPet**](docs/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**DeletePet**](docs/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/FakeApi.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**TestGroupParameters**](FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**TestInlineAdditionalProperties**](FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**TestJsonFormData**](FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+[**TestQueryParameterCollectionFormat**](FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
 
 
 <a name="createxmlitem"></a>
@@ -953,6 +954,81 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a name="testqueryparametercollectionformat"></a>
+# **TestQueryParameterCollectionFormat**
+> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class TestQueryParameterCollectionFormatExample
+    {
+        public static void Main()
+        {
+            Configuration.Default.BasePath = "http://petstore.swagger.io:80/v2";
+            var apiInstance = new FakeApi(Configuration.Default);
+            var pipe = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var url = new List<string>(); // List<string> | 
+            var context = new List<string>(); // List<string> | 
+
+            try
+            {
+                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling FakeApi.TestQueryParameterCollectionFormat: " + e.Message );
+                Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;string&gt;**](string.md)|  | 
+ **ioutil** | [**List&lt;string&gt;**](string.md)|  | 
+ **http** | [**List&lt;string&gt;**](string.md)|  | 
+ **url** | [**List&lt;string&gt;**](string.md)|  | 
+ **context** | [**List&lt;string&gt;**](string.md)|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -354,6 +354,35 @@ namespace Org.OpenAPITools.Api
         /// <param name="param2">field2</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> TestJsonFormDataWithHttpInfo (string param, string param2);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>ApiResponse of Object(void)</returns>
+        ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
         #endregion Synchronous Operations
     }
 
@@ -690,6 +719,35 @@ namespace Org.OpenAPITools.Api
         /// <param name="param2">field2</param>
         /// <returns>Task of ApiResponse</returns>
         System.Threading.Tasks.Task<ApiResponse<Object>> TestJsonFormDataAsyncWithHttpInfo (string param, string param2);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of void</returns>
+        System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of ApiResponse</returns>
+        System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatAsyncWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
         #endregion Asynchronous Operations
     }
 
@@ -2748,6 +2806,262 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception exception = this.ExceptionFactory("TestJsonFormData", response);
+                if (exception != null) throw exception;
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+             TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>ApiResponse of Object(void)</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+            // verify the required parameter 'pipe' is set
+            if (pipe == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'pipe' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'ioutil' is set
+            if (ioutil == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'ioutil' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'http' is set
+            if (http == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'http' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'url' is set
+            if (url == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'url' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'context' is set
+            if (context == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'context' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            String[] @contentTypes = new String[] {
+            };
+
+            // to determine the Accept header
+            String[] @accepts = new String[] {
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(@contentTypes);
+            if (localVarContentType != null) requestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(@accepts);
+            if (localVarAccept != null) requestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+            if (pipe != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "pipe", pipe))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (ioutil != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "ioutil", ioutil))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (http != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("space", "http", http))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (url != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "url", url))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (context != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("multi", "context", context))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+
+
+            // make the HTTP request
+
+            var response = this.Client.Put<Object>("/fake/test-query-paramters", requestOptions, this.Configuration);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception exception = this.ExceptionFactory("TestQueryParameterCollectionFormat", response);
+                if (exception != null) throw exception;
+            }
+
+            return response;
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of void</returns>
+        public async System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+             await TestQueryParameterCollectionFormatAsyncWithHttpInfo(pipe, ioutil, http, url, context);
+
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Object>> TestQueryParameterCollectionFormatAsyncWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+            // verify the required parameter 'pipe' is set
+            if (pipe == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'pipe' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'ioutil' is set
+            if (ioutil == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'ioutil' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'http' is set
+            if (http == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'http' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'url' is set
+            if (url == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'url' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            // verify the required parameter 'context' is set
+            if (context == null)
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'context' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+
+            Org.OpenAPITools.Client.RequestOptions requestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            String[] @contentTypes = new String[] {
+            };
+
+            // to determine the Accept header
+            String[] @accepts = new String[] {
+            };
+            
+            foreach (var contentType in @contentTypes)
+                requestOptions.HeaderParameters.Add("Content-Type", contentType);
+            
+            foreach (var accept in @accepts)
+                requestOptions.HeaderParameters.Add("Accept", accept);
+            
+            if (pipe != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "pipe", pipe))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (ioutil != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "ioutil", ioutil))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (http != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("space", "http", http))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (url != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "url", url))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+            if (context != null)
+            {
+                foreach (var kvp in Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("multi", "context", context))
+                {
+                    foreach (var value in kvp.Value)
+                    {
+                        requestOptions.QueryParameters.Add(kvp.Key, value);
+                    }
+                }
+            }
+
+
+            // make the HTTP request
+
+            var response = await this.AsynchronousClient.PutAsync<Object>("/fake/test-query-paramters", requestOptions, this.Configuration);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception exception = this.ExceptionFactory("TestQueryParameterCollectionFormat", response);
                 if (exception != null) throw exception;
             }
 

--- a/samples/client/petstore/csharp/OpenAPIClient/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/README.md
@@ -119,6 +119,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**TestGroupParameters**](docs/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**TestInlineAdditionalProperties**](docs/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**TestJsonFormData**](docs/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**TestQueryParameterCollectionFormat**](docs/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**TestClassname**](docs/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**AddPet**](docs/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**DeletePet**](docs/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**TestGroupParameters**](FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**TestInlineAdditionalProperties**](FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**TestJsonFormData**](FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+[**TestQueryParameterCollectionFormat**](FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -1028,6 +1029,87 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+[[Back to top]](#)
+[[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## TestQueryParameterCollectionFormat
+
+> void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class TestQueryParameterCollectionFormatExample
+    {
+        public static void Main()
+        {
+            Configuration.Default.BasePath = "http://petstore.swagger.io:80/v2";
+            var apiInstance = new FakeApi(Configuration.Default);
+            var pipe = new List<string>(); // List<string> | 
+            var ioutil = new List<string>(); // List<string> | 
+            var http = new List<string>(); // List<string> | 
+            var url = new List<string>(); // List<string> | 
+            var context = new List<string>(); // List<string> | 
+
+            try
+            {
+                apiInstance.TestQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+            }
+            catch (ApiException e)
+            {
+                Debug.Print("Exception when calling FakeApi.TestQueryParameterCollectionFormat: " + e.Message );
+                Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;string&gt;**](string.md)|  | 
+ **ioutil** | [**List&lt;string&gt;**](string.md)|  | 
+ **http** | [**List&lt;string&gt;**](string.md)|  | 
+ **url** | [**List&lt;string&gt;**](string.md)|  | 
+ **context** | [**List&lt;string&gt;**](string.md)|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 
 [[Back to top]](#)
 [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -351,6 +351,35 @@ namespace Org.OpenAPITools.Api
         /// <param name="param2">field2</param>
         /// <returns>ApiResponse of Object(void)</returns>
         ApiResponse<Object> TestJsonFormDataWithHttpInfo (string param, string param2);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>ApiResponse of Object(void)</returns>
+        ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
         #endregion Synchronous Operations
         #region Asynchronous Operations
         /// <summary>
@@ -680,6 +709,35 @@ namespace Org.OpenAPITools.Api
         /// <param name="param2">field2</param>
         /// <returns>Task of ApiResponse</returns>
         System.Threading.Tasks.Task<ApiResponse<Object>> TestJsonFormDataAsyncWithHttpInfo (string param, string param2);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of void</returns>
+        System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// To test the collection format in query parameters
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of ApiResponse</returns>
+        System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatAsyncWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context);
         #endregion Asynchronous Operations
     }
 
@@ -2818,6 +2876,183 @@ namespace Org.OpenAPITools.Api
             if (ExceptionFactory != null)
             {
                 Exception exception = ExceptionFactory("TestJsonFormData", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse<Object>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Name, x => string.Join(",", x.Value)),
+                null);
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public void TestQueryParameterCollectionFormat (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+             TestQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>ApiResponse of Object(void)</returns>
+        public ApiResponse<Object> TestQueryParameterCollectionFormatWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+            // verify the required parameter 'pipe' is set
+            if (pipe == null)
+                throw new ApiException(400, "Missing required parameter 'pipe' when calling FakeApi->TestQueryParameterCollectionFormat");
+            // verify the required parameter 'ioutil' is set
+            if (ioutil == null)
+                throw new ApiException(400, "Missing required parameter 'ioutil' when calling FakeApi->TestQueryParameterCollectionFormat");
+            // verify the required parameter 'http' is set
+            if (http == null)
+                throw new ApiException(400, "Missing required parameter 'http' when calling FakeApi->TestQueryParameterCollectionFormat");
+            // verify the required parameter 'url' is set
+            if (url == null)
+                throw new ApiException(400, "Missing required parameter 'url' when calling FakeApi->TestQueryParameterCollectionFormat");
+            // verify the required parameter 'context' is set
+            if (context == null)
+                throw new ApiException(400, "Missing required parameter 'context' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            var localVarPath = "/fake/test-query-paramters";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new List<KeyValuePair<String, String>>();
+            var localVarHeaderParams = new Dictionary<String, String>(this.Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+            };
+            String localVarHttpContentType = this.Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+            };
+            String localVarHttpHeaderAccept = this.Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            if (pipe != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("csv", "pipe", pipe)); // query parameter
+            if (ioutil != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("csv", "ioutil", ioutil)); // query parameter
+            if (http != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("space", "http", http)); // query parameter
+            if (url != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("csv", "url", url)); // query parameter
+            if (context != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("multi", "context", context)); // query parameter
+
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse) this.Configuration.ApiClient.CallApi(localVarPath,
+                Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int) localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("TestQueryParameterCollectionFormat", localVarResponse);
+                if (exception != null) throw exception;
+            }
+
+            return new ApiResponse<Object>(localVarStatusCode,
+                localVarResponse.Headers.ToDictionary(x => x.Name, x => string.Join(",", x.Value)),
+                null);
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of void</returns>
+        public async System.Threading.Tasks.Task TestQueryParameterCollectionFormatAsync (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+             await TestQueryParameterCollectionFormatAsyncWithHttpInfo(pipe, ioutil, http, url, context);
+
+        }
+
+        /// <summary>
+        ///  To test the collection format in query parameters
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="pipe"></param>
+        /// <param name="ioutil"></param>
+        /// <param name="http"></param>
+        /// <param name="url"></param>
+        /// <param name="context"></param>
+        /// <returns>Task of ApiResponse</returns>
+        public async System.Threading.Tasks.Task<ApiResponse<Object>> TestQueryParameterCollectionFormatAsyncWithHttpInfo (List<string> pipe, List<string> ioutil, List<string> http, List<string> url, List<string> context)
+        {
+            // verify the required parameter 'pipe' is set
+            if (pipe == null)
+                throw new ApiException(400, "Missing required parameter 'pipe' when calling FakeApi->TestQueryParameterCollectionFormat");
+            // verify the required parameter 'ioutil' is set
+            if (ioutil == null)
+                throw new ApiException(400, "Missing required parameter 'ioutil' when calling FakeApi->TestQueryParameterCollectionFormat");
+            // verify the required parameter 'http' is set
+            if (http == null)
+                throw new ApiException(400, "Missing required parameter 'http' when calling FakeApi->TestQueryParameterCollectionFormat");
+            // verify the required parameter 'url' is set
+            if (url == null)
+                throw new ApiException(400, "Missing required parameter 'url' when calling FakeApi->TestQueryParameterCollectionFormat");
+            // verify the required parameter 'context' is set
+            if (context == null)
+                throw new ApiException(400, "Missing required parameter 'context' when calling FakeApi->TestQueryParameterCollectionFormat");
+
+            var localVarPath = "/fake/test-query-paramters";
+            var localVarPathParams = new Dictionary<String, String>();
+            var localVarQueryParams = new List<KeyValuePair<String, String>>();
+            var localVarHeaderParams = new Dictionary<String, String>(this.Configuration.DefaultHeader);
+            var localVarFormParams = new Dictionary<String, String>();
+            var localVarFileParams = new Dictionary<String, FileParameter>();
+            Object localVarPostBody = null;
+
+            // to determine the Content-Type header
+            String[] localVarHttpContentTypes = new String[] {
+            };
+            String localVarHttpContentType = this.Configuration.ApiClient.SelectHeaderContentType(localVarHttpContentTypes);
+
+            // to determine the Accept header
+            String[] localVarHttpHeaderAccepts = new String[] {
+            };
+            String localVarHttpHeaderAccept = this.Configuration.ApiClient.SelectHeaderAccept(localVarHttpHeaderAccepts);
+            if (localVarHttpHeaderAccept != null)
+                localVarHeaderParams.Add("Accept", localVarHttpHeaderAccept);
+
+            if (pipe != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("csv", "pipe", pipe)); // query parameter
+            if (ioutil != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("csv", "ioutil", ioutil)); // query parameter
+            if (http != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("space", "http", http)); // query parameter
+            if (url != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("csv", "url", url)); // query parameter
+            if (context != null) localVarQueryParams.AddRange(this.Configuration.ApiClient.ParameterToKeyValuePairs("multi", "context", context)); // query parameter
+
+
+            // make the HTTP request
+            IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
+                Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
+                localVarPathParams, localVarHttpContentType);
+
+            int localVarStatusCode = (int) localVarResponse.StatusCode;
+
+            if (ExceptionFactory != null)
+            {
+                Exception exception = ExceptionFactory("TestQueryParameterCollectionFormat", localVarResponse);
                 if (exception != null) throw exception;
             }
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
@@ -429,4 +429,38 @@ defmodule OpenapiPetstore.Api.Fake do
       { 200, false}
     ])
   end
+
+  @doc """
+  To test the collection format in query parameters
+
+  ## Parameters
+
+  - connection (OpenapiPetstore.Connection): Connection to server
+  - pipe ([String.t]): 
+  - ioutil ([String.t]): 
+  - http ([String.t]): 
+  - url ([String.t]): 
+  - context ([String.t]): 
+  - opts (KeywordList): [optional] Optional parameters
+  ## Returns
+
+  {:ok, %{}} on success
+  {:error, info} on failure
+  """
+  @spec test_query_parameter_collection_format(Tesla.Env.client, list(String.t), list(String.t), list(String.t), list(String.t), list(String.t), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  def test_query_parameter_collection_format(connection, pipe, ioutil, http, url, context, _opts \\ []) do
+    %{}
+    |> method(:put)
+    |> url("/fake/test-query-paramters")
+    |> add_param(:query, :"pipe", pipe)
+    |> add_param(:query, :"ioutil", ioutil)
+    |> add_param(:query, :"http", http)
+    |> add_param(:query, :"url", url)
+    |> add_param(:query, :"context", context)
+    |> Enum.into([])
+    |> (&Connection.request(connection, &1)).()
+    |> evaluate_response([
+      { 200, false}
+    ])
+  end
 end

--- a/samples/client/petstore/go/go-petstore-withXml/README.md
+++ b/samples/client/petstore/go/go-petstore-withXml/README.md
@@ -46,6 +46,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**TestGroupParameters**](docs/FakeApi.md#testgroupparameters) | **Delete** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**TestInlineAdditionalProperties**](docs/FakeApi.md#testinlineadditionalproperties) | **Post** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**TestJsonFormData**](docs/FakeApi.md#testjsonformdata) | **Get** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**TestQueryParameterCollectionFormat**](docs/FakeApi.md#testqueryparametercollectionformat) | **Put** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**TestClassname**](docs/FakeClassnameTags123Api.md#testclassname) | **Patch** /fake_classname_test | To test class name in snake case
 *PetApi* | [**AddPet**](docs/PetApi.md#addpet) | **Post** /pet | Add a new pet to the store
 *PetApi* | [**DeletePet**](docs/PetApi.md#deletepet) | **Delete** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/go/go-petstore-withXml/api/openapi.yaml
+++ b/samples/client/petstore/go/go-petstore-withXml/api/openapi.yaml
@@ -1100,6 +1100,59 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+  /fake/test-query-paramters:
+    put:
+      description: To test the collection format in query parameters
+      operationId: testQueryParameterCollectionFormat
+      parameters:
+      - explode: false
+        in: query
+        name: pipe
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - in: query
+        name: ioutil
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+      - in: query
+        name: http
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: spaceDelimited
+      - explode: false
+        in: query
+        name: url
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - explode: true
+        in: query
+        name: context
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      responses:
+        200:
+          content: {}
+          description: Success
+      tags:
+      - fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile

--- a/samples/client/petstore/go/go-petstore-withXml/api_fake.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_fake.go
@@ -17,6 +17,7 @@ import (
 	_neturl "net/url"
 	"github.com/antihax/optional"
 	"os"
+	"reflect"
 )
 
 // Linger please
@@ -1181,6 +1182,89 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 	}
 	localVarFormParams.Add("param", parameterToString(param, ""))
 	localVarFormParams.Add("param2", parameterToString(param2, ""))
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarHttpResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarHttpResponse, err
+	}
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		return localVarHttpResponse, newErr
+	}
+
+	return localVarHttpResponse, nil
+}
+
+/*
+FakeApiService
+To test the collection format in query parameters
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param pipe
+ * @param ioutil
+ * @param http
+ * @param url
+ * @param context
+*/
+func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context, pipe []string, ioutil []string, http []string, url []string, context []string) (*_nethttp.Response, error) {
+	var (
+		localVarHttpMethod   = _nethttp.MethodPut
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/fake/test-query-paramters"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	localVarQueryParams.Add("pipe", parameterToString(pipe, "csv"))
+	localVarQueryParams.Add("ioutil", parameterToString(ioutil, "csv"))
+	localVarQueryParams.Add("http", parameterToString(http, "space"))
+	localVarQueryParams.Add("url", parameterToString(url, "csv"))
+	t:=context
+	if reflect.TypeOf(t).Kind() == reflect.Slice {
+		s := reflect.ValueOf(t)
+		for i := 0; i < s.Len(); i++ {
+			localVarQueryParams.Add("context", parameterToString(s.Index(i), "multi"))
+		}
+	} else {
+		localVarQueryParams.Add("context", parameterToString(t, "multi"))
+	}
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err

--- a/samples/client/petstore/go/go-petstore-withXml/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**TestGroupParameters**](FakeApi.md#TestGroupParameters) | **Delete** /fake | Fake endpoint to test group parameters (optional)
 [**TestInlineAdditionalProperties**](FakeApi.md#TestInlineAdditionalProperties) | **Post** /fake/inline-additionalProperties | test inline additionalProperties
 [**TestJsonFormData**](FakeApi.md#TestJsonFormData) | **Get** /fake/jsonFormData | test json serialization of form data
+[**TestQueryParameterCollectionFormat**](FakeApi.md#TestQueryParameterCollectionFormat) | **Put** /fake/test-query-paramters | 
 
 
 
@@ -533,6 +534,43 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## TestQueryParameterCollectionFormat
+
+> TestQueryParameterCollectionFormat(ctx, pipe, ioutil, http, url, context)
+
+
+To test the collection format in query parameters
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**pipe** | [**[]string**](string.md)|  | 
+**ioutil** | [**[]string**](string.md)|  | 
+**http** | [**[]string**](string.md)|  | 
+**url** | [**[]string**](string.md)|  | 
+**context** | [**[]string**](string.md)|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/samples/client/petstore/go/go-petstore/README.md
+++ b/samples/client/petstore/go/go-petstore/README.md
@@ -46,6 +46,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**TestGroupParameters**](docs/FakeApi.md#testgroupparameters) | **Delete** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**TestInlineAdditionalProperties**](docs/FakeApi.md#testinlineadditionalproperties) | **Post** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**TestJsonFormData**](docs/FakeApi.md#testjsonformdata) | **Get** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**TestQueryParameterCollectionFormat**](docs/FakeApi.md#testqueryparametercollectionformat) | **Put** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**TestClassname**](docs/FakeClassnameTags123Api.md#testclassname) | **Patch** /fake_classname_test | To test class name in snake case
 *PetApi* | [**AddPet**](docs/PetApi.md#addpet) | **Post** /pet | Add a new pet to the store
 *PetApi* | [**DeletePet**](docs/PetApi.md#deletepet) | **Delete** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/go/go-petstore/api/openapi.yaml
+++ b/samples/client/petstore/go/go-petstore/api/openapi.yaml
@@ -1100,6 +1100,59 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+  /fake/test-query-paramters:
+    put:
+      description: To test the collection format in query parameters
+      operationId: testQueryParameterCollectionFormat
+      parameters:
+      - explode: false
+        in: query
+        name: pipe
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - in: query
+        name: ioutil
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+      - in: query
+        name: http
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: spaceDelimited
+      - explode: false
+        in: query
+        name: url
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - explode: true
+        in: query
+        name: context
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      responses:
+        200:
+          content: {}
+          description: Success
+      tags:
+      - fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -16,6 +16,7 @@ import (
 	_neturl "net/url"
 	"github.com/antihax/optional"
 	"os"
+	"reflect"
 )
 
 // Linger please
@@ -1180,6 +1181,89 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 	}
 	localVarFormParams.Add("param", parameterToString(param, ""))
 	localVarFormParams.Add("param2", parameterToString(param2, ""))
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarHttpResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarHttpResponse, err
+	}
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		return localVarHttpResponse, newErr
+	}
+
+	return localVarHttpResponse, nil
+}
+
+/*
+FakeApiService
+To test the collection format in query parameters
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param pipe
+ * @param ioutil
+ * @param http
+ * @param url
+ * @param context
+*/
+func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context, pipe []string, ioutil []string, http []string, url []string, context []string) (*_nethttp.Response, error) {
+	var (
+		localVarHttpMethod   = _nethttp.MethodPut
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/fake/test-query-paramters"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	localVarQueryParams.Add("pipe", parameterToString(pipe, "csv"))
+	localVarQueryParams.Add("ioutil", parameterToString(ioutil, "csv"))
+	localVarQueryParams.Add("http", parameterToString(http, "space"))
+	localVarQueryParams.Add("url", parameterToString(url, "csv"))
+	t:=context
+	if reflect.TypeOf(t).Kind() == reflect.Slice {
+		s := reflect.ValueOf(t)
+		for i := 0; i < s.Len(); i++ {
+			localVarQueryParams.Add("context", parameterToString(s.Index(i), "multi"))
+		}
+	} else {
+		localVarQueryParams.Add("context", parameterToString(t, "multi"))
+	}
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**TestGroupParameters**](FakeApi.md#TestGroupParameters) | **Delete** /fake | Fake endpoint to test group parameters (optional)
 [**TestInlineAdditionalProperties**](FakeApi.md#TestInlineAdditionalProperties) | **Post** /fake/inline-additionalProperties | test inline additionalProperties
 [**TestJsonFormData**](FakeApi.md#TestJsonFormData) | **Get** /fake/jsonFormData | test json serialization of form data
+[**TestQueryParameterCollectionFormat**](FakeApi.md#TestQueryParameterCollectionFormat) | **Put** /fake/test-query-paramters | 
 
 
 
@@ -533,6 +534,43 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## TestQueryParameterCollectionFormat
+
+> TestQueryParameterCollectionFormat(ctx, pipe, ioutil, http, url, context)
+
+
+To test the collection format in query parameters
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**pipe** | [**[]string**](string.md)|  | 
+**ioutil** | [**[]string**](string.md)|  | 
+**http** | [**[]string**](string.md)|  | 
+**url** | [**[]string**](string.md)|  | 
+**context** | [**[]string**](string.md)|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/API/Fake.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/API/Fake.hs
@@ -504,3 +504,28 @@ instance Consumes TestJsonFormData MimeFormUrlEncoded
 
 instance Produces TestJsonFormData MimeNoContent
 
+
+-- *** testQueryParameterCollectionFormat
+
+-- | @PUT \/fake\/test-query-paramters@
+-- 
+-- To test the collection format in query parameters
+-- 
+testQueryParameterCollectionFormat 
+  :: Pipe -- ^ "pipe"
+  -> Ioutil -- ^ "ioutil"
+  -> Http -- ^ "http"
+  -> Url -- ^ "url"
+  -> Context -- ^ "context"
+  -> OpenAPIPetstoreRequest TestQueryParameterCollectionFormat MimeNoContent NoContent MimeNoContent
+testQueryParameterCollectionFormat (Pipe pipe) (Ioutil ioutil) (Http http) (Url url) (Context context) =
+  _mkRequest "PUT" ["/fake/test-query-paramters"]
+    `setQuery` toQueryColl CommaSeparated ("pipe", Just pipe)
+    `setQuery` toQueryColl CommaSeparated ("ioutil", Just ioutil)
+    `setQuery` toQueryColl SpaceSeparated ("http", Just http)
+    `setQuery` toQueryColl CommaSeparated ("url", Just url)
+    `setQuery` toQueryColl MultiParamArray ("context", Just context)
+
+data TestQueryParameterCollectionFormat  
+instance Produces TestQueryParameterCollectionFormat MimeNoContent
+

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Model.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Model.hs
@@ -93,6 +93,9 @@ newtype Byte = Byte { unByte :: ByteArray } deriving (P.Eq, P.Show)
 -- ** Callback
 newtype Callback = Callback { unCallback :: Text } deriving (P.Eq, P.Show)
 
+-- ** Context
+newtype Context = Context { unContext :: [Text] } deriving (P.Eq, P.Show)
+
 -- ** EnumFormString
 newtype EnumFormString = EnumFormString { unEnumFormString :: E'EnumFormString } deriving (P.Eq, P.Show)
 
@@ -120,6 +123,9 @@ newtype EnumQueryStringArray = EnumQueryStringArray { unEnumQueryStringArray :: 
 -- ** File2
 newtype File2 = File2 { unFile2 :: FilePath } deriving (P.Eq, P.Show)
 
+-- ** Http
+newtype Http = Http { unHttp :: [Text] } deriving (P.Eq, P.Show)
+
 -- ** Int32
 newtype Int32 = Int32 { unInt32 :: Int } deriving (P.Eq, P.Show)
 
@@ -128,6 +134,9 @@ newtype Int64 = Int64 { unInt64 :: Integer } deriving (P.Eq, P.Show)
 
 -- ** Int64Group
 newtype Int64Group = Int64Group { unInt64Group :: Integer } deriving (P.Eq, P.Show)
+
+-- ** Ioutil
+newtype Ioutil = Ioutil { unIoutil :: [Text] } deriving (P.Eq, P.Show)
 
 -- ** Name2
 newtype Name2 = Name2 { unName2 :: Text } deriving (P.Eq, P.Show)
@@ -180,6 +189,9 @@ newtype PatternWithoutDelimiter = PatternWithoutDelimiter { unPatternWithoutDeli
 -- ** PetId
 newtype PetId = PetId { unPetId :: Integer } deriving (P.Eq, P.Show)
 
+-- ** Pipe
+newtype Pipe = Pipe { unPipe :: [Text] } deriving (P.Eq, P.Show)
+
 -- ** Query
 newtype Query = Query { unQuery :: Text } deriving (P.Eq, P.Show)
 
@@ -206,6 +218,9 @@ newtype StringGroup = StringGroup { unStringGroup :: Int } deriving (P.Eq, P.Sho
 
 -- ** Tags
 newtype Tags = Tags { unTags :: [Text] } deriving (P.Eq, P.Show)
+
+-- ** Url
+newtype Url = Url { unUrl :: [Text] } deriving (P.Eq, P.Show)
 
 -- ** Username
 newtype Username = Username { unUsername :: Text } deriving (P.Eq, P.Show)

--- a/samples/client/petstore/haskell-http-client/openapi.yaml
+++ b/samples/client/petstore/haskell-http-client/openapi.yaml
@@ -1100,6 +1100,59 @@ paths:
       tags:
       - fake
       x-codegen-request-body-name: body
+  /fake/test-query-paramters:
+    put:
+      description: To test the collection format in query parameters
+      operationId: testQueryParameterCollectionFormat
+      parameters:
+      - explode: false
+        in: query
+        name: pipe
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - in: query
+        name: ioutil
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+      - in: query
+        name: http
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: spaceDelimited
+      - explode: false
+        in: query
+        name: url
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - explode: true
+        in: query
+        name: context
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      responses:
+        200:
+          content: {}
+          description: Success
+      tags:
+      - fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -353,4 +353,70 @@ public interface FakeApi extends ApiClient.Api {
     "Accept: application/json",
   })
   void testJsonFormData(@Param("param") String param, @Param("param2") String param2);
+
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   */
+  @RequestLine("PUT /fake/test-query-paramters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}")
+  @Headers({
+    "Accept: application/json",
+  })
+  void testQueryParameterCollectionFormat(@Param("pipe") List<String> pipe, @Param("ioutil") List<String> ioutil, @Param("http") List<String> http, @Param("url") List<String> url, @Param("context") List<String> context);
+
+  /**
+   * 
+   * To test the collection format in query parameters
+   * Note, this is equivalent to the other <code>testQueryParameterCollectionFormat</code> method,
+   * but with the query parameters collected into a single Map parameter. This
+   * is convenient for services with optional query parameters, especially when
+   * used with the {@link TestQueryParameterCollectionFormatQueryParams} class that allows for
+   * building up this map in a fluent style.
+   * @param queryParams Map of query parameters as name-value pairs
+   *   <p>The following elements may be specified in the query map:</p>
+   *   <ul>
+   *   <li>pipe -  (required)</li>
+   *   <li>ioutil -  (required)</li>
+   *   <li>http -  (required)</li>
+   *   <li>url -  (required)</li>
+   *   <li>context -  (required)</li>
+   *   </ul>
+   */
+  @RequestLine("PUT /fake/test-query-paramters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}")
+  @Headers({
+  "Accept: application/json",
+  })
+  void testQueryParameterCollectionFormat(@QueryMap(encoded=true) Map<String, Object> queryParams);
+
+  /**
+   * A convenience class for generating query parameters for the
+   * <code>testQueryParameterCollectionFormat</code> method in a fluent style.
+   */
+  public static class TestQueryParameterCollectionFormatQueryParams extends HashMap<String, Object> {
+    public TestQueryParameterCollectionFormatQueryParams pipe(final List<String> value) {
+      put("pipe", EncodingUtils.encodeCollection(value, "csv"));
+      return this;
+    }
+    public TestQueryParameterCollectionFormatQueryParams ioutil(final List<String> value) {
+      put("ioutil", EncodingUtils.encodeCollection(value, "csv"));
+      return this;
+    }
+    public TestQueryParameterCollectionFormatQueryParams http(final List<String> value) {
+      put("http", EncodingUtils.encodeCollection(value, "space"));
+      return this;
+    }
+    public TestQueryParameterCollectionFormatQueryParams url(final List<String> value) {
+      put("url", EncodingUtils.encodeCollection(value, "csv"));
+      return this;
+    }
+    public TestQueryParameterCollectionFormatQueryParams context(final List<String> value) {
+      put("context", EncodingUtils.encodeCollection(value, "multi"));
+      return this;
+    }
+  }
 }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -353,4 +353,70 @@ public interface FakeApi extends ApiClient.Api {
     "Accept: application/json",
   })
   void testJsonFormData(@Param("param") String param, @Param("param2") String param2);
+
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   */
+  @RequestLine("PUT /fake/test-query-paramters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}")
+  @Headers({
+    "Accept: application/json",
+  })
+  void testQueryParameterCollectionFormat(@Param("pipe") List<String> pipe, @Param("ioutil") List<String> ioutil, @Param("http") List<String> http, @Param("url") List<String> url, @Param("context") List<String> context);
+
+  /**
+   * 
+   * To test the collection format in query parameters
+   * Note, this is equivalent to the other <code>testQueryParameterCollectionFormat</code> method,
+   * but with the query parameters collected into a single Map parameter. This
+   * is convenient for services with optional query parameters, especially when
+   * used with the {@link TestQueryParameterCollectionFormatQueryParams} class that allows for
+   * building up this map in a fluent style.
+   * @param queryParams Map of query parameters as name-value pairs
+   *   <p>The following elements may be specified in the query map:</p>
+   *   <ul>
+   *   <li>pipe -  (required)</li>
+   *   <li>ioutil -  (required)</li>
+   *   <li>http -  (required)</li>
+   *   <li>url -  (required)</li>
+   *   <li>context -  (required)</li>
+   *   </ul>
+   */
+  @RequestLine("PUT /fake/test-query-paramters?pipe={pipe}&ioutil={ioutil}&http={http}&url={url}&context={context}")
+  @Headers({
+  "Accept: application/json",
+  })
+  void testQueryParameterCollectionFormat(@QueryMap(encoded=true) Map<String, Object> queryParams);
+
+  /**
+   * A convenience class for generating query parameters for the
+   * <code>testQueryParameterCollectionFormat</code> method in a fluent style.
+   */
+  public static class TestQueryParameterCollectionFormatQueryParams extends HashMap<String, Object> {
+    public TestQueryParameterCollectionFormatQueryParams pipe(final List<String> value) {
+      put("pipe", EncodingUtils.encodeCollection(value, "csv"));
+      return this;
+    }
+    public TestQueryParameterCollectionFormatQueryParams ioutil(final List<String> value) {
+      put("ioutil", EncodingUtils.encodeCollection(value, "csv"));
+      return this;
+    }
+    public TestQueryParameterCollectionFormatQueryParams http(final List<String> value) {
+      put("http", EncodingUtils.encodeCollection(value, "space"));
+      return this;
+    }
+    public TestQueryParameterCollectionFormatQueryParams url(final List<String> value) {
+      put("url", EncodingUtils.encodeCollection(value, "csv"));
+      return this;
+    }
+    public TestQueryParameterCollectionFormatQueryParams context(final List<String> value) {
+      put("context", EncodingUtils.encodeCollection(value, "multi"));
+      return this;
+    }
+  }
 }

--- a/samples/client/petstore/java/google-api-client/docs/FakeApi.md
+++ b/samples/client/petstore/java/google-api-client/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -76,8 +76,8 @@ public class AnotherFakeApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/another-fake/dummy");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PATCH, genericUrl, content).execute();
@@ -90,8 +90,8 @@ public class AnotherFakeApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/another-fake/dummy");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -124,8 +124,8 @@ public class AnotherFakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PATCH, genericUrl, content).execute();

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -1260,4 +1260,165 @@ public class FakeApi {
     }
 
 
+  /**
+    * To test the collection format in query parameters
+    * <p><b>200</b> - Success
+    * @param pipe The pipe parameter
+    * @param ioutil The ioutil parameter
+    * @param http The http parameter
+    * @param url The url parameter
+    * @param context The context parameter
+    * @throws IOException if an error occurs while attempting to invoke the API
+    **/
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws IOException {
+        testQueryParameterCollectionFormatForHttpResponse(pipe, ioutil, http, url, context);
+    }
+
+  /**
+    * To test the collection format in query parameters
+    * <p><b>200</b> - Success
+    * @param pipe The pipe parameter
+    * @param ioutil The ioutil parameter
+    * @param http The http parameter
+    * @param url The url parameter
+    * @param context The context parameter
+    * @param params Map of query params. A collection will be interpreted as passing in multiple instances of the same query param.
+    * @throws IOException if an error occurs while attempting to invoke the API
+    **/
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, Object> params) throws IOException {
+        testQueryParameterCollectionFormatForHttpResponse(pipe, ioutil, http, url, context, params);
+    }
+
+    public HttpResponse testQueryParameterCollectionFormatForHttpResponse(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws IOException {
+        // verify the required parameter 'pipe' is set
+        if (pipe == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+        }// verify the required parameter 'ioutil' is set
+        if (ioutil == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+        }// verify the required parameter 'http' is set
+        if (http == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+        }// verify the required parameter 'url' is set
+        if (url == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+        }// verify the required parameter 'context' is set
+        if (context == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+        }
+        UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/test-query-paramters");
+        if (pipe != null) {
+            String key = "pipe";
+            Object value = pipe;
+            if (value instanceof Collection) {
+                uriBuilder = uriBuilder.queryParam(key, ((Collection) value).toArray());
+            } else if (value instanceof Object[]) {
+                uriBuilder = uriBuilder.queryParam(key, (Object[]) value);
+            } else {
+                uriBuilder = uriBuilder.queryParam(key, value);
+            }
+        }        if (ioutil != null) {
+            String key = "ioutil";
+            Object value = ioutil;
+            if (value instanceof Collection) {
+                uriBuilder = uriBuilder.queryParam(key, ((Collection) value).toArray());
+            } else if (value instanceof Object[]) {
+                uriBuilder = uriBuilder.queryParam(key, (Object[]) value);
+            } else {
+                uriBuilder = uriBuilder.queryParam(key, value);
+            }
+        }        if (http != null) {
+            String key = "http";
+            Object value = http;
+            if (value instanceof Collection) {
+                uriBuilder = uriBuilder.queryParam(key, ((Collection) value).toArray());
+            } else if (value instanceof Object[]) {
+                uriBuilder = uriBuilder.queryParam(key, (Object[]) value);
+            } else {
+                uriBuilder = uriBuilder.queryParam(key, value);
+            }
+        }        if (url != null) {
+            String key = "url";
+            Object value = url;
+            if (value instanceof Collection) {
+                uriBuilder = uriBuilder.queryParam(key, ((Collection) value).toArray());
+            } else if (value instanceof Object[]) {
+                uriBuilder = uriBuilder.queryParam(key, (Object[]) value);
+            } else {
+                uriBuilder = uriBuilder.queryParam(key, value);
+            }
+        }        if (context != null) {
+            String key = "context";
+            Object value = context;
+            if (value instanceof Collection) {
+                uriBuilder = uriBuilder.queryParam(key, ((Collection) value).toArray());
+            } else if (value instanceof Object[]) {
+                uriBuilder = uriBuilder.queryParam(key, (Object[]) value);
+            } else {
+                uriBuilder = uriBuilder.queryParam(key, value);
+            }
+        }
+
+        String url = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(url);
+
+        HttpContent content = apiClient.new JacksonJsonHttpContent(null);
+        return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
+    }
+
+    public HttpResponse testQueryParameterCollectionFormatForHttpResponse(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Map<String, Object> params) throws IOException {
+        // verify the required parameter 'pipe' is set
+        if (pipe == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+        }// verify the required parameter 'ioutil' is set
+        if (ioutil == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+        }// verify the required parameter 'http' is set
+        if (http == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+        }// verify the required parameter 'url' is set
+        if (url == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+        }// verify the required parameter 'context' is set
+        if (context == null) {
+            throw new IllegalArgumentException("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+        }
+        UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/test-query-paramters");
+
+        // Copy the params argument if present, to allow passing in immutable maps
+        Map<String, Object> allParams = params == null ? new HashMap<String, Object>() : new HashMap<String, Object>(params);
+        // Add the required query param 'pipe' to the map of query params
+        allParams.put("pipe", pipe);
+        // Add the required query param 'ioutil' to the map of query params
+        allParams.put("ioutil", ioutil);
+        // Add the required query param 'http' to the map of query params
+        allParams.put("http", http);
+        // Add the required query param 'url' to the map of query params
+        allParams.put("url", url);
+        // Add the required query param 'context' to the map of query params
+        allParams.put("context", context);
+
+        for (Map.Entry<String, Object> entry: allParams.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            if (key != null && value != null) {
+                if (value instanceof Collection) {
+                    uriBuilder = uriBuilder.queryParam(key, ((Collection) value).toArray());
+                } else if (value instanceof Object[]) {
+                    uriBuilder = uriBuilder.queryParam(key, (Object[]) value);
+                } else {
+                    uriBuilder = uriBuilder.queryParam(key, value);
+                }
+            }
+        }
+
+        String url = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(url);
+
+        HttpContent content = apiClient.new JacksonJsonHttpContent(null);
+        return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
+    }
+
+
 }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -78,8 +78,8 @@ public class FakeApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/create_xml_item");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(xmlItem);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -92,8 +92,8 @@ public class FakeApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/create_xml_item");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = xmlItem == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -126,8 +126,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(xmlItem);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -164,8 +164,8 @@ public class FakeApi {
         
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/outer/boolean");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -175,8 +175,8 @@ public class FakeApi {
           
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/outer/boolean");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -206,8 +206,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -244,8 +244,8 @@ public class FakeApi {
         
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/outer/composite");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -255,8 +255,8 @@ public class FakeApi {
           
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/outer/composite");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -286,8 +286,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -324,8 +324,8 @@ public class FakeApi {
         
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/outer/number");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -335,8 +335,8 @@ public class FakeApi {
           
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/outer/number");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -366,8 +366,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -404,8 +404,8 @@ public class FakeApi {
         
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/outer/string");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -415,8 +415,8 @@ public class FakeApi {
           
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/outer/string");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -446,8 +446,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -482,8 +482,8 @@ public class FakeApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/body-with-file-schema");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
@@ -496,8 +496,8 @@ public class FakeApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/body-with-file-schema");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -530,8 +530,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
@@ -580,8 +580,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
@@ -608,8 +608,8 @@ public class FakeApi {
                   }
               }
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -647,8 +647,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
@@ -691,8 +691,8 @@ public class FakeApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PATCH, genericUrl, content).execute();
@@ -705,8 +705,8 @@ public class FakeApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -739,8 +739,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PATCH, genericUrl, content).execute();
@@ -804,8 +804,8 @@ public class FakeApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(null);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -845,8 +845,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(null);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -929,8 +929,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -958,8 +958,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -1050,8 +1050,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.DELETE, genericUrl, content).execute();
@@ -1092,8 +1092,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.DELETE, genericUrl, content).execute();
@@ -1128,8 +1128,8 @@ public class FakeApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/inline-additionalProperties");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(param);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -1142,8 +1142,8 @@ public class FakeApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/inline-additionalProperties");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = param == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -1176,8 +1176,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(param);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -1217,8 +1217,8 @@ public class FakeApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/jsonFormData");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -1252,8 +1252,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -1359,8 +1359,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(null);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
@@ -1413,8 +1413,8 @@ public class FakeApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(null);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -76,8 +76,8 @@ public class FakeClassnameTags123Api {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake_classname_test");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PATCH, genericUrl, content).execute();
@@ -90,8 +90,8 @@ public class FakeClassnameTags123Api {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake_classname_test");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -124,8 +124,8 @@ public class FakeClassnameTags123Api {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PATCH, genericUrl, content).execute();

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/PetApi.java
@@ -72,8 +72,8 @@ public class PetApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/pet");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -86,8 +86,8 @@ public class PetApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/pet");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -120,8 +120,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -162,8 +162,8 @@ public class PetApi {
         uriVariables.put("petId", petId);
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/pet/{petId}");
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.DELETE, genericUrl, content).execute();
@@ -197,8 +197,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.DELETE, genericUrl, content).execute();
@@ -254,8 +254,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -288,8 +288,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -345,8 +345,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -379,8 +379,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -430,8 +430,8 @@ public class PetApi {
         uriVariables.put("petId", petId);
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/pet/{petId}");
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -465,8 +465,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -507,8 +507,8 @@ public class PetApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/pet");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
@@ -521,8 +521,8 @@ public class PetApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/pet");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -555,8 +555,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
@@ -596,8 +596,8 @@ public class PetApi {
         uriVariables.put("petId", petId);
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/pet/{petId}");
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(null);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -631,8 +631,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(null);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -678,8 +678,8 @@ public class PetApi {
         uriVariables.put("petId", petId);
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/pet/{petId}/uploadImage");
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(null);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -713,8 +713,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(null);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -764,8 +764,8 @@ public class PetApi {
         uriVariables.put("petId", petId);
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/fake/{petId}/uploadImageWithRequiredFile");
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(null);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -802,8 +802,8 @@ public class PetApi {
             }
         }
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(null);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -75,8 +75,8 @@ public class StoreApi {
         uriVariables.put("order_id", orderId);
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/store/order/{order_id}");
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.DELETE, genericUrl, content).execute();
@@ -110,8 +110,8 @@ public class StoreApi {
             }
         }
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.DELETE, genericUrl, content).execute();
@@ -149,8 +149,8 @@ public class StoreApi {
         
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/store/inventory");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -178,8 +178,8 @@ public class StoreApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -229,8 +229,8 @@ public class StoreApi {
         uriVariables.put("order_id", orderId);
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/store/order/{order_id}");
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -264,8 +264,8 @@ public class StoreApi {
             }
         }
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -308,8 +308,8 @@ public class StoreApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/store/order");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -322,8 +322,8 @@ public class StoreApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/store/order");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -356,8 +356,8 @@ public class StoreApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/api/UserApi.java
@@ -70,8 +70,8 @@ public class UserApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -84,8 +84,8 @@ public class UserApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -118,8 +118,8 @@ public class UserApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -154,8 +154,8 @@ public class UserApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user/createWithArray");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -168,8 +168,8 @@ public class UserApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user/createWithArray");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -202,8 +202,8 @@ public class UserApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -238,8 +238,8 @@ public class UserApi {
         }
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user/createWithList");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -252,8 +252,8 @@ public class UserApi {
               }
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user/createWithList");
 
-              String url = uriBuilder.build().toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.build().toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -286,8 +286,8 @@ public class UserApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.POST, genericUrl, content).execute();
@@ -329,8 +329,8 @@ public class UserApi {
         uriVariables.put("username", username);
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user/{username}");
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.DELETE, genericUrl, content).execute();
@@ -364,8 +364,8 @@ public class UserApi {
             }
         }
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.DELETE, genericUrl, content).execute();
@@ -413,8 +413,8 @@ public class UserApi {
         uriVariables.put("username", username);
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user/{username}");
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -448,8 +448,8 @@ public class UserApi {
             }
         }
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -518,8 +518,8 @@ public class UserApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -557,8 +557,8 @@ public class UserApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -588,8 +588,8 @@ public class UserApi {
         
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user/logout");
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -617,8 +617,8 @@ public class UserApi {
             }
         }
 
-        String url = uriBuilder.build().toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.build().toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = null;
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.GET, genericUrl, content).execute();
@@ -665,8 +665,8 @@ public class UserApi {
         uriVariables.put("username", username);
         UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user/{username}");
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();
@@ -685,8 +685,8 @@ public class UserApi {
                       uriVariables.put("username", username);
               UriBuilder uriBuilder = UriBuilder.fromUri(apiClient.getBasePath() + "/user/{username}");
 
-              String url = uriBuilder.buildFromMap(uriVariables).toString();
-              GenericUrl genericUrl = new GenericUrl(url);
+              String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+              GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
               HttpContent content = body == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
@@ -725,8 +725,8 @@ public class UserApi {
             }
         }
 
-        String url = uriBuilder.buildFromMap(uriVariables).toString();
-        GenericUrl genericUrl = new GenericUrl(url);
+        String localVarUrl = uriBuilder.buildFromMap(uriVariables).toString();
+        GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = apiClient.new JacksonJsonHttpContent(body);
         return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.PUT, genericUrl, content).execute();

--- a/samples/client/petstore/java/jersey1/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey1/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -684,4 +684,74 @@ if (param2 != null)
 
     apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
   }
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @throws ApiException if fails to make API call
+   */
+  public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+    Object localVarPostBody = null;
+    
+    // verify the required parameter 'pipe' is set
+    if (pipe == null) {
+      throw new ApiException(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'ioutil' is set
+    if (ioutil == null) {
+      throw new ApiException(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'http' is set
+    if (http == null) {
+      throw new ApiException(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'url' is set
+    if (url == null) {
+      throw new ApiException(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'context' is set
+    if (context == null) {
+      throw new ApiException(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/fake/test-query-paramters";
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    localVarCollectionQueryParams.addAll(apiClient.parameterToPairs("csv", "pipe", pipe));
+    localVarCollectionQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
+    localVarCollectionQueryParams.addAll(apiClient.parameterToPairs("space", "http", http));
+    localVarCollectionQueryParams.addAll(apiClient.parameterToPairs("csv", "url", url));
+    localVarCollectionQueryParams.addAll(apiClient.parameterToPairs("multi", "context", context));
+
+    
+    
+    final String[] localVarAccepts = {
+      
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+
+    apiClient.invokeAPI(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+  }
 }

--- a/samples/client/petstore/java/jersey2-java6/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -970,4 +970,99 @@ if (param2 != null)
 
     return apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
   }
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+   */
+  public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+
+    testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+  }
+
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @return ApiResponse&lt;Void&gt;
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+   */
+  public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+    Object localVarPostBody = new Object();
+    
+    // verify the required parameter 'pipe' is set
+    if (pipe == null) {
+      throw new ApiException(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'ioutil' is set
+    if (ioutil == null) {
+      throw new ApiException(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'http' is set
+    if (http == null) {
+      throw new ApiException(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'url' is set
+    if (url == null) {
+      throw new ApiException(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'context' is set
+    if (context == null) {
+      throw new ApiException(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/fake/test-query-paramters";
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "pipe", pipe));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("space", "http", http));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "url", url));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "context", context));
+
+    
+    
+    final String[] localVarAccepts = {
+      
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+
+    return apiClient.invokeAPI(localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+  }
 }

--- a/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -970,4 +970,99 @@ if (param2 != null)
 
     return apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
   }
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+   */
+  public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+
+    testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+  }
+
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @return ApiResponse&lt;Void&gt;
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+   */
+  public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+    Object localVarPostBody = new Object();
+    
+    // verify the required parameter 'pipe' is set
+    if (pipe == null) {
+      throw new ApiException(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'ioutil' is set
+    if (ioutil == null) {
+      throw new ApiException(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'http' is set
+    if (http == null) {
+      throw new ApiException(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'url' is set
+    if (url == null) {
+      throw new ApiException(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'context' is set
+    if (context == null) {
+      throw new ApiException(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/fake/test-query-paramters";
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "pipe", pipe));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("space", "http", http));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "url", url));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "context", context));
+
+    
+    
+    final String[] localVarAccepts = {
+      
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+
+    return apiClient.invokeAPI(localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+  }
 }

--- a/samples/client/petstore/java/jersey2/docs/FakeApi.md
+++ b/samples/client/petstore/java/jersey2/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -970,4 +970,99 @@ if (param2 != null)
 
     return apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
   }
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+   */
+  public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+
+    testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+  }
+
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @return ApiResponse&lt;Void&gt;
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+   */
+  public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+    Object localVarPostBody = new Object();
+    
+    // verify the required parameter 'pipe' is set
+    if (pipe == null) {
+      throw new ApiException(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'ioutil' is set
+    if (ioutil == null) {
+      throw new ApiException(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'http' is set
+    if (http == null) {
+      throw new ApiException(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'url' is set
+    if (url == null) {
+      throw new ApiException(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'context' is set
+    if (context == null) {
+      throw new ApiException(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/fake/test-query-paramters";
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "pipe", pipe));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("space", "http", http));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "url", url));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "context", context));
+
+    
+    
+    final String[] localVarAccepts = {
+      
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+
+    return apiClient.invokeAPI(localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+  }
 }

--- a/samples/client/petstore/java/native/docs/FakeApi.md
+++ b/samples/client/petstore/java/native/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -730,4 +730,80 @@ public class FakeApi {
       throw new ApiException(e);
     }
   }
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @throws ApiException if fails to make API call
+   */
+  public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+    // verify the required parameter 'pipe' is set
+    if (pipe == null) {
+      throw new ApiException(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+    }
+    // verify the required parameter 'ioutil' is set
+    if (ioutil == null) {
+      throw new ApiException(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+    }
+    // verify the required parameter 'http' is set
+    if (http == null) {
+      throw new ApiException(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+    }
+    // verify the required parameter 'url' is set
+    if (url == null) {
+      throw new ApiException(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+    }
+    // verify the required parameter 'context' is set
+    if (context == null) {
+      throw new ApiException(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+    }
+
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
+    String localVarPath = "/fake/test-query-paramters";
+
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("csv", "pipe", pipe));
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("csv", "ioutil", ioutil));
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("space", "http", http));
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("csv", "url", url));
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("multi", "context", context));
+
+    if (!localVarQueryParams.isEmpty()) {
+      StringJoiner queryJoiner = new StringJoiner("&");
+      localVarQueryParams.forEach(p -> queryJoiner.add(p.getName() + '=' + p.getValue()));
+      localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath + '?' + queryJoiner.toString()));
+    } else {
+      localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
+    }
+
+    localVarRequestBuilder.header("Accept", "application/json");
+
+    try {
+      localVarRequestBuilder.method("PUT", HttpRequest.BodyPublishers.noBody());
+      if (memberVarReadTimeout != null) {
+        localVarRequestBuilder.timeout(memberVarReadTimeout);
+      }
+      if (memberVarInterceptor != null) {
+        memberVarInterceptor.accept(localVarRequestBuilder);
+      }
+
+      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+          localVarRequestBuilder.build(),
+          HttpResponse.BodyHandlers.ofInputStream());
+      if (localVarResponse.statusCode()/ 100 != 2) {
+        throw new ApiException(localVarResponse.statusCode(),
+            "testQueryParameterCollectionFormat call received non-success response",
+            localVarResponse.headers(),
+            localVarResponse.body() == null ? null : new String(localVarResponse.body().readAllBytes()));
+      }
+
+    } catch (IOException | InterruptedException e) {
+      throw new ApiException(e);
+    }
+  }
 }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 <a name="createXmlItem"></a>
@@ -876,4 +877,73 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | successful operation |  -  |
+
+<a name="testQueryParameterCollectionFormat"></a>
+# **testQueryParameterCollectionFormat**
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    List<String> pipe = Arrays.asList(); // List<String> | 
+    List<String> ioutil = Arrays.asList(); // List<String> | 
+    List<String> http = Arrays.asList(); // List<String> | 
+    List<String> url = Arrays.asList(); // List<String> | 
+    List<String> context = Arrays.asList(); // List<String> | 
+    try {
+      apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Success |  -  |
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -1745,4 +1745,165 @@ public class FakeApi {
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+    /**
+     * Build call for testQueryParameterCollectionFormat
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testQueryParameterCollectionFormatCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback _callback) throws ApiException {
+        Object localVarPostBody = new Object();
+
+        // create path and map variables
+        String localVarPath = "/fake/test-query-paramters";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        if (pipe != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "pipe", pipe));
+        }
+
+        if (ioutil != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "ioutil", ioutil));
+        }
+
+        if (http != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("space", "http", http));
+        }
+
+        if (url != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "url", url));
+        }
+
+        if (context != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("multi", "context", context));
+        }
+
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+        final String[] localVarAccepts = {
+            
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        localVarHeaderParams.put("Content-Type", localVarContentType);
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call testQueryParameterCollectionFormatValidateBeforeCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback _callback) throws ApiException {
+        
+        // verify the required parameter 'pipe' is set
+        if (pipe == null) {
+            throw new ApiException("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat(Async)");
+        }
+        
+        // verify the required parameter 'ioutil' is set
+        if (ioutil == null) {
+            throw new ApiException("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat(Async)");
+        }
+        
+        // verify the required parameter 'http' is set
+        if (http == null) {
+            throw new ApiException("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat(Async)");
+        }
+        
+        // verify the required parameter 'url' is set
+        if (url == null) {
+            throw new ApiException("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat(Async)");
+        }
+        
+        // verify the required parameter 'context' is set
+        if (context == null) {
+            throw new ApiException("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat(Async)");
+        }
+        
+
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatCall(pipe, ioutil, http, url, context, _callback);
+        return localVarCall;
+
+    }
+
+    /**
+     * 
+     * To test the collection format in query parameters
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+     */
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+        testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+    }
+
+    /**
+     * 
+     * To test the collection format in query parameters
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @return ApiResponse&lt;Void&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, null);
+        return localVarApiClient.execute(localVarCall);
+    }
+
+    /**
+     *  (asynchronously)
+     * To test the collection format in query parameters
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback<Void> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, _callback);
+        localVarApiClient.executeAsync(localVarCall, _callback);
+        return localVarCall;
+    }
 }

--- a/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 <a name="createXmlItem"></a>
@@ -876,4 +877,73 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | successful operation |  -  |
+
+<a name="testQueryParameterCollectionFormat"></a>
+# **testQueryParameterCollectionFormat**
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    List<String> pipe = Arrays.asList(); // List<String> | 
+    List<String> ioutil = Arrays.asList(); // List<String> | 
+    List<String> http = Arrays.asList(); // List<String> | 
+    List<String> url = Arrays.asList(); // List<String> | 
+    List<String> context = Arrays.asList(); // List<String> | 
+    try {
+      apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Success |  -  |
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -1745,4 +1745,165 @@ public class FakeApi {
         localVarApiClient.executeAsync(localVarCall, _callback);
         return localVarCall;
     }
+    /**
+     * Build call for testQueryParameterCollectionFormat
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testQueryParameterCollectionFormatCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback _callback) throws ApiException {
+        Object localVarPostBody = new Object();
+
+        // create path and map variables
+        String localVarPath = "/fake/test-query-paramters";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        if (pipe != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "pipe", pipe));
+        }
+
+        if (ioutil != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "ioutil", ioutil));
+        }
+
+        if (http != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("space", "http", http));
+        }
+
+        if (url != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "url", url));
+        }
+
+        if (context != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("multi", "context", context));
+        }
+
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+        final String[] localVarAccepts = {
+            
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        localVarHeaderParams.put("Content-Type", localVarContentType);
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(localVarPath, "PUT", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call testQueryParameterCollectionFormatValidateBeforeCall(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback _callback) throws ApiException {
+        
+        // verify the required parameter 'pipe' is set
+        if (pipe == null) {
+            throw new ApiException("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat(Async)");
+        }
+        
+        // verify the required parameter 'ioutil' is set
+        if (ioutil == null) {
+            throw new ApiException("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat(Async)");
+        }
+        
+        // verify the required parameter 'http' is set
+        if (http == null) {
+            throw new ApiException("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat(Async)");
+        }
+        
+        // verify the required parameter 'url' is set
+        if (url == null) {
+            throw new ApiException("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat(Async)");
+        }
+        
+        // verify the required parameter 'context' is set
+        if (context == null) {
+            throw new ApiException("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat(Async)");
+        }
+        
+
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatCall(pipe, ioutil, http, url, context, _callback);
+        return localVarCall;
+
+    }
+
+    /**
+     * 
+     * To test the collection format in query parameters
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+     */
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+        testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+    }
+
+    /**
+     * 
+     * To test the collection format in query parameters
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @return ApiResponse&lt;Void&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, null);
+        return localVarApiClient.execute(localVarCall);
+    }
+
+    /**
+     *  (asynchronously)
+     * To test the collection format in query parameters
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Success </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testQueryParameterCollectionFormatAsync(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, final ApiCallback<Void> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testQueryParameterCollectionFormatValidateBeforeCall(pipe, ioutil, http, url, context, _callback);
+        localVarApiClient.executeAsync(localVarCall, _callback);
+        return localVarCall;
+    }
 }

--- a/samples/client/petstore/java/rest-assured/docs/FakeApi.md
+++ b/samples/client/petstore/java/rest-assured/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 <a name="createXmlItem"></a>
@@ -586,5 +587,55 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: application/x-www-form-urlencoded
+ - **Accept**: Not defined
+
+<a name="testQueryParameterCollectionFormat"></a>
+# **testQueryParameterCollectionFormat**
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+```java
+// Import classes:
+//import org.openapitools.client.ApiClient;
+//import io.restassured.builder.RequestSpecBuilder;
+//import io.restassured.filter.log.ErrorLoggingFilter;
+
+FakeApi api = ApiClient.api(ApiClient.Config.apiConfig().withReqSpecSupplier(
+                () -> new RequestSpecBuilder()
+                        .setBaseUri("http://petstore.swagger.io:80/v2"))).fake();
+
+api.testQueryParameterCollectionFormat()
+    .pipeQuery(pipe)
+    .ioutilQuery(ioutil)
+    .httpQuery(http)
+    .urlQuery(url)
+    .contextQuery(context).execute(r -> r.prettyPeek());
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  | [default to new ArrayList&lt;String&gt;()]
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  | [default to new ArrayList&lt;String&gt;()]
+ **http** | [**List&lt;String&gt;**](String.md)|  | [default to new ArrayList&lt;String&gt;()]
+ **url** | [**List&lt;String&gt;**](String.md)|  | [default to new ArrayList&lt;String&gt;()]
+ **context** | [**List&lt;String&gt;**](String.md)|  | [default to new ArrayList&lt;String&gt;()]
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
  - **Accept**: Not defined
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -199,6 +199,16 @@ public class FakeApi {
         return new TestJsonFormDataOper(createReqSpec());
     }
 
+    @ApiOperation(value = "",
+            notes = "To test the collection format in query parameters",
+            nickname = "testQueryParameterCollectionFormat",
+            tags = { "fake" })
+    @ApiResponses(value = { 
+            @ApiResponse(code = 200, message = "Success")  })
+    public TestQueryParameterCollectionFormatOper testQueryParameterCollectionFormat() {
+        return new TestQueryParameterCollectionFormatOper(createReqSpec());
+    }
+
     /**
      * Customize request specification
      * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
@@ -1371,6 +1381,115 @@ public class FakeApi {
          * @return operation
          */
         public TestJsonFormDataOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
+            respSpecCustomizer.accept(respSpec);
+            return this;
+        }
+    }
+    /**
+     * 
+     * To test the collection format in query parameters
+     *
+     * @see #pipeQuery  (required)
+     * @see #ioutilQuery  (required)
+     * @see #httpQuery  (required)
+     * @see #urlQuery  (required)
+     * @see #contextQuery  (required)
+     */
+    public static class TestQueryParameterCollectionFormatOper {
+
+        public static final Method REQ_METHOD = PUT;
+        public static final String REQ_URI = "/fake/test-query-paramters";
+
+        private RequestSpecBuilder reqSpec;
+        private ResponseSpecBuilder respSpec;
+
+        public TestQueryParameterCollectionFormatOper(RequestSpecBuilder reqSpec) {
+            this.reqSpec = reqSpec;
+            reqSpec.setAccept("application/json");
+            this.respSpec = new ResponseSpecBuilder();
+        }
+
+        /**
+         * PUT /fake/test-query-paramters
+         * @param handler handler
+         * @param <T> type
+         * @return type
+         */
+        public <T> T execute(Function<Response, T> handler) {
+            return handler.apply(RestAssured.given().spec(reqSpec.build()).expect().spec(respSpec.build()).when().request(REQ_METHOD, REQ_URI));
+        }
+
+        public static final String PIPE_QUERY = "pipe";
+
+        /**
+         * @param pipe (List&lt;String&gt;)  (required)
+         * @return operation
+         */
+        public TestQueryParameterCollectionFormatOper pipeQuery(Object... pipe) {
+            reqSpec.addQueryParam(PIPE_QUERY, pipe);
+            return this;
+        }
+
+        public static final String IOUTIL_QUERY = "ioutil";
+
+        /**
+         * @param ioutil (List&lt;String&gt;)  (required)
+         * @return operation
+         */
+        public TestQueryParameterCollectionFormatOper ioutilQuery(Object... ioutil) {
+            reqSpec.addQueryParam(IOUTIL_QUERY, ioutil);
+            return this;
+        }
+
+        public static final String HTTP_QUERY = "http";
+
+        /**
+         * @param http (List&lt;String&gt;)  (required)
+         * @return operation
+         */
+        public TestQueryParameterCollectionFormatOper httpQuery(Object... http) {
+            reqSpec.addQueryParam(HTTP_QUERY, http);
+            return this;
+        }
+
+        public static final String URL_QUERY = "url";
+
+        /**
+         * @param url (List&lt;String&gt;)  (required)
+         * @return operation
+         */
+        public TestQueryParameterCollectionFormatOper urlQuery(Object... url) {
+            reqSpec.addQueryParam(URL_QUERY, url);
+            return this;
+        }
+
+        public static final String CONTEXT_QUERY = "context";
+
+        /**
+         * @param context (List&lt;String&gt;)  (required)
+         * @return operation
+         */
+        public TestQueryParameterCollectionFormatOper contextQuery(Object... context) {
+            reqSpec.addQueryParam(CONTEXT_QUERY, context);
+            return this;
+        }
+
+        /**
+         * Customize request specification
+         * @param reqSpecCustomizer consumer to modify the RequestSpecBuilder
+         * @return operation
+         */
+        public TestQueryParameterCollectionFormatOper reqSpec(Consumer<RequestSpecBuilder> reqSpecCustomizer) {
+            reqSpecCustomizer.accept(reqSpec);
+            return this;
+        }
+
+        /**
+         * Customize response specification
+         * @param respSpecCustomizer consumer to modify the ResponseSpecBuilder
+         * @return operation
+         */
+        public TestQueryParameterCollectionFormatOper respSpec(Consumer<ResponseSpecBuilder> respSpecCustomizer) {
             respSpecCustomizer.accept(respSpec);
             return this;
         }

--- a/samples/client/petstore/java/resteasy/docs/FakeApi.md
+++ b/samples/client/petstore/java/resteasy/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -657,4 +657,73 @@ if (param2 != null)
 
     apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
   }
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @throws ApiException if fails to make API call
+   */
+  public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws ApiException {
+    Object localVarPostBody = new Object();
+    
+    // verify the required parameter 'pipe' is set
+    if (pipe == null) {
+      throw new ApiException(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'ioutil' is set
+    if (ioutil == null) {
+      throw new ApiException(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'http' is set
+    if (http == null) {
+      throw new ApiException(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'url' is set
+    if (url == null) {
+      throw new ApiException(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // verify the required parameter 'context' is set
+    if (context == null) {
+      throw new ApiException(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+    }
+    
+    // create path and map variables
+    String localVarPath = "/fake/test-query-paramters".replaceAll("\\{format\\}","json");
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "pipe", pipe));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("space", "http", http));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "url", url));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "context", context));
+
+    
+    
+    final String[] localVarAccepts = {
+      
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+
+    apiClient.invokeAPI(localVarPath, "PUT", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);
+  }
 }

--- a/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -589,4 +589,65 @@ public class FakeApi {
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
         apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
+    /**
+     * 
+     * To test the collection format in query parameters
+     * <p><b>200</b> - Success
+     * @param pipe The pipe parameter
+     * @param ioutil The ioutil parameter
+     * @param http The http parameter
+     * @param url The url parameter
+     * @param context The context parameter
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws RestClientException {
+        Object postBody = null;
+        
+        // verify the required parameter 'pipe' is set
+        if (pipe == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'ioutil' is set
+        if (ioutil == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'http' is set
+        if (http == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'url' is set
+        if (url == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'context' is set
+        if (context == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+        }
+        
+        String path = apiClient.expandPath("/fake/test-query-paramters", Collections.<String, Object>emptyMap());
+
+        final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
+        final HttpHeaders headerParams = new HttpHeaders();
+        final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
+
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "pipe", pipe));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", ioutil));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("space".toUpperCase(Locale.ROOT)), "http", http));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
+
+        final String[] accepts = { };
+        final List<MediaType> accept = apiClient.selectHeaderAccept(accepts);
+        final String[] contentTypes = { };
+        final MediaType contentType = apiClient.selectHeaderContentType(contentTypes);
+
+        String[] authNames = new String[] {  };
+
+        ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
+        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    }
 }

--- a/samples/client/petstore/java/resttemplate/docs/FakeApi.md
+++ b/samples/client/petstore/java/resttemplate/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -589,4 +589,65 @@ public class FakeApi {
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
         apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
+    /**
+     * 
+     * To test the collection format in query parameters
+     * <p><b>200</b> - Success
+     * @param pipe The pipe parameter
+     * @param ioutil The ioutil parameter
+     * @param http The http parameter
+     * @param url The url parameter
+     * @param context The context parameter
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws RestClientException {
+        Object postBody = null;
+        
+        // verify the required parameter 'pipe' is set
+        if (pipe == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'ioutil' is set
+        if (ioutil == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'http' is set
+        if (http == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'url' is set
+        if (url == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'context' is set
+        if (context == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+        }
+        
+        String path = apiClient.expandPath("/fake/test-query-paramters", Collections.<String, Object>emptyMap());
+
+        final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
+        final HttpHeaders headerParams = new HttpHeaders();
+        final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
+
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "pipe", pipe));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", ioutil));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("space".toUpperCase(Locale.ROOT)), "http", http));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
+
+        final String[] accepts = { };
+        final List<MediaType> accept = apiClient.selectHeaderAccept(accepts);
+        final String[] contentTypes = { };
+        final MediaType contentType = apiClient.selectHeaderContentType(contentTypes);
+
+        String[] authNames = new String[] {  };
+
+        ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
+        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    }
 }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/CollectionFormats.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/CollectionFormats.java
@@ -35,6 +35,10 @@ public class CollectionFormats {
         
     }
     
+    public static class SPACEParams extends SSVParams {
+
+    }
+
     public static class SSVParams extends CSVParams {
         
         public SSVParams() {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -394,4 +394,36 @@ public interface FakeApi {
   void testJsonFormData(
     @retrofit.http.Field("param") String param, @retrofit.http.Field("param2") String param2, Callback<Void> cb
   );
+  /**
+   * 
+   * Sync method
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @return Void
+   */
+  
+  @PUT("/fake/test-query-paramters")
+  Void testQueryParameterCollectionFormat(
+    @retrofit.http.Query("pipe") CSVParams pipe, @retrofit.http.Query("ioutil") CSVParams ioutil, @retrofit.http.Query("http") SPACEParams http, @retrofit.http.Query("url") CSVParams url, @retrofit.http.Query("context") List<String> context
+  );
+
+  /**
+   * 
+   * Async method
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @param cb callback method
+   */
+  
+  @PUT("/fake/test-query-paramters")
+  void testQueryParameterCollectionFormat(
+    @retrofit.http.Query("pipe") CSVParams pipe, @retrofit.http.Query("ioutil") CSVParams ioutil, @retrofit.http.Query("http") SPACEParams http, @retrofit.http.Query("url") CSVParams url, @retrofit.http.Query("context") List<String> context, Callback<Void> cb
+  );
 }

--- a/samples/client/petstore/java/retrofit2-play24/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/CollectionFormats.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/CollectionFormats.java
@@ -35,6 +35,10 @@ public class CollectionFormats {
 
     }
 
+    public static class SPACEParams extends SSVParams {
+
+    }
+
     public static class SSVParams extends CSVParams {
 
         public SSVParams() {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -218,4 +218,19 @@ public interface FakeApi {
     @retrofit2.http.Field("param") String param, @retrofit2.http.Field("param2") String param2
   );
 
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @return Call&lt;Void&gt;
+   */
+  @PUT("fake/test-query-paramters")
+  F.Promise<Response<Void>> testQueryParameterCollectionFormat(
+    @retrofit2.http.Query("pipe") CSVParams pipe, @retrofit2.http.Query("ioutil") CSVParams ioutil, @retrofit2.http.Query("http") SPACEParams http, @retrofit2.http.Query("url") CSVParams url, @retrofit2.http.Query("context") List<String> context
+  );
+
 }

--- a/samples/client/petstore/java/retrofit2-play25/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/CollectionFormats.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/CollectionFormats.java
@@ -35,6 +35,10 @@ public class CollectionFormats {
 
     }
 
+    public static class SPACEParams extends SSVParams {
+
+    }
+
     public static class SSVParams extends CSVParams {
 
         public SSVParams() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -218,4 +218,19 @@ public interface FakeApi {
     @retrofit2.http.Field("param") String param, @retrofit2.http.Field("param2") String param2
   );
 
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @return Call&lt;Void&gt;
+   */
+  @PUT("fake/test-query-paramters")
+  CompletionStage<Response<Void>> testQueryParameterCollectionFormat(
+    @retrofit2.http.Query("pipe") CSVParams pipe, @retrofit2.http.Query("ioutil") CSVParams ioutil, @retrofit2.http.Query("http") SPACEParams http, @retrofit2.http.Query("url") CSVParams url, @retrofit2.http.Query("context") List<String> context
+  );
+
 }

--- a/samples/client/petstore/java/retrofit2-play26/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/CollectionFormats.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/CollectionFormats.java
@@ -35,6 +35,10 @@ public class CollectionFormats {
 
     }
 
+    public static class SPACEParams extends SSVParams {
+
+    }
+
     public static class SSVParams extends CSVParams {
 
         public SSVParams() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -218,4 +218,19 @@ public interface FakeApi {
     @retrofit2.http.Field("param") String param, @retrofit2.http.Field("param2") String param2
   );
 
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @return Call&lt;Void&gt;
+   */
+  @PUT("fake/test-query-paramters")
+  CompletionStage<Response<Void>> testQueryParameterCollectionFormat(
+    @retrofit2.http.Query("pipe") CSVParams pipe, @retrofit2.http.Query("ioutil") CSVParams ioutil, @retrofit2.http.Query("http") SPACEParams http, @retrofit2.http.Query("url") CSVParams url, @retrofit2.http.Query("context") List<String> context
+  );
+
 }

--- a/samples/client/petstore/java/retrofit2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/CollectionFormats.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/CollectionFormats.java
@@ -35,6 +35,10 @@ public class CollectionFormats {
 
     }
 
+    public static class SPACEParams extends SSVParams {
+
+    }
+
     public static class SSVParams extends CSVParams {
 
         public SSVParams() {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -213,4 +213,19 @@ public interface FakeApi {
     @retrofit2.http.Field("param") String param, @retrofit2.http.Field("param2") String param2
   );
 
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @return Call&lt;Void&gt;
+   */
+  @PUT("fake/test-query-paramters")
+  Call<Void> testQueryParameterCollectionFormat(
+    @retrofit2.http.Query("pipe") CSVParams pipe, @retrofit2.http.Query("ioutil") CSVParams ioutil, @retrofit2.http.Query("http") SPACEParams http, @retrofit2.http.Query("url") CSVParams url, @retrofit2.http.Query("context") List<String> context
+  );
+
 }

--- a/samples/client/petstore/java/retrofit2rx/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/CollectionFormats.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/CollectionFormats.java
@@ -35,6 +35,10 @@ public class CollectionFormats {
 
     }
 
+    public static class SPACEParams extends SSVParams {
+
+    }
+
     public static class SSVParams extends CSVParams {
 
         public SSVParams() {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -213,4 +213,19 @@ public interface FakeApi {
     @retrofit2.http.Field("param") String param, @retrofit2.http.Field("param2") String param2
   );
 
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @return Observable&lt;Void&gt;
+   */
+  @PUT("fake/test-query-paramters")
+  Observable<Void> testQueryParameterCollectionFormat(
+    @retrofit2.http.Query("pipe") CSVParams pipe, @retrofit2.http.Query("ioutil") CSVParams ioutil, @retrofit2.http.Query("http") SPACEParams http, @retrofit2.http.Query("url") CSVParams url, @retrofit2.http.Query("context") List<String> context
+  );
+
 }

--- a/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/CollectionFormats.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/CollectionFormats.java
@@ -35,6 +35,10 @@ public class CollectionFormats {
 
     }
 
+    public static class SPACEParams extends SSVParams {
+
+    }
+
     public static class SSVParams extends CSVParams {
 
         public SSVParams() {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -214,4 +214,19 @@ public interface FakeApi {
     @retrofit2.http.Field("param") String param, @retrofit2.http.Field("param2") String param2
   );
 
+  /**
+   * 
+   * To test the collection format in query parameters
+   * @param pipe  (required)
+   * @param ioutil  (required)
+   * @param http  (required)
+   * @param url  (required)
+   * @param context  (required)
+   * @return Completable
+   */
+  @PUT("fake/test-query-paramters")
+  Completable testQueryParameterCollectionFormat(
+    @retrofit2.http.Query("pipe") CSVParams pipe, @retrofit2.http.Query("ioutil") CSVParams ioutil, @retrofit2.http.Query("http") SPACEParams http, @retrofit2.http.Query("url") CSVParams url, @retrofit2.http.Query("context") List<String> context
+  );
+
 }

--- a/samples/client/petstore/java/vertx/docs/FakeApi.md
+++ b/samples/client/petstore/java/vertx/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -43,4 +43,6 @@ public interface FakeApi {
 
     void testJsonFormData(String param, String param2, Handler<AsyncResult<Void>> handler);
 
+    void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Handler<AsyncResult<Void>> handler);
+
 }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/FakeApiImpl.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/FakeApiImpl.java
@@ -561,4 +561,71 @@ if (param2 != null) localVarFormParams.put("param2", param2);
 
         apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarBody, localVarHeaderParams, localVarFormParams, localVarAccepts, localVarContentTypes, localVarAuthNames, null, resultHandler);
     }
+    /**
+     * 
+     * To test the collection format in query parameters
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @param resultHandler Asynchronous result handler
+     */
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Handler<AsyncResult<Void>> resultHandler) {
+        Object localVarBody = null;
+        
+        // verify the required parameter 'pipe' is set
+        if (pipe == null) {
+            resultHandler.handle(ApiException.fail(400, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat"));
+            return;
+        }
+        
+        // verify the required parameter 'ioutil' is set
+        if (ioutil == null) {
+            resultHandler.handle(ApiException.fail(400, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat"));
+            return;
+        }
+        
+        // verify the required parameter 'http' is set
+        if (http == null) {
+            resultHandler.handle(ApiException.fail(400, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat"));
+            return;
+        }
+        
+        // verify the required parameter 'url' is set
+        if (url == null) {
+            resultHandler.handle(ApiException.fail(400, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat"));
+            return;
+        }
+        
+        // verify the required parameter 'context' is set
+        if (context == null) {
+            resultHandler.handle(ApiException.fail(400, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat"));
+            return;
+        }
+        
+        // create path and map variables
+        String localVarPath = "/fake/test-query-paramters";
+
+        // query params
+        List<Pair> localVarQueryParams = new ArrayList<>();
+        localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "pipe", pipe));
+        localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "ioutil", ioutil));
+        localVarQueryParams.addAll(apiClient.parameterToPairs("space", "http", http));
+        localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "url", url));
+        localVarQueryParams.addAll(apiClient.parameterToPairs("multi", "context", context));
+
+        // header params
+        MultiMap localVarHeaderParams = MultiMap.caseInsensitiveMultiMap();
+        
+        // form params
+        // TODO: sending files within multipart/form-data is not supported yet (because of vertx web-client)
+        Map<String, Object> localVarFormParams = new HashMap<>();
+        
+        String[] localVarAccepts = {  };
+        String[] localVarContentTypes = {  };
+        String[] localVarAuthNames = new String[] {  };
+
+        apiClient.invokeAPI(localVarPath, "PUT", localVarQueryParams, localVarBody, localVarHeaderParams, localVarFormParams, localVarAccepts, localVarContentTypes, localVarAuthNames, null, resultHandler);
+    }
 }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/rxjava/FakeApi.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/api/rxjava/FakeApi.java
@@ -356,6 +356,35 @@ public class FakeApi {
             delegate.testJsonFormData(param, param2, fut);
         }));
     }
+    /**
+     * 
+     * To test the collection format in query parameters
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @param resultHandler Asynchronous result handler
+     */
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, Handler<AsyncResult<Void>> resultHandler) {
+        delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, resultHandler);
+    }
+
+    /**
+     * 
+     * To test the collection format in query parameters
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @return Asynchronous result handler (RxJava Single)
+     */
+    public Single<Void> rxTestQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) {
+        return Single.create(new io.vertx.rx.java.SingleOnSubscribeAdapter<>(fut -> {
+            delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, fut);
+        }));
+    }
 
     public static FakeApi newInstance(org.openapitools.client.api.FakeApi arg) {
         return arg != null ? new FakeApi(arg) : null;

--- a/samples/client/petstore/java/webclient/docs/FakeApi.md
+++ b/samples/client/petstore/java/webclient/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -911,4 +912,76 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | successful operation |  -  |
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://petstore.swagger.io:80/v2");
+
+        FakeApi apiInstance = new FakeApi(defaultClient);
+        List<String> pipe = Arrays.asList(); // List<String> | 
+        List<String> ioutil = Arrays.asList(); // List<String> | 
+        List<String> http = Arrays.asList(); // List<String> | 
+        List<String> url = Arrays.asList(); // List<String> | 
+        List<String> context = Arrays.asList(); // List<String> | 
+        try {
+            apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling FakeApi#testQueryParameterCollectionFormat");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**List&lt;String&gt;**](String.md)|  |
+ **ioutil** | [**List&lt;String&gt;**](String.md)|  |
+ **http** | [**List&lt;String&gt;**](String.md)|  |
+ **url** | [**List&lt;String&gt;**](String.md)|  |
+ **context** | [**List&lt;String&gt;**](String.md)|  |
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Success |  -  |
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -587,4 +587,65 @@ public class FakeApi {
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
         return apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
+    /**
+     * 
+     * To test the collection format in query parameters
+     * <p><b>200</b> - Success
+     * @param pipe The pipe parameter
+     * @param ioutil The ioutil parameter
+     * @param http The http parameter
+     * @param url The url parameter
+     * @param context The context parameter
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public Mono<Void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws RestClientException {
+        Object postBody = null;
+        
+        // verify the required parameter 'pipe' is set
+        if (pipe == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'ioutil' is set
+        if (ioutil == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'http' is set
+        if (http == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'url' is set
+        if (url == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+        }
+        
+        // verify the required parameter 'context' is set
+        if (context == null) {
+            throw new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+        }
+        
+        String path = UriComponentsBuilder.fromPath("/fake/test-query-paramters").build().toUriString();
+        
+        final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
+        final HttpHeaders headerParams = new HttpHeaders();
+        final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
+        
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "pipe", pipe));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "ioutil", ioutil));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("space".toUpperCase(Locale.ROOT)), "http", http));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "url", url));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
+
+        final String[] accepts = { };
+        final List<MediaType> accept = apiClient.selectHeaderAccept(accepts);
+        final String[] contentTypes = { };
+        final MediaType contentType = apiClient.selectHeaderContentType(contentTypes);
+
+        String[] authNames = new String[] {  };
+
+        ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    }
 }

--- a/samples/client/petstore/javascript-es6/README.md
+++ b/samples/client/petstore/javascript-es6/README.md
@@ -134,6 +134,7 @@ Class | Method | HTTP request | Description
 *OpenApiPetstore.FakeApi* | [**testGroupParameters**](docs/FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *OpenApiPetstore.FakeApi* | [**testInlineAdditionalProperties**](docs/FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *OpenApiPetstore.FakeApi* | [**testJsonFormData**](docs/FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+*OpenApiPetstore.FakeApi* | [**testQueryParameterCollectionFormat**](docs/FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 *OpenApiPetstore.FakeClassnameTags123Api* | [**testClassname**](docs/FakeClassnameTags123Api.md#testClassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *OpenApiPetstore.PetApi* | [**addPet**](docs/PetApi.md#addPet) | **POST** /pet | Add a new pet to the store
 *OpenApiPetstore.PetApi* | [**deletePet**](docs/PetApi.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/javascript-es6/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-es6/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -669,5 +670,58 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```javascript
+import OpenApiPetstore from 'open_api_petstore';
+
+let apiInstance = new OpenApiPetstore.FakeApi();
+let pipe = ["null"]; // [String] | 
+let ioutil = ["null"]; // [String] | 
+let http = ["null"]; // [String] | 
+let url = ["null"]; // [String] | 
+let context = ["null"]; // [String] | 
+apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, (error, data, response) => {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+});
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**[String]**](String.md)|  | 
+ **ioutil** | [**[String]**](String.md)|  | 
+ **http** | [**[String]**](String.md)|  | 
+ **url** | [**[String]**](String.md)|  | 
+ **context** | [**[String]**](String.md)|  | 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 

--- a/samples/client/petstore/javascript-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-es6/src/api/FakeApi.js
@@ -647,5 +647,70 @@ export default class FakeApi {
       );
     }
 
+    /**
+     * Callback function to receive the result of the testQueryParameterCollectionFormat operation.
+     * @callback module:api/FakeApi~testQueryParameterCollectionFormatCallback
+     * @param {String} error Error message, if any.
+     * @param data This operation does not return a value.
+     * @param {String} response The complete HTTP response.
+     */
+
+    /**
+     * To test the collection format in query parameters
+     * @param {Array.<String>} pipe 
+     * @param {Array.<String>} ioutil 
+     * @param {Array.<String>} http 
+     * @param {Array.<String>} url 
+     * @param {Array.<String>} context 
+     * @param {module:api/FakeApi~testQueryParameterCollectionFormatCallback} callback The callback function, accepting three arguments: error, data, response
+     */
+    testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, callback) {
+      let postBody = null;
+      // verify the required parameter 'pipe' is set
+      if (pipe === undefined || pipe === null) {
+        throw new Error("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'ioutil' is set
+      if (ioutil === undefined || ioutil === null) {
+        throw new Error("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'http' is set
+      if (http === undefined || http === null) {
+        throw new Error("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'url' is set
+      if (url === undefined || url === null) {
+        throw new Error("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'context' is set
+      if (context === undefined || context === null) {
+        throw new Error("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+      }
+
+      let pathParams = {
+      };
+      let queryParams = {
+        'pipe': this.apiClient.buildCollectionParam(pipe, 'csv'),
+        'ioutil': this.apiClient.buildCollectionParam(ioutil, 'csv'),
+        'http': this.apiClient.buildCollectionParam(http, 'space'),
+        'url': this.apiClient.buildCollectionParam(url, 'csv'),
+        'context': this.apiClient.buildCollectionParam(context, 'multi')
+      };
+      let headerParams = {
+      };
+      let formParams = {
+      };
+
+      let authNames = [];
+      let contentTypes = [];
+      let accepts = [];
+      let returnType = null;
+      return this.apiClient.callApi(
+        '/fake/test-query-paramters', 'PUT',
+        pathParams, queryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType, null, callback
+      );
+    }
+
 
 }

--- a/samples/client/petstore/javascript-promise-es6/README.md
+++ b/samples/client/petstore/javascript-promise-es6/README.md
@@ -132,6 +132,7 @@ Class | Method | HTTP request | Description
 *OpenApiPetstore.FakeApi* | [**testGroupParameters**](docs/FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *OpenApiPetstore.FakeApi* | [**testInlineAdditionalProperties**](docs/FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *OpenApiPetstore.FakeApi* | [**testJsonFormData**](docs/FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+*OpenApiPetstore.FakeApi* | [**testQueryParameterCollectionFormat**](docs/FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 *OpenApiPetstore.FakeClassnameTags123Api* | [**testClassname**](docs/FakeClassnameTags123Api.md#testClassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *OpenApiPetstore.PetApi* | [**addPet**](docs/PetApi.md#addPet) | **POST** /pet | Add a new pet to the store
 *OpenApiPetstore.PetApi* | [**deletePet**](docs/PetApi.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/javascript-promise-es6/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -656,5 +657,57 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```javascript
+import OpenApiPetstore from 'open_api_petstore';
+
+let apiInstance = new OpenApiPetstore.FakeApi();
+let pipe = ["null"]; // [String] | 
+let ioutil = ["null"]; // [String] | 
+let http = ["null"]; // [String] | 
+let url = ["null"]; // [String] | 
+let context = ["null"]; // [String] | 
+apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context).then(() => {
+  console.log('API called successfully.');
+}, (error) => {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**[String]**](String.md)|  | 
+ **ioutil** | [**[String]**](String.md)|  | 
+ **http** | [**[String]**](String.md)|  | 
+ **url** | [**[String]**](String.md)|  | 
+ **context** | [**[String]**](String.md)|  | 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 

--- a/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-promise-es6/src/api/FakeApi.js
@@ -746,4 +746,78 @@ export default class FakeApi {
     }
 
 
+    /**
+     * To test the collection format in query parameters
+     * @param {Array.<String>} pipe 
+     * @param {Array.<String>} ioutil 
+     * @param {Array.<String>} http 
+     * @param {Array.<String>} url 
+     * @param {Array.<String>} context 
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context) {
+      let postBody = null;
+      // verify the required parameter 'pipe' is set
+      if (pipe === undefined || pipe === null) {
+        throw new Error("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'ioutil' is set
+      if (ioutil === undefined || ioutil === null) {
+        throw new Error("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'http' is set
+      if (http === undefined || http === null) {
+        throw new Error("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'url' is set
+      if (url === undefined || url === null) {
+        throw new Error("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'context' is set
+      if (context === undefined || context === null) {
+        throw new Error("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+      }
+
+      let pathParams = {
+      };
+      let queryParams = {
+        'pipe': this.apiClient.buildCollectionParam(pipe, 'csv'),
+        'ioutil': this.apiClient.buildCollectionParam(ioutil, 'csv'),
+        'http': this.apiClient.buildCollectionParam(http, 'space'),
+        'url': this.apiClient.buildCollectionParam(url, 'csv'),
+        'context': this.apiClient.buildCollectionParam(context, 'multi')
+      };
+      let headerParams = {
+      };
+      let formParams = {
+      };
+
+      let authNames = [];
+      let contentTypes = [];
+      let accepts = [];
+      let returnType = null;
+      return this.apiClient.callApi(
+        '/fake/test-query-paramters', 'PUT',
+        pathParams, queryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType, null
+      );
+    }
+
+    /**
+     * To test the collection format in query parameters
+     * @param {Array.<String>} pipe 
+     * @param {Array.<String>} ioutil 
+     * @param {Array.<String>} http 
+     * @param {Array.<String>} url 
+     * @param {Array.<String>} context 
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    testQueryParameterCollectionFormat(pipe, ioutil, http, url, context) {
+      return this.testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
+
+
 }

--- a/samples/client/petstore/javascript-promise/README.md
+++ b/samples/client/petstore/javascript-promise/README.md
@@ -120,6 +120,7 @@ Class | Method | HTTP request | Description
 *OpenApiPetstore.FakeApi* | [**testGroupParameters**](docs/FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *OpenApiPetstore.FakeApi* | [**testInlineAdditionalProperties**](docs/FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *OpenApiPetstore.FakeApi* | [**testJsonFormData**](docs/FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+*OpenApiPetstore.FakeApi* | [**testQueryParameterCollectionFormat**](docs/FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 *OpenApiPetstore.FakeClassnameTags123Api* | [**testClassname**](docs/FakeClassnameTags123Api.md#testClassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *OpenApiPetstore.PetApi* | [**addPet**](docs/PetApi.md#addPet) | **POST** /pet | Add a new pet to the store
 *OpenApiPetstore.PetApi* | [**deletePet**](docs/PetApi.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/javascript-promise/docs/FakeApi.md
+++ b/samples/client/petstore/javascript-promise/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -669,5 +670,58 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```javascript
+var OpenApiPetstore = require('open_api_petstore');
+
+var apiInstance = new OpenApiPetstore.FakeApi();
+var pipe = ["null"]; // [String] | 
+var ioutil = ["null"]; // [String] | 
+var http = ["null"]; // [String] | 
+var url = ["null"]; // [String] | 
+var context = ["null"]; // [String] | 
+apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context).then(function() {
+  console.log('API called successfully.');
+}, function(error) {
+  console.error(error);
+});
+
+```
+
+### Parameters
+
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**[String]**](String.md)|  | 
+ **ioutil** | [**[String]**](String.md)|  | 
+ **http** | [**[String]**](String.md)|  | 
+ **url** | [**[String]**](String.md)|  | 
+ **context** | [**[String]**](String.md)|  | 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 

--- a/samples/client/petstore/javascript-promise/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript-promise/src/api/FakeApi.js
@@ -782,6 +782,97 @@
           return response_and_data.data;
         });
     }
+
+
+    /**
+     * To test the collection format in query parameters
+     * @param {Array.<String>} pipe 
+     * @param {Array.<String>} ioutil 
+     * @param {Array.<String>} http 
+     * @param {Array.<String>} url 
+     * @param {Array.<String>} context 
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing HTTP response
+     */
+    this.testQueryParameterCollectionFormatWithHttpInfo = function(pipe, ioutil, http, url, context) {
+      var postBody = null;
+      // verify the required parameter 'pipe' is set
+      if (pipe === undefined || pipe === null) {
+        throw new Error("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'ioutil' is set
+      if (ioutil === undefined || ioutil === null) {
+        throw new Error("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'http' is set
+      if (http === undefined || http === null) {
+        throw new Error("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'url' is set
+      if (url === undefined || url === null) {
+        throw new Error("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'context' is set
+      if (context === undefined || context === null) {
+        throw new Error("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+      }
+
+      var pathParams = {
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+        'pipe': {
+          value: pipe,
+          collectionFormat: 'csv'
+        },
+        'ioutil': {
+          value: ioutil,
+          collectionFormat: 'csv'
+        },
+        'http': {
+          value: http,
+          collectionFormat: 'space'
+        },
+        'url': {
+          value: url,
+          collectionFormat: 'csv'
+        },
+        'context': {
+          value: context,
+          collectionFormat: 'multi'
+        },
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = [];
+      var contentTypes = [];
+      var accepts = [];
+      var returnType = null;
+      return this.apiClient.callApi(
+        '/fake/test-query-paramters', 'PUT',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType, null
+      );
+    }
+
+    /**
+     * To test the collection format in query parameters
+     * @param {Array.<String>} pipe 
+     * @param {Array.<String>} ioutil 
+     * @param {Array.<String>} http 
+     * @param {Array.<String>} url 
+     * @param {Array.<String>} context 
+     * @return {Promise} a {@link https://www.promisejs.org/|Promise}
+     */
+    this.testQueryParameterCollectionFormat = function(pipe, ioutil, http, url, context) {
+      return this.testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context)
+        .then(function(response_and_data) {
+          return response_and_data.data;
+        });
+    }
   };
 
   return exports;

--- a/samples/client/petstore/javascript/README.md
+++ b/samples/client/petstore/javascript/README.md
@@ -123,6 +123,7 @@ Class | Method | HTTP request | Description
 *OpenApiPetstore.FakeApi* | [**testGroupParameters**](docs/FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *OpenApiPetstore.FakeApi* | [**testInlineAdditionalProperties**](docs/FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *OpenApiPetstore.FakeApi* | [**testJsonFormData**](docs/FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+*OpenApiPetstore.FakeApi* | [**testQueryParameterCollectionFormat**](docs/FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 *OpenApiPetstore.FakeClassnameTags123Api* | [**testClassname**](docs/FakeClassnameTags123Api.md#testClassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *OpenApiPetstore.PetApi* | [**addPet**](docs/PetApi.md#addPet) | **POST** /pet | Add a new pet to the store
 *OpenApiPetstore.PetApi* | [**deletePet**](docs/PetApi.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/javascript/docs/FakeApi.md
+++ b/samples/client/petstore/javascript/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -695,5 +696,60 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```javascript
+var OpenApiPetstore = require('open_api_petstore');
+
+var apiInstance = new OpenApiPetstore.FakeApi();
+var pipe = ["null"]; // [String] | 
+var ioutil = ["null"]; // [String] | 
+var http = ["null"]; // [String] | 
+var url = ["null"]; // [String] | 
+var context = ["null"]; // [String] | 
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+apiInstance.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, callback);
+```
+
+### Parameters
+
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**[String]**](String.md)|  | 
+ **ioutil** | [**[String]**](String.md)|  | 
+ **http** | [**[String]**](String.md)|  | 
+ **url** | [**[String]**](String.md)|  | 
+ **context** | [**[String]**](String.md)|  | 
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 

--- a/samples/client/petstore/javascript/src/api/FakeApi.js
+++ b/samples/client/petstore/javascript/src/api/FakeApi.js
@@ -684,6 +684,88 @@
         authNames, contentTypes, accepts, returnType, null, callback
       );
     }
+
+    /**
+     * Callback function to receive the result of the testQueryParameterCollectionFormat operation.
+     * @callback module:api/FakeApi~testQueryParameterCollectionFormatCallback
+     * @param {String} error Error message, if any.
+     * @param data This operation does not return a value.
+     * @param {String} response The complete HTTP response.
+     */
+
+    /**
+     * To test the collection format in query parameters
+     * @param {Array.<String>} pipe 
+     * @param {Array.<String>} ioutil 
+     * @param {Array.<String>} http 
+     * @param {Array.<String>} url 
+     * @param {Array.<String>} context 
+     * @param {module:api/FakeApi~testQueryParameterCollectionFormatCallback} callback The callback function, accepting three arguments: error, data, response
+     */
+    this.testQueryParameterCollectionFormat = function(pipe, ioutil, http, url, context, callback) {
+      var postBody = null;
+      // verify the required parameter 'pipe' is set
+      if (pipe === undefined || pipe === null) {
+        throw new Error("Missing the required parameter 'pipe' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'ioutil' is set
+      if (ioutil === undefined || ioutil === null) {
+        throw new Error("Missing the required parameter 'ioutil' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'http' is set
+      if (http === undefined || http === null) {
+        throw new Error("Missing the required parameter 'http' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'url' is set
+      if (url === undefined || url === null) {
+        throw new Error("Missing the required parameter 'url' when calling testQueryParameterCollectionFormat");
+      }
+      // verify the required parameter 'context' is set
+      if (context === undefined || context === null) {
+        throw new Error("Missing the required parameter 'context' when calling testQueryParameterCollectionFormat");
+      }
+
+      var pathParams = {
+      };
+      var queryParams = {
+      };
+      var collectionQueryParams = {
+        'pipe': {
+          value: pipe,
+          collectionFormat: 'csv'
+        },
+        'ioutil': {
+          value: ioutil,
+          collectionFormat: 'csv'
+        },
+        'http': {
+          value: http,
+          collectionFormat: 'space'
+        },
+        'url': {
+          value: url,
+          collectionFormat: 'csv'
+        },
+        'context': {
+          value: context,
+          collectionFormat: 'multi'
+        },
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = [];
+      var contentTypes = [];
+      var accepts = [];
+      var returnType = null;
+      return this.apiClient.callApi(
+        '/fake/test-query-paramters', 'PUT',
+        pathParams, queryParams, collectionQueryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType, null, callback
+      );
+    }
   };
 
   return exports;

--- a/samples/client/petstore/perl/README.md
+++ b/samples/client/petstore/perl/README.md
@@ -383,6 +383,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**test_group_parameters**](docs/FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**test_inline_additional_properties**](docs/FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**test_json_form_data**](docs/FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**test_query_parameter_collection_format**](docs/FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**test_classname**](docs/FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**add_pet**](docs/PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**delete_pet**](docs/PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/perl/docs/FakeApi.md
+++ b/samples/client/petstore/perl/docs/FakeApi.md
@@ -22,6 +22,7 @@ Method | HTTP request | Description
 [**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+[**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 
 
 # **create_xml_item**
@@ -663,6 +664,59 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: application/x-www-form-urlencoded
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_query_parameter_collection_format**
+> test_query_parameter_collection_format(pipe => $pipe, ioutil => $ioutil, http => $http, url => $url, context => $context)
+
+
+
+To test the collection format in query parameters
+
+### Example 
+```perl
+use Data::Dumper;
+use WWW::OpenAPIClient::FakeApi;
+my $api_instance = WWW::OpenAPIClient::FakeApi->new(
+);
+
+my $pipe = [("null")]; # ARRAY[string] | 
+my $ioutil = [("null")]; # ARRAY[string] | 
+my $http = [("null")]; # ARRAY[string] | 
+my $url = [("null")]; # ARRAY[string] | 
+my $context = [("null")]; # ARRAY[string] | 
+
+eval { 
+    $api_instance->test_query_parameter_collection_format(pipe => $pipe, ioutil => $ioutil, http => $http, url => $url, context => $context);
+};
+if ($@) {
+    warn "Exception when calling FakeApi->test_query_parameter_collection_format: $@\n";
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**ARRAY[string]**](string.md)|  | 
+ **ioutil** | [**ARRAY[string]**](string.md)|  | 
+ **http** | [**ARRAY[string]**](string.md)|  | 
+ **url** | [**ARRAY[string]**](string.md)|  | 
+ **context** | [**ARRAY[string]**](string.md)|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
  - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeApi.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/FakeApi.pm
@@ -1169,4 +1169,129 @@ sub test_json_form_data {
     return;
 }
 
+#
+# test_query_parameter_collection_format
+#
+# 
+# 
+# @param ARRAY[string] $pipe  (required)
+# @param ARRAY[string] $ioutil  (required)
+# @param ARRAY[string] $http  (required)
+# @param ARRAY[string] $url  (required)
+# @param ARRAY[string] $context  (required)
+{
+    my $params = {
+    'pipe' => {
+        data_type => 'ARRAY[string]',
+        description => '',
+        required => '1',
+    },
+    'ioutil' => {
+        data_type => 'ARRAY[string]',
+        description => '',
+        required => '1',
+    },
+    'http' => {
+        data_type => 'ARRAY[string]',
+        description => '',
+        required => '1',
+    },
+    'url' => {
+        data_type => 'ARRAY[string]',
+        description => '',
+        required => '1',
+    },
+    'context' => {
+        data_type => 'ARRAY[string]',
+        description => '',
+        required => '1',
+    },
+    };
+    __PACKAGE__->method_documentation->{ 'test_query_parameter_collection_format' } = { 
+        summary => '',
+        params => $params,
+        returns => undef,
+        };
+}
+# @return void
+#
+sub test_query_parameter_collection_format {
+    my ($self, %args) = @_;
+
+    # verify the required parameter 'pipe' is set
+    unless (exists $args{'pipe'}) {
+      croak("Missing the required parameter 'pipe' when calling test_query_parameter_collection_format");
+    }
+
+    # verify the required parameter 'ioutil' is set
+    unless (exists $args{'ioutil'}) {
+      croak("Missing the required parameter 'ioutil' when calling test_query_parameter_collection_format");
+    }
+
+    # verify the required parameter 'http' is set
+    unless (exists $args{'http'}) {
+      croak("Missing the required parameter 'http' when calling test_query_parameter_collection_format");
+    }
+
+    # verify the required parameter 'url' is set
+    unless (exists $args{'url'}) {
+      croak("Missing the required parameter 'url' when calling test_query_parameter_collection_format");
+    }
+
+    # verify the required parameter 'context' is set
+    unless (exists $args{'context'}) {
+      croak("Missing the required parameter 'context' when calling test_query_parameter_collection_format");
+    }
+
+    # parse inputs
+    my $_resource_path = '/fake/test-query-paramters';
+
+    my $_method = 'PUT';
+    my $query_params = {};
+    my $header_params = {};
+    my $form_params = {};
+
+    # 'Accept' and 'Content-Type' header
+    my $_header_accept = $self->{api_client}->select_header_accept();
+    if ($_header_accept) {
+        $header_params->{'Accept'} = $_header_accept;
+    }
+    $header_params->{'Content-Type'} = $self->{api_client}->select_header_content_type();
+
+    # query params
+    if ( exists $args{'pipe'}) {
+        $query_params->{'pipe'} = $self->{api_client}->to_query_value($args{'pipe'});
+    }
+
+    # query params
+    if ( exists $args{'ioutil'}) {
+        $query_params->{'ioutil'} = $self->{api_client}->to_query_value($args{'ioutil'});
+    }
+
+    # query params
+    if ( exists $args{'http'}) {
+        $query_params->{'http'} = $self->{api_client}->to_query_value($args{'http'});
+    }
+
+    # query params
+    if ( exists $args{'url'}) {
+        $query_params->{'url'} = $self->{api_client}->to_query_value($args{'url'});
+    }
+
+    # query params
+    if ( exists $args{'context'}) {
+        $query_params->{'context'} = $self->{api_client}->to_query_value($args{'context'});
+    }
+
+    my $_body_data;
+    # authentication setting, if any
+    my $auth_settings = [qw()];
+
+    # make the API Call
+    $self->{api_client}->call_api($_resource_path, $_method,
+                                           $query_params, $form_params,
+                                           $header_params, $_body_data, $auth_settings);
+    return;
+}
+
 1;

--- a/samples/client/petstore/php/OpenAPIClient-php/README.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/README.md
@@ -97,6 +97,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**testGroupParameters**](docs/Api/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**testInlineAdditionalProperties**](docs/Api/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**testJsonFormData**](docs/Api/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**testQueryParameterCollectionFormat**](docs/Api/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**testClassname**](docs/Api/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**addPet**](docs/Api/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**deletePet**](docs/Api/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -790,6 +791,69 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../../README.md#documentation-for-models)
+[[Back to README]](../../README.md)
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+$apiInstance = new OpenAPI\Client\Api\FakeApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client()
+);
+$pipe = array('pipe_example'); // string[] | 
+$ioutil = array('ioutil_example'); // string[] | 
+$http = array('http_example'); // string[] | 
+$url = array('url_example'); // string[] | 
+$context = array('context_example'); // string[] | 
+
+try {
+    $apiInstance->testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context);
+} catch (Exception $e) {
+    echo 'Exception when calling FakeApi->testQueryParameterCollectionFormat: ', $e->getMessage(), PHP_EOL;
+}
+?>
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**string[]**](../Model/string.md)|  |
+ **ioutil** | [**string[]**](../Model/string.md)|  |
+ **http** | [**string[]**](../Model/string.md)|  |
+ **url** | [**string[]**](../Model/string.md)|  |
+ **context** | [**string[]**](../Model/string.md)|  |
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints)

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -3514,6 +3514,297 @@ class FakeApi
     }
 
     /**
+     * Operation testQueryParameterCollectionFormat
+     *
+     * @param  string[] $pipe pipe (required)
+     * @param  string[] $ioutil ioutil (required)
+     * @param  string[] $http http (required)
+     * @param  string[] $url url (required)
+     * @param  string[] $context context (required)
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context)
+    {
+        $this->testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context);
+    }
+
+    /**
+     * Operation testQueryParameterCollectionFormatWithHttpInfo
+     *
+     * @param  string[] $pipe (required)
+     * @param  string[] $ioutil (required)
+     * @param  string[] $http (required)
+     * @param  string[] $url (required)
+     * @param  string[] $context (required)
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of null, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context)
+    {
+        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? $e->getResponse()->getBody()->getContents() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()
+                );
+            }
+
+            return [null, $statusCode, $response->getHeaders()];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation testQueryParameterCollectionFormatAsync
+     *
+     * 
+     *
+     * @param  string[] $pipe (required)
+     * @param  string[] $ioutil (required)
+     * @param  string[] $http (required)
+     * @param  string[] $url (required)
+     * @param  string[] $context (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function testQueryParameterCollectionFormatAsync($pipe, $ioutil, $http, $url, $context)
+    {
+        return $this->testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation testQueryParameterCollectionFormatAsyncWithHttpInfo
+     *
+     * 
+     *
+     * @param  string[] $pipe (required)
+     * @param  string[] $ioutil (required)
+     * @param  string[] $http (required)
+     * @param  string[] $url (required)
+     * @param  string[] $context (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context)
+    {
+        $returnType = '';
+        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    return [null, $response->getStatusCode(), $response->getHeaders()];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'testQueryParameterCollectionFormat'
+     *
+     * @param  string[] $pipe (required)
+     * @param  string[] $ioutil (required)
+     * @param  string[] $http (required)
+     * @param  string[] $url (required)
+     * @param  string[] $context (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    protected function testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context)
+    {
+        // verify the required parameter 'pipe' is set
+        if ($pipe === null || (is_array($pipe) && count($pipe) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $pipe when calling testQueryParameterCollectionFormat'
+            );
+        }
+        // verify the required parameter 'ioutil' is set
+        if ($ioutil === null || (is_array($ioutil) && count($ioutil) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $ioutil when calling testQueryParameterCollectionFormat'
+            );
+        }
+        // verify the required parameter 'http' is set
+        if ($http === null || (is_array($http) && count($http) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $http when calling testQueryParameterCollectionFormat'
+            );
+        }
+        // verify the required parameter 'url' is set
+        if ($url === null || (is_array($url) && count($url) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $url when calling testQueryParameterCollectionFormat'
+            );
+        }
+        // verify the required parameter 'context' is set
+        if ($context === null || (is_array($context) && count($context) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $context when calling testQueryParameterCollectionFormat'
+            );
+        }
+
+        $resourcePath = '/fake/test-query-paramters';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        if (is_array($pipe)) {
+            $pipe = ObjectSerializer::serializeCollection($pipe, 'csv', true);
+        }
+        if ($pipe !== null) {
+            $queryParams['pipe'] = ObjectSerializer::toQueryValue($pipe);
+        }
+        // query params
+        if (is_array($ioutil)) {
+            $ioutil = ObjectSerializer::serializeCollection($ioutil, 'csv', true);
+        }
+        if ($ioutil !== null) {
+            $queryParams['ioutil'] = ObjectSerializer::toQueryValue($ioutil);
+        }
+        // query params
+        if (is_array($http)) {
+            $http = ObjectSerializer::serializeCollection($http, 'space', true);
+        }
+        if ($http !== null) {
+            $queryParams['http'] = ObjectSerializer::toQueryValue($http);
+        }
+        // query params
+        if (is_array($url)) {
+            $url = ObjectSerializer::serializeCollection($url, 'csv', true);
+        }
+        if ($url !== null) {
+            $queryParams['url'] = ObjectSerializer::toQueryValue($url);
+        }
+        // query params
+        if (is_array($context)) {
+            $context = ObjectSerializer::serializeCollection($context, 'multi', true);
+        }
+        if ($context !== null) {
+            $queryParams['context'] = ObjectSerializer::toQueryValue($context);
+        }
+
+
+        // body params
+        $_tempBody = null;
+
+        if ($multipart) {
+            $headers = $this->headerSelector->selectHeadersForMultipart(
+                []
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                [],
+                []
+            );
+        }
+
+        // for model (json/xml)
+        if (isset($_tempBody)) {
+            // $_tempBody is the method argument, if present
+            if ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
+            }
+        } elseif (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $multipartContents[] = [
+                        'name' => $formParamName,
+                        'contents' => $formParamValue
+                    ];
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+        return new Request(
+            'PUT',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
      * Create http client option
      *
      * @throws \RuntimeException on file opening failure

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Api/FakeApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Api/FakeApiTest.php
@@ -201,4 +201,14 @@ class FakeApiTest extends TestCase
     public function testTestJsonFormData()
     {
     }
+
+    /**
+     * Test case for testQueryParameterCollectionFormat
+     *
+     * .
+     *
+     */
+    public function testTestQueryParameterCollectionFormat()
+    {
+    }
 }

--- a/samples/client/petstore/python-asyncio/README.md
+++ b/samples/client/petstore/python-asyncio/README.md
@@ -87,6 +87,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**test_group_parameters**](docs/FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**test_inline_additional_properties**](docs/FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**test_json_form_data**](docs/FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**test_query_parameter_collection_format**](docs/FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**test_classname**](docs/FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**add_pet**](docs/PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**delete_pet**](docs/PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/python-asyncio/docs/FakeApi.md
+++ b/samples/client/petstore/python-asyncio/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+[**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 
 
 # **create_xml_item**
@@ -761,6 +762,66 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_query_parameter_collection_format**
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```python
+from __future__ import print_function
+import time
+import petstore_api
+from petstore_api.rest import ApiException
+from pprint import pprint
+
+# Create an instance of the API class
+api_instance = petstore_api.FakeApi()
+pipe = ['pipe_example'] # list[str] | 
+ioutil = ['ioutil_example'] # list[str] | 
+http = ['http_example'] # list[str] | 
+url = ['url_example'] # list[str] | 
+context = ['context_example'] # list[str] | 
+
+try:
+    api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+except ApiException as e:
+    print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**list[str]**](str.md)|  | 
+ **ioutil** | [**list[str]**](str.md)|  | 
+ **http** | [**list[str]**](str.md)|  | 
+ **url** | [**list[str]**](str.md)|  | 
+ **context** | [**list[str]**](str.md)|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Success |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-asyncio/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api/fake_api.py
@@ -1580,3 +1580,144 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats)
+
+    def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
+        """test_query_parameter_collection_format  # noqa: E501
+
+        To test the collection format in query parameters  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.test_query_parameter_collection_format(pipe, ioutil, http, url, context, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param list[str] pipe: (required)
+        :param list[str] ioutil: (required)
+        :param list[str] http: (required)
+        :param list[str] url: (required)
+        :param list[str] context: (required)
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, **kwargs)  # noqa: E501
+
+    def test_query_parameter_collection_format_with_http_info(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
+        """test_query_parameter_collection_format  # noqa: E501
+
+        To test the collection format in query parameters  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param list[str] pipe: (required)
+        :param list[str] ioutil: (required)
+        :param list[str] http: (required)
+        :param list[str] url: (required)
+        :param list[str] context: (required)
+        :param _return_http_data_only: response data without head status code
+                                       and headers
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        local_var_params = locals()
+
+        all_params = ['pipe', 'ioutil', 'http', 'url', 'context']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        for key, val in six.iteritems(local_var_params['kwargs']):
+            if key not in all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_query_parameter_collection_format" % key
+                )
+            local_var_params[key] = val
+        del local_var_params['kwargs']
+        # verify the required parameter 'pipe' is set
+        if ('pipe' not in local_var_params or
+                local_var_params['pipe'] is None):
+            raise ApiValueError("Missing the required parameter `pipe` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'ioutil' is set
+        if ('ioutil' not in local_var_params or
+                local_var_params['ioutil'] is None):
+            raise ApiValueError("Missing the required parameter `ioutil` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'http' is set
+        if ('http' not in local_var_params or
+                local_var_params['http'] is None):
+            raise ApiValueError("Missing the required parameter `http` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'url' is set
+        if ('url' not in local_var_params or
+                local_var_params['url'] is None):
+            raise ApiValueError("Missing the required parameter `url` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'context' is set
+        if ('context' not in local_var_params or
+                local_var_params['context'] is None):
+            raise ApiValueError("Missing the required parameter `context` when calling `test_query_parameter_collection_format`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'pipe' in local_var_params:
+            query_params.append(('pipe', local_var_params['pipe']))  # noqa: E501
+            collection_formats['pipe'] = 'csv'  # noqa: E501
+        if 'ioutil' in local_var_params:
+            query_params.append(('ioutil', local_var_params['ioutil']))  # noqa: E501
+            collection_formats['ioutil'] = 'csv'  # noqa: E501
+        if 'http' in local_var_params:
+            query_params.append(('http', local_var_params['http']))  # noqa: E501
+            collection_formats['http'] = 'space'  # noqa: E501
+        if 'url' in local_var_params:
+            query_params.append(('url', local_var_params['url']))  # noqa: E501
+            collection_formats['url'] = 'csv'  # noqa: E501
+        if 'context' in local_var_params:
+            query_params.append(('context', local_var_params['context']))  # noqa: E501
+            collection_formats['context'] = 'multi'  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/fake/test-query-paramters', 'PUT',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type=None,  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=local_var_params.get('async_req'),
+            _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=local_var_params.get('_preload_content', True),
+            _request_timeout=local_var_params.get('_request_timeout'),
+            collection_formats=collection_formats)

--- a/samples/client/petstore/python-tornado/README.md
+++ b/samples/client/petstore/python-tornado/README.md
@@ -87,6 +87,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**test_group_parameters**](docs/FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**test_inline_additional_properties**](docs/FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**test_json_form_data**](docs/FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**test_query_parameter_collection_format**](docs/FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**test_classname**](docs/FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**add_pet**](docs/PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**delete_pet**](docs/PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/python-tornado/docs/FakeApi.md
+++ b/samples/client/petstore/python-tornado/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+[**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 
 
 # **create_xml_item**
@@ -761,6 +762,66 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_query_parameter_collection_format**
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```python
+from __future__ import print_function
+import time
+import petstore_api
+from petstore_api.rest import ApiException
+from pprint import pprint
+
+# Create an instance of the API class
+api_instance = petstore_api.FakeApi()
+pipe = ['pipe_example'] # list[str] | 
+ioutil = ['ioutil_example'] # list[str] | 
+http = ['http_example'] # list[str] | 
+url = ['url_example'] # list[str] | 
+context = ['context_example'] # list[str] | 
+
+try:
+    api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+except ApiException as e:
+    print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**list[str]**](str.md)|  | 
+ **ioutil** | [**list[str]**](str.md)|  | 
+ **http** | [**list[str]**](str.md)|  | 
+ **url** | [**list[str]**](str.md)|  | 
+ **context** | [**list[str]**](str.md)|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Success |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-tornado/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api/fake_api.py
@@ -1580,3 +1580,144 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats)
+
+    def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
+        """test_query_parameter_collection_format  # noqa: E501
+
+        To test the collection format in query parameters  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.test_query_parameter_collection_format(pipe, ioutil, http, url, context, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param list[str] pipe: (required)
+        :param list[str] ioutil: (required)
+        :param list[str] http: (required)
+        :param list[str] url: (required)
+        :param list[str] context: (required)
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, **kwargs)  # noqa: E501
+
+    def test_query_parameter_collection_format_with_http_info(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
+        """test_query_parameter_collection_format  # noqa: E501
+
+        To test the collection format in query parameters  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param list[str] pipe: (required)
+        :param list[str] ioutil: (required)
+        :param list[str] http: (required)
+        :param list[str] url: (required)
+        :param list[str] context: (required)
+        :param _return_http_data_only: response data without head status code
+                                       and headers
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        local_var_params = locals()
+
+        all_params = ['pipe', 'ioutil', 'http', 'url', 'context']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        for key, val in six.iteritems(local_var_params['kwargs']):
+            if key not in all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_query_parameter_collection_format" % key
+                )
+            local_var_params[key] = val
+        del local_var_params['kwargs']
+        # verify the required parameter 'pipe' is set
+        if ('pipe' not in local_var_params or
+                local_var_params['pipe'] is None):
+            raise ApiValueError("Missing the required parameter `pipe` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'ioutil' is set
+        if ('ioutil' not in local_var_params or
+                local_var_params['ioutil'] is None):
+            raise ApiValueError("Missing the required parameter `ioutil` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'http' is set
+        if ('http' not in local_var_params or
+                local_var_params['http'] is None):
+            raise ApiValueError("Missing the required parameter `http` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'url' is set
+        if ('url' not in local_var_params or
+                local_var_params['url'] is None):
+            raise ApiValueError("Missing the required parameter `url` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'context' is set
+        if ('context' not in local_var_params or
+                local_var_params['context'] is None):
+            raise ApiValueError("Missing the required parameter `context` when calling `test_query_parameter_collection_format`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'pipe' in local_var_params:
+            query_params.append(('pipe', local_var_params['pipe']))  # noqa: E501
+            collection_formats['pipe'] = 'csv'  # noqa: E501
+        if 'ioutil' in local_var_params:
+            query_params.append(('ioutil', local_var_params['ioutil']))  # noqa: E501
+            collection_formats['ioutil'] = 'csv'  # noqa: E501
+        if 'http' in local_var_params:
+            query_params.append(('http', local_var_params['http']))  # noqa: E501
+            collection_formats['http'] = 'space'  # noqa: E501
+        if 'url' in local_var_params:
+            query_params.append(('url', local_var_params['url']))  # noqa: E501
+            collection_formats['url'] = 'csv'  # noqa: E501
+        if 'context' in local_var_params:
+            query_params.append(('context', local_var_params['context']))  # noqa: E501
+            collection_formats['context'] = 'multi'  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/fake/test-query-paramters', 'PUT',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type=None,  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=local_var_params.get('async_req'),
+            _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=local_var_params.get('_preload_content', True),
+            _request_timeout=local_var_params.get('_request_timeout'),
+            collection_formats=collection_formats)

--- a/samples/client/petstore/python/README.md
+++ b/samples/client/petstore/python/README.md
@@ -87,6 +87,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**test_group_parameters**](docs/FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**test_inline_additional_properties**](docs/FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**test_json_form_data**](docs/FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**test_query_parameter_collection_format**](docs/FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**test_classname**](docs/FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**add_pet**](docs/PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**delete_pet**](docs/PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/python/docs/FakeApi.md
+++ b/samples/client/petstore/python/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+[**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 
 
 # **create_xml_item**
@@ -761,6 +762,66 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_query_parameter_collection_format**
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```python
+from __future__ import print_function
+import time
+import petstore_api
+from petstore_api.rest import ApiException
+from pprint import pprint
+
+# Create an instance of the API class
+api_instance = petstore_api.FakeApi()
+pipe = ['pipe_example'] # list[str] | 
+ioutil = ['ioutil_example'] # list[str] | 
+http = ['http_example'] # list[str] | 
+url = ['url_example'] # list[str] | 
+context = ['context_example'] # list[str] | 
+
+try:
+    api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+except ApiException as e:
+    print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**list[str]**](str.md)|  | 
+ **ioutil** | [**list[str]**](str.md)|  | 
+ **http** | [**list[str]**](str.md)|  | 
+ **url** | [**list[str]**](str.md)|  | 
+ **context** | [**list[str]**](str.md)|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Success |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_api.py
@@ -1580,3 +1580,144 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats)
+
+    def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
+        """test_query_parameter_collection_format  # noqa: E501
+
+        To test the collection format in query parameters  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.test_query_parameter_collection_format(pipe, ioutil, http, url, context, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param list[str] pipe: (required)
+        :param list[str] ioutil: (required)
+        :param list[str] http: (required)
+        :param list[str] url: (required)
+        :param list[str] context: (required)
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, **kwargs)  # noqa: E501
+
+    def test_query_parameter_collection_format_with_http_info(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
+        """test_query_parameter_collection_format  # noqa: E501
+
+        To test the collection format in query parameters  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param list[str] pipe: (required)
+        :param list[str] ioutil: (required)
+        :param list[str] http: (required)
+        :param list[str] url: (required)
+        :param list[str] context: (required)
+        :param _return_http_data_only: response data without head status code
+                                       and headers
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        local_var_params = locals()
+
+        all_params = ['pipe', 'ioutil', 'http', 'url', 'context']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        for key, val in six.iteritems(local_var_params['kwargs']):
+            if key not in all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_query_parameter_collection_format" % key
+                )
+            local_var_params[key] = val
+        del local_var_params['kwargs']
+        # verify the required parameter 'pipe' is set
+        if ('pipe' not in local_var_params or
+                local_var_params['pipe'] is None):
+            raise ApiValueError("Missing the required parameter `pipe` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'ioutil' is set
+        if ('ioutil' not in local_var_params or
+                local_var_params['ioutil'] is None):
+            raise ApiValueError("Missing the required parameter `ioutil` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'http' is set
+        if ('http' not in local_var_params or
+                local_var_params['http'] is None):
+            raise ApiValueError("Missing the required parameter `http` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'url' is set
+        if ('url' not in local_var_params or
+                local_var_params['url'] is None):
+            raise ApiValueError("Missing the required parameter `url` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'context' is set
+        if ('context' not in local_var_params or
+                local_var_params['context'] is None):
+            raise ApiValueError("Missing the required parameter `context` when calling `test_query_parameter_collection_format`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'pipe' in local_var_params:
+            query_params.append(('pipe', local_var_params['pipe']))  # noqa: E501
+            collection_formats['pipe'] = 'csv'  # noqa: E501
+        if 'ioutil' in local_var_params:
+            query_params.append(('ioutil', local_var_params['ioutil']))  # noqa: E501
+            collection_formats['ioutil'] = 'csv'  # noqa: E501
+        if 'http' in local_var_params:
+            query_params.append(('http', local_var_params['http']))  # noqa: E501
+            collection_formats['http'] = 'space'  # noqa: E501
+        if 'url' in local_var_params:
+            query_params.append(('url', local_var_params['url']))  # noqa: E501
+            collection_formats['url'] = 'csv'  # noqa: E501
+        if 'context' in local_var_params:
+            query_params.append(('context', local_var_params['context']))  # noqa: E501
+            collection_formats['context'] = 'multi'  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/fake/test-query-paramters', 'PUT',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type=None,  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=local_var_params.get('async_req'),
+            _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=local_var_params.get('_preload_content', True),
+            _request_timeout=local_var_params.get('_request_timeout'),
+            collection_formats=collection_formats)

--- a/samples/client/petstore/ruby/README.md
+++ b/samples/client/petstore/ruby/README.md
@@ -89,6 +89,7 @@ Class | Method | HTTP request | Description
 *Petstore::FakeApi* | [**test_group_parameters**](docs/FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *Petstore::FakeApi* | [**test_inline_additional_properties**](docs/FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *Petstore::FakeApi* | [**test_json_form_data**](docs/FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+*Petstore::FakeApi* | [**test_query_parameter_collection_format**](docs/FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 *Petstore::FakeClassnameTags123Api* | [**test_classname**](docs/FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case
 *Petstore::PetApi* | [**add_pet**](docs/PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
 *Petstore::PetApi* | [**delete_pet**](docs/PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/client/petstore/ruby/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+[**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -682,5 +683,58 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+
+## test_query_parameter_collection_format
+
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```ruby
+# load the gem
+require 'petstore'
+
+api_instance = Petstore::FakeApi.new
+pipe = ['pipe_example'] # Array<String> | 
+ioutil = ['ioutil_example'] # Array<String> | 
+http = ['http_example'] # Array<String> | 
+url = ['url_example'] # Array<String> | 
+context = ['context_example'] # Array<String> | 
+
+begin
+  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+rescue Petstore::ApiError => e
+  puts "Exception when calling FakeApi->test_query_parameter_collection_format: #{e}"
+end
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**Array&lt;String&gt;**](String.md)|  | 
+ **ioutil** | [**Array&lt;String&gt;**](String.md)|  | 
+ **http** | [**Array&lt;String&gt;**](String.md)|  | 
+ **url** | [**Array&lt;String&gt;**](String.md)|  | 
+ **context** | [**Array&lt;String&gt;**](String.md)|  | 
+
+### Return type
+
+nil (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 

--- a/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -985,5 +985,92 @@ module Petstore
       end
       return data, status_code, headers
     end
+
+    # To test the collection format in query parameters
+    # @param pipe [Array<String>] 
+    # @param ioutil [Array<String>] 
+    # @param http [Array<String>] 
+    # @param url [Array<String>] 
+    # @param context [Array<String>] 
+    # @param [Hash] opts the optional parameters
+    # @return [nil]
+    def test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts = {})
+      test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
+      nil
+    end
+
+    # To test the collection format in query parameters
+    # @param pipe [Array<String>] 
+    # @param ioutil [Array<String>] 
+    # @param http [Array<String>] 
+    # @param url [Array<String>] 
+    # @param context [Array<String>] 
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
+    def test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: FakeApi.test_query_parameter_collection_format ...'
+      end
+      # verify the required parameter 'pipe' is set
+      if @api_client.config.client_side_validation && pipe.nil?
+        fail ArgumentError, "Missing the required parameter 'pipe' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'ioutil' is set
+      if @api_client.config.client_side_validation && ioutil.nil?
+        fail ArgumentError, "Missing the required parameter 'ioutil' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'http' is set
+      if @api_client.config.client_side_validation && http.nil?
+        fail ArgumentError, "Missing the required parameter 'http' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'url' is set
+      if @api_client.config.client_side_validation && url.nil?
+        fail ArgumentError, "Missing the required parameter 'url' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'context' is set
+      if @api_client.config.client_side_validation && context.nil?
+        fail ArgumentError, "Missing the required parameter 'context' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # resource path
+      local_var_path = '/fake/test-query-paramters'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+      query_params[:'pipe'] = @api_client.build_collection_param(pipe, :csv)
+      query_params[:'ioutil'] = @api_client.build_collection_param(ioutil, :csv)
+      query_params[:'http'] = @api_client.build_collection_param(http, :space)
+      query_params[:'url'] = @api_client.build_collection_param(url, :csv)
+      query_params[:'context'] = @api_client.build_collection_param(context, :multi)
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_options = opts.merge(
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: FakeApi#test_query_parameter_collection_format\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
   end
 end

--- a/samples/client/petstore/ruby/spec/api/fake_api_spec.rb
+++ b/samples/client/petstore/ruby/spec/api/fake_api_spec.rb
@@ -206,4 +206,19 @@ describe 'FakeApi' do
     end
   end
 
+  # unit tests for test_query_parameter_collection_format
+  # To test the collection format in query parameters
+  # @param pipe 
+  # @param ioutil 
+  # @param http 
+  # @param url 
+  # @param context 
+  # @param [Hash] opts the optional parameters
+  # @return [nil]
+  describe 'test_query_parameter_collection_format test' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
 end

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/README.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/README.md
@@ -98,6 +98,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**testGroupParameters**](docs/Api/FakeApi.md#testgroupparameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**testInlineAdditionalProperties**](docs/Api/FakeApi.md#testinlineadditionalproperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**testJsonFormData**](docs/Api/FakeApi.md#testjsonformdata) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**testQueryParameterCollectionFormat**](docs/Api/FakeApi.md#testqueryparametercollectionformat) | **PUT** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**testClassname**](docs/Api/FakeClassnameTags123Api.md#testclassname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**addPet**](docs/Api/PetApi.md#addpet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**deletePet**](docs/Api/PetApi.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**testGroupParameters**](FakeApi.md#testGroupParameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**testInlineAdditionalProperties**](FakeApi.md#testInlineAdditionalProperties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**testJsonFormData**](FakeApi.md#testJsonFormData) | **GET** /fake/jsonFormData | test json serialization of form data
+[**testQueryParameterCollectionFormat**](FakeApi.md#testQueryParameterCollectionFormat) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -790,6 +791,69 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../../README.md#documentation-for-models)
+[[Back to README]](../../README.md)
+
+
+## testQueryParameterCollectionFormat
+
+> testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+$apiInstance = new OpenAPI\Client\Api\FakeApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client()
+);
+$pipe = array('pipe_example'); // string[] | 
+$ioutil = array('ioutil_example'); // string[] | 
+$http = array('http_example'); // string[] | 
+$url = array('url_example'); // string[] | 
+$context = array('context_example'); // string[] | 
+
+try {
+    $apiInstance->testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context);
+} catch (Exception $e) {
+    echo 'Exception when calling FakeApi->testQueryParameterCollectionFormat: ', $e->getMessage(), PHP_EOL;
+}
+?>
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**string[]**](../Model/string.md)|  |
+ **ioutil** | [**string[]**](../Model/string.md)|  |
+ **http** | [**string[]**](../Model/string.md)|  |
+ **url** | [**string[]**](../Model/string.md)|  |
+ **context** | [**string[]**](../Model/string.md)|  |
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints)

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -3552,6 +3552,297 @@ class FakeApi
     }
 
     /**
+     * Operation testQueryParameterCollectionFormat
+     *
+     * @param  string[] $pipe pipe (required)
+     * @param  string[] $ioutil ioutil (required)
+     * @param  string[] $http http (required)
+     * @param  string[] $url url (required)
+     * @param  string[] $context context (required)
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context)
+    {
+        $this->testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context);
+    }
+
+    /**
+     * Operation testQueryParameterCollectionFormatWithHttpInfo
+     *
+     * @param  string[] $pipe (required)
+     * @param  string[] $ioutil (required)
+     * @param  string[] $http (required)
+     * @param  string[] $url (required)
+     * @param  string[] $context (required)
+     *
+     * @throws \OpenAPI\Client\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return array of null, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context)
+    {
+        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? $e->getResponse()->getBody()->getContents() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()
+                );
+            }
+
+            return [null, $statusCode, $response->getHeaders()];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation testQueryParameterCollectionFormatAsync
+     *
+     * 
+     *
+     * @param  string[] $pipe (required)
+     * @param  string[] $ioutil (required)
+     * @param  string[] $http (required)
+     * @param  string[] $url (required)
+     * @param  string[] $context (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function testQueryParameterCollectionFormatAsync($pipe, $ioutil, $http, $url, $context)
+    {
+        return $this->testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation testQueryParameterCollectionFormatAsyncWithHttpInfo
+     *
+     * 
+     *
+     * @param  string[] $pipe (required)
+     * @param  string[] $ioutil (required)
+     * @param  string[] $http (required)
+     * @param  string[] $url (required)
+     * @param  string[] $context (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context)
+    {
+        $returnType = '';
+        $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    return [null, $response->getStatusCode(), $response->getHeaders()];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'testQueryParameterCollectionFormat'
+     *
+     * @param  string[] $pipe (required)
+     * @param  string[] $ioutil (required)
+     * @param  string[] $http (required)
+     * @param  string[] $url (required)
+     * @param  string[] $context (required)
+     *
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    protected function testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context)
+    {
+        // verify the required parameter 'pipe' is set
+        if ($pipe === null || (is_array($pipe) && count($pipe) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $pipe when calling testQueryParameterCollectionFormat'
+            );
+        }
+        // verify the required parameter 'ioutil' is set
+        if ($ioutil === null || (is_array($ioutil) && count($ioutil) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $ioutil when calling testQueryParameterCollectionFormat'
+            );
+        }
+        // verify the required parameter 'http' is set
+        if ($http === null || (is_array($http) && count($http) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $http when calling testQueryParameterCollectionFormat'
+            );
+        }
+        // verify the required parameter 'url' is set
+        if ($url === null || (is_array($url) && count($url) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $url when calling testQueryParameterCollectionFormat'
+            );
+        }
+        // verify the required parameter 'context' is set
+        if ($context === null || (is_array($context) && count($context) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $context when calling testQueryParameterCollectionFormat'
+            );
+        }
+
+        $resourcePath = '/fake/test-query-paramters';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        if (is_array($pipe)) {
+            $pipe = ObjectSerializer::serializeCollection($pipe, 'multi', true);
+        }
+        if ($pipe !== null) {
+            $queryParams['pipe'] = ObjectSerializer::toQueryValue($pipe);
+        }
+        // query params
+        if (is_array($ioutil)) {
+            $ioutil = ObjectSerializer::serializeCollection($ioutil, 'csv', true);
+        }
+        if ($ioutil !== null) {
+            $queryParams['ioutil'] = ObjectSerializer::toQueryValue($ioutil);
+        }
+        // query params
+        if (is_array($http)) {
+            $http = ObjectSerializer::serializeCollection($http, 'space', true);
+        }
+        if ($http !== null) {
+            $queryParams['http'] = ObjectSerializer::toQueryValue($http);
+        }
+        // query params
+        if (is_array($url)) {
+            $url = ObjectSerializer::serializeCollection($url, 'csv', true);
+        }
+        if ($url !== null) {
+            $queryParams['url'] = ObjectSerializer::toQueryValue($url);
+        }
+        // query params
+        if (is_array($context)) {
+            $context = ObjectSerializer::serializeCollection($context, 'multi', true);
+        }
+        if ($context !== null) {
+            $queryParams['context'] = ObjectSerializer::toQueryValue($context);
+        }
+
+
+        // body params
+        $_tempBody = null;
+
+        if ($multipart) {
+            $headers = $this->headerSelector->selectHeadersForMultipart(
+                []
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                [],
+                []
+            );
+        }
+
+        // for model (json/xml)
+        if (isset($_tempBody)) {
+            // $_tempBody is the method argument, if present
+            if ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode(ObjectSerializer::sanitizeForSerialization($_tempBody));
+            } else {
+                $httpBody = $_tempBody;
+            }
+        } elseif (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $multipartContents[] = [
+                        'name' => $formParamName,
+                        'contents' => $formParamValue
+                    ];
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+        return new Request(
+            'PUT',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
      * Create http client option
      *
      * @throws \RuntimeException on file opening failure

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/test/Api/FakeApiTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/test/Api/FakeApiTest.php
@@ -201,4 +201,14 @@ class FakeApiTest extends TestCase
     public function testTestJsonFormData()
     {
     }
+
+    /**
+     * Test case for testQueryParameterCollectionFormat
+     *
+     * .
+     *
+     */
+    public function testTestQueryParameterCollectionFormat()
+    {
+    }
 }

--- a/samples/openapi3/client/petstore/python/README.md
+++ b/samples/openapi3/client/petstore/python/README.md
@@ -88,6 +88,7 @@ Class | Method | HTTP request | Description
 *FakeApi* | [**test_group_parameters**](docs/FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *FakeApi* | [**test_inline_additional_properties**](docs/FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *FakeApi* | [**test_json_form_data**](docs/FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+*FakeApi* | [**test_query_parameter_collection_format**](docs/FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 *FakeClassnameTags123Api* | [**test_classname**](docs/FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case
 *PetApi* | [**add_pet**](docs/PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
 *PetApi* | [**delete_pet**](docs/PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/openapi3/client/petstore/python/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+[**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 
 
 # **fake_health_get**
@@ -762,6 +763,66 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_query_parameter_collection_format**
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```python
+from __future__ import print_function
+import time
+import petstore_api
+from petstore_api.rest import ApiException
+from pprint import pprint
+
+# Create an instance of the API class
+api_instance = petstore_api.FakeApi()
+pipe = ['pipe_example'] # list[str] | 
+ioutil = ['ioutil_example'] # list[str] | 
+http = ['http_example'] # list[str] | 
+url = ['url_example'] # list[str] | 
+context = ['context_example'] # list[str] | 
+
+try:
+    api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+except ApiException as e:
+    print("Exception when calling FakeApi->test_query_parameter_collection_format: %s\n" % e)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**list[str]**](str.md)|  | 
+ **ioutil** | [**list[str]**](str.md)|  | 
+ **http** | [**list[str]**](str.md)|  | 
+ **url** | [**list[str]**](str.md)|  | 
+ **context** | [**list[str]**](str.md)|  | 
+
+### Return type
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Success |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -1586,3 +1586,144 @@ class FakeApi(object):
             _preload_content=local_var_params.get('_preload_content', True),
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats)
+
+    def test_query_parameter_collection_format(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
+        """test_query_parameter_collection_format  # noqa: E501
+
+        To test the collection format in query parameters  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.test_query_parameter_collection_format(pipe, ioutil, http, url, context, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param list[str] pipe: (required)
+        :param list[str] ioutil: (required)
+        :param list[str] http: (required)
+        :param list[str] url: (required)
+        :param list[str] context: (required)
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, **kwargs)  # noqa: E501
+
+    def test_query_parameter_collection_format_with_http_info(self, pipe, ioutil, http, url, context, **kwargs):  # noqa: E501
+        """test_query_parameter_collection_format  # noqa: E501
+
+        To test the collection format in query parameters  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool: execute request asynchronously
+        :param list[str] pipe: (required)
+        :param list[str] ioutil: (required)
+        :param list[str] http: (required)
+        :param list[str] url: (required)
+        :param list[str] context: (required)
+        :param _return_http_data_only: response data without head status code
+                                       and headers
+        :param _preload_content: if False, the urllib3.HTTPResponse object will
+                                 be returned without reading/decoding response
+                                 data. Default is True.
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        local_var_params = locals()
+
+        all_params = ['pipe', 'ioutil', 'http', 'url', 'context']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        for key, val in six.iteritems(local_var_params['kwargs']):
+            if key not in all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_query_parameter_collection_format" % key
+                )
+            local_var_params[key] = val
+        del local_var_params['kwargs']
+        # verify the required parameter 'pipe' is set
+        if ('pipe' not in local_var_params or
+                local_var_params['pipe'] is None):
+            raise ApiValueError("Missing the required parameter `pipe` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'ioutil' is set
+        if ('ioutil' not in local_var_params or
+                local_var_params['ioutil'] is None):
+            raise ApiValueError("Missing the required parameter `ioutil` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'http' is set
+        if ('http' not in local_var_params or
+                local_var_params['http'] is None):
+            raise ApiValueError("Missing the required parameter `http` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'url' is set
+        if ('url' not in local_var_params or
+                local_var_params['url'] is None):
+            raise ApiValueError("Missing the required parameter `url` when calling `test_query_parameter_collection_format`")  # noqa: E501
+        # verify the required parameter 'context' is set
+        if ('context' not in local_var_params or
+                local_var_params['context'] is None):
+            raise ApiValueError("Missing the required parameter `context` when calling `test_query_parameter_collection_format`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if 'pipe' in local_var_params:
+            query_params.append(('pipe', local_var_params['pipe']))  # noqa: E501
+            collection_formats['pipe'] = 'multi'  # noqa: E501
+        if 'ioutil' in local_var_params:
+            query_params.append(('ioutil', local_var_params['ioutil']))  # noqa: E501
+            collection_formats['ioutil'] = 'csv'  # noqa: E501
+        if 'http' in local_var_params:
+            query_params.append(('http', local_var_params['http']))  # noqa: E501
+            collection_formats['http'] = 'space'  # noqa: E501
+        if 'url' in local_var_params:
+            query_params.append(('url', local_var_params['url']))  # noqa: E501
+            collection_formats['url'] = 'csv'  # noqa: E501
+        if 'context' in local_var_params:
+            query_params.append(('context', local_var_params['context']))  # noqa: E501
+            collection_formats['context'] = 'multi'  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # Authentication setting
+        auth_settings = []  # noqa: E501
+
+        return self.api_client.call_api(
+            '/fake/test-query-paramters', 'PUT',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type=None,  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=local_var_params.get('async_req'),
+            _return_http_data_only=local_var_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=local_var_params.get('_preload_content', True),
+            _request_timeout=local_var_params.get('_request_timeout'),
+            collection_formats=collection_formats)

--- a/samples/openapi3/client/petstore/ruby-faraday/README.md
+++ b/samples/openapi3/client/petstore/ruby-faraday/README.md
@@ -90,6 +90,7 @@ Class | Method | HTTP request | Description
 *Petstore::FakeApi* | [**test_group_parameters**](docs/FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *Petstore::FakeApi* | [**test_inline_additional_properties**](docs/FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *Petstore::FakeApi* | [**test_json_form_data**](docs/FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+*Petstore::FakeApi* | [**test_query_parameter_collection_format**](docs/FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 *Petstore::FakeClassnameTags123Api* | [**test_classname**](docs/FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case
 *Petstore::PetApi* | [**add_pet**](docs/PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
 *Petstore::PetApi* | [**delete_pet**](docs/PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/openapi3/client/petstore/ruby-faraday/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/ruby-faraday/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+[**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -682,5 +683,58 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+
+## test_query_parameter_collection_format
+
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```ruby
+# load the gem
+require 'petstore'
+
+api_instance = Petstore::FakeApi.new
+pipe = ['pipe_example'] # Array<String> | 
+ioutil = ['ioutil_example'] # Array<String> | 
+http = ['http_example'] # Array<String> | 
+url = ['url_example'] # Array<String> | 
+context = ['context_example'] # Array<String> | 
+
+begin
+  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+rescue Petstore::ApiError => e
+  puts "Exception when calling FakeApi->test_query_parameter_collection_format: #{e}"
+end
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**Array&lt;String&gt;**](String.md)|  | 
+ **ioutil** | [**Array&lt;String&gt;**](String.md)|  | 
+ **http** | [**Array&lt;String&gt;**](String.md)|  | 
+ **url** | [**Array&lt;String&gt;**](String.md)|  | 
+ **context** | [**Array&lt;String&gt;**](String.md)|  | 
+
+### Return type
+
+nil (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 

--- a/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/api/fake_api.rb
@@ -985,5 +985,92 @@ module Petstore
       end
       return data, status_code, headers
     end
+
+    # To test the collection format in query parameters
+    # @param pipe [Array<String>] 
+    # @param ioutil [Array<String>] 
+    # @param http [Array<String>] 
+    # @param url [Array<String>] 
+    # @param context [Array<String>] 
+    # @param [Hash] opts the optional parameters
+    # @return [nil]
+    def test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts = {})
+      test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
+      nil
+    end
+
+    # To test the collection format in query parameters
+    # @param pipe [Array<String>] 
+    # @param ioutil [Array<String>] 
+    # @param http [Array<String>] 
+    # @param url [Array<String>] 
+    # @param context [Array<String>] 
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
+    def test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: FakeApi.test_query_parameter_collection_format ...'
+      end
+      # verify the required parameter 'pipe' is set
+      if @api_client.config.client_side_validation && pipe.nil?
+        fail ArgumentError, "Missing the required parameter 'pipe' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'ioutil' is set
+      if @api_client.config.client_side_validation && ioutil.nil?
+        fail ArgumentError, "Missing the required parameter 'ioutil' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'http' is set
+      if @api_client.config.client_side_validation && http.nil?
+        fail ArgumentError, "Missing the required parameter 'http' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'url' is set
+      if @api_client.config.client_side_validation && url.nil?
+        fail ArgumentError, "Missing the required parameter 'url' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'context' is set
+      if @api_client.config.client_side_validation && context.nil?
+        fail ArgumentError, "Missing the required parameter 'context' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # resource path
+      local_var_path = '/fake/test-query-paramters'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+      query_params[:'pipe'] = @api_client.build_collection_param(pipe, :multi)
+      query_params[:'ioutil'] = @api_client.build_collection_param(ioutil, :csv)
+      query_params[:'http'] = @api_client.build_collection_param(http, :space)
+      query_params[:'url'] = @api_client.build_collection_param(url, :csv)
+      query_params[:'context'] = @api_client.build_collection_param(context, :multi)
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_options = opts.merge(
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: FakeApi#test_query_parameter_collection_format\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
   end
 end

--- a/samples/openapi3/client/petstore/ruby-faraday/spec/api/fake_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/spec/api/fake_api_spec.rb
@@ -204,4 +204,19 @@ describe 'FakeApi' do
     end
   end
 
+  # unit tests for test_query_parameter_collection_format
+  # To test the collection format in query parameters
+  # @param pipe 
+  # @param ioutil 
+  # @param http 
+  # @param url 
+  # @param context 
+  # @param [Hash] opts the optional parameters
+  # @return [nil]
+  describe 'test_query_parameter_collection_format test' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
 end

--- a/samples/openapi3/client/petstore/ruby/README.md
+++ b/samples/openapi3/client/petstore/ruby/README.md
@@ -90,6 +90,7 @@ Class | Method | HTTP request | Description
 *Petstore::FakeApi* | [**test_group_parameters**](docs/FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *Petstore::FakeApi* | [**test_inline_additional_properties**](docs/FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *Petstore::FakeApi* | [**test_json_form_data**](docs/FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+*Petstore::FakeApi* | [**test_query_parameter_collection_format**](docs/FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 *Petstore::FakeClassnameTags123Api* | [**test_classname**](docs/FakeClassnameTags123Api.md#test_classname) | **PATCH** /fake_classname_test | To test class name in snake case
 *Petstore::PetApi* | [**add_pet**](docs/PetApi.md#add_pet) | **POST** /pet | Add a new pet to the store
 *Petstore::PetApi* | [**delete_pet**](docs/PetApi.md#delete_pet) | **DELETE** /pet/{petId} | Deletes a pet

--- a/samples/openapi3/client/petstore/ruby/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/ruby/docs/FakeApi.md
@@ -17,6 +17,7 @@ Method | HTTP request | Description
 [**test_group_parameters**](FakeApi.md#test_group_parameters) | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 [**test_inline_additional_properties**](FakeApi.md#test_inline_additional_properties) | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 [**test_json_form_data**](FakeApi.md#test_json_form_data) | **GET** /fake/jsonFormData | test json serialization of form data
+[**test_query_parameter_collection_format**](FakeApi.md#test_query_parameter_collection_format) | **PUT** /fake/test-query-paramters | 
 
 
 
@@ -682,5 +683,58 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: application/x-www-form-urlencoded
+- **Accept**: Not defined
+
+
+## test_query_parameter_collection_format
+
+> test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+
+
+
+To test the collection format in query parameters
+
+### Example
+
+```ruby
+# load the gem
+require 'petstore'
+
+api_instance = Petstore::FakeApi.new
+pipe = ['pipe_example'] # Array<String> | 
+ioutil = ['ioutil_example'] # Array<String> | 
+http = ['http_example'] # Array<String> | 
+url = ['url_example'] # Array<String> | 
+context = ['context_example'] # Array<String> | 
+
+begin
+  api_instance.test_query_parameter_collection_format(pipe, ioutil, http, url, context)
+rescue Petstore::ApiError => e
+  puts "Exception when calling FakeApi->test_query_parameter_collection_format: #{e}"
+end
+```
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **pipe** | [**Array&lt;String&gt;**](String.md)|  | 
+ **ioutil** | [**Array&lt;String&gt;**](String.md)|  | 
+ **http** | [**Array&lt;String&gt;**](String.md)|  | 
+ **url** | [**Array&lt;String&gt;**](String.md)|  | 
+ **context** | [**Array&lt;String&gt;**](String.md)|  | 
+
+### Return type
+
+nil (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
 - **Accept**: Not defined
 

--- a/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
+++ b/samples/openapi3/client/petstore/ruby/lib/petstore/api/fake_api.rb
@@ -985,5 +985,92 @@ module Petstore
       end
       return data, status_code, headers
     end
+
+    # To test the collection format in query parameters
+    # @param pipe [Array<String>] 
+    # @param ioutil [Array<String>] 
+    # @param http [Array<String>] 
+    # @param url [Array<String>] 
+    # @param context [Array<String>] 
+    # @param [Hash] opts the optional parameters
+    # @return [nil]
+    def test_query_parameter_collection_format(pipe, ioutil, http, url, context, opts = {})
+      test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts)
+      nil
+    end
+
+    # To test the collection format in query parameters
+    # @param pipe [Array<String>] 
+    # @param ioutil [Array<String>] 
+    # @param http [Array<String>] 
+    # @param url [Array<String>] 
+    # @param context [Array<String>] 
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
+    def test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: FakeApi.test_query_parameter_collection_format ...'
+      end
+      # verify the required parameter 'pipe' is set
+      if @api_client.config.client_side_validation && pipe.nil?
+        fail ArgumentError, "Missing the required parameter 'pipe' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'ioutil' is set
+      if @api_client.config.client_side_validation && ioutil.nil?
+        fail ArgumentError, "Missing the required parameter 'ioutil' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'http' is set
+      if @api_client.config.client_side_validation && http.nil?
+        fail ArgumentError, "Missing the required parameter 'http' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'url' is set
+      if @api_client.config.client_side_validation && url.nil?
+        fail ArgumentError, "Missing the required parameter 'url' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # verify the required parameter 'context' is set
+      if @api_client.config.client_side_validation && context.nil?
+        fail ArgumentError, "Missing the required parameter 'context' when calling FakeApi.test_query_parameter_collection_format"
+      end
+      # resource path
+      local_var_path = '/fake/test-query-paramters'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+      query_params[:'pipe'] = @api_client.build_collection_param(pipe, :multi)
+      query_params[:'ioutil'] = @api_client.build_collection_param(ioutil, :csv)
+      query_params[:'http'] = @api_client.build_collection_param(http, :space)
+      query_params[:'url'] = @api_client.build_collection_param(url, :csv)
+      query_params[:'context'] = @api_client.build_collection_param(context, :multi)
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:body] 
+
+      # return_type
+      return_type = opts[:return_type] 
+
+      # auth_names
+      auth_names = opts[:auth_names] || []
+
+      new_options = opts.merge(
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:PUT, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: FakeApi#test_query_parameter_collection_format\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
   end
 end

--- a/samples/openapi3/client/petstore/ruby/spec/api/fake_api_spec.rb
+++ b/samples/openapi3/client/petstore/ruby/spec/api/fake_api_spec.rb
@@ -204,4 +204,19 @@ describe 'FakeApi' do
     end
   end
 
+  # unit tests for test_query_parameter_collection_format
+  # To test the collection format in query parameters
+  # @param pipe 
+  # @param ioutil 
+  # @param http 
+  # @param url 
+  # @param context 
+  # @param [Hash] opts the optional parameters
+  # @return [nil]
+  describe 'test_query_parameter_collection_format test' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
 end

--- a/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/FakeApi.java
@@ -230,6 +230,22 @@ public class FakeApi  {
     throws NotFoundException {
         return delegate.testJsonFormData(param,param2);
     }
+    @PUT
+    @Path("/test-query-paramters")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "",required=true, defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("pipe") List<String> pipe
+,@ApiParam(value = "",required=true, defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("ioutil") List<String> ioutil
+,@ApiParam(value = "",required=true, defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("http") List<String> http
+,@ApiParam(value = "",required=true, defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("url") List<String> url
+,@ApiParam(value = "",required=true, defaultValue="new ArrayList<String>()") @DefaultValue("new ArrayList<String>()") @QueryParam("context") List<String> context
+)
+    throws NotFoundException {
+        return delegate.testQueryParameterCollectionFormat(pipe,ioutil,http,url,context);
+    }
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -80,6 +80,12 @@ public abstract class FakeApiService {
     public abstract Response testJsonFormData(String param
  ,String param2
  ) throws NotFoundException;
+    public abstract Response testQueryParameterCollectionFormat(List<String> pipe
+ ,List<String> ioutil
+ ,List<String> http
+ ,List<String> url
+ ,List<String> context
+ ) throws NotFoundException;
     public abstract Response uploadFileWithRequiredFile(Long petId
  ,InputStream requiredFileInputStream, FileInfo requiredFileDetail
  ,String additionalMetadata

--- a/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/java-msf4j/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -133,6 +133,16 @@ public class FakeApiServiceImpl extends FakeApiService {
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
     @Override
+    public Response testQueryParameterCollectionFormat(List<String> pipe
+, List<String> ioutil
+, List<String> http
+, List<String> url
+, List<String> context
+ ) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+    @Override
     public Response uploadFileWithRequiredFile(Long petId
 , InputStream requiredFileInputStream, FileInfo requiredFileDetail
 , String additionalMetadata

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/api/FakeApi.java
@@ -177,9 +177,16 @@ public interface FakeApi  {
     @GET
     @Path("/fake/jsonFormData")
     @Consumes({ "application/x-www-form-urlencoded" })
-    @ApiOperation(value = "test json serialization of form data", tags={ "fake" })
+    @ApiOperation(value = "test json serialization of form data", tags={ "fake",  })
     @ApiResponses(value = { 
         @ApiResponse(code = 200, message = "successful operation") })
     public void testJsonFormData(@Multipart(value = "param")  String param, @Multipart(value = "param2")  String param2);
+
+    @PUT
+    @Path("/fake/test-query-paramters")
+    @ApiOperation(value = "", tags={ "fake" })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    public void testQueryParameterCollectionFormat(@QueryParam("pipe") @NotNull  List<String> pipe, @QueryParam("ioutil") @NotNull  List<String> ioutil, @QueryParam("http") @NotNull  List<String> http, @QueryParam("url") @NotNull  List<String> url, @QueryParam("context") @NotNull  List<String> context);
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-cxf/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -148,5 +148,11 @@ public class FakeApiServiceImpl implements FakeApi {
         
     }
     
+    public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) {
+        // TODO: Implement...
+        
+        
+    }
+    
 }
 

--- a/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/FakeApiTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/test/java/org/openapitools/api/FakeApiTest.java
@@ -313,4 +313,22 @@ public class FakeApiTest {
         
     }
     
+    /**
+     * @throws ApiException
+     *          if the Api call fails
+     */
+    @Test
+    public void testQueryParameterCollectionFormatTest() {
+        List<String> pipe = null;
+        List<String> ioutil = null;
+        List<String> http = null;
+        List<String> url = null;
+        List<String> context = null;
+        //api.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+        
+        // TODO: test validations
+        
+        
+    }
+    
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApi.java
@@ -256,6 +256,22 @@ public class FakeApi  {
     throws NotFoundException {
         return delegate.testJsonFormData(param, param2, securityContext);
     }
+    @PUT
+    @Path("/test-query-paramters")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe
+,@ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil
+,@ApiParam(value = "",required=true)@QueryParam("http") List<String> http
+,@ApiParam(value = "",required=true)@QueryParam("url") List<String> url
+,@ApiParam(value = "",required=true)@QueryParam("context") List<String> context
+,@Context SecurityContext securityContext)
+    throws NotFoundException {
+        return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, securityContext);
+    }
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -40,5 +40,6 @@ public abstract class FakeApiService {
     public abstract Response testGroupParameters( @NotNull Integer requiredStringGroup, @NotNull Boolean requiredBooleanGroup, @NotNull Long requiredInt64Group,Integer stringGroup,Boolean booleanGroup,Long int64Group,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testInlineAdditionalProperties(Map<String, String> param,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testJsonFormData(String param,String param2,SecurityContext securityContext) throws NotFoundException;
+    public abstract Response testQueryParameterCollectionFormat( @NotNull List<String> pipe, @NotNull List<String> ioutil, @NotNull List<String> http, @NotNull List<String> url, @NotNull List<String> context,SecurityContext securityContext) throws NotFoundException;
     public abstract Response uploadFileWithRequiredFile(Long petId,InputStream requiredFileInputStream, FormDataContentDisposition requiredFileDetail,String additionalMetadata,SecurityContext securityContext) throws NotFoundException;
 }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -93,6 +93,11 @@ public class FakeApiServiceImpl extends FakeApiService {
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
     @Override
+    public Response testQueryParameterCollectionFormat( @NotNull List<String> pipe,  @NotNull List<String> ioutil,  @NotNull List<String> http,  @NotNull List<String> url,  @NotNull List<String> context, SecurityContext securityContext) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+    @Override
     public Response uploadFileWithRequiredFile(Long petId, InputStream requiredFileInputStream, FormDataContentDisposition requiredFileDetail, String additionalMetadata, SecurityContext securityContext) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
@@ -256,6 +256,22 @@ public class FakeApi  {
     throws NotFoundException {
         return delegate.testJsonFormData(param, param2, securityContext);
     }
+    @PUT
+    @Path("/test-query-paramters")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe
+,@ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil
+,@ApiParam(value = "",required=true)@QueryParam("http") List<String> http
+,@ApiParam(value = "",required=true)@QueryParam("url") List<String> url
+,@ApiParam(value = "",required=true)@QueryParam("context") List<String> context
+,@Context SecurityContext securityContext)
+    throws NotFoundException {
+        return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, securityContext);
+    }
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -39,5 +39,6 @@ public abstract class FakeApiService {
     public abstract Response testGroupParameters( @NotNull Integer requiredStringGroup, @NotNull Boolean requiredBooleanGroup, @NotNull Long requiredInt64Group,Integer stringGroup,Boolean booleanGroup,Long int64Group,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testInlineAdditionalProperties(Map<String, String> requestBody,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testJsonFormData(String param,String param2,SecurityContext securityContext) throws NotFoundException;
+    public abstract Response testQueryParameterCollectionFormat( @NotNull List<String> pipe, @NotNull List<String> ioutil, @NotNull List<String> http, @NotNull List<String> url, @NotNull List<String> context,SecurityContext securityContext) throws NotFoundException;
     public abstract Response uploadFileWithRequiredFile(Long petId,InputStream requiredFileInputStream, FormDataContentDisposition requiredFileDetail,String additionalMetadata,SecurityContext securityContext) throws NotFoundException;
 }

--- a/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs-jersey/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -92,6 +92,11 @@ public class FakeApiServiceImpl extends FakeApiService {
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
     @Override
+    public Response testQueryParameterCollectionFormat( @NotNull List<String> pipe,  @NotNull List<String> ioutil,  @NotNull List<String> http,  @NotNull List<String> url,  @NotNull List<String> context, SecurityContext securityContext) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+    @Override
     public Response uploadFileWithRequiredFile(Long petId, InputStream requiredFileInputStream, FormDataContentDisposition requiredFileDetail, String additionalMetadata, SecurityContext securityContext) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeApi.java
@@ -131,6 +131,13 @@ public interface FakeApi {
         @ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     void testJsonFormData(@FormParam(value = "param")  String param,@FormParam(value = "param2")  String param2);
 
+    @PUT
+    @Path("/test-query-paramters")
+    @ApiOperation(value = "", notes = "To test the collection format in query parameters", tags={ "fake",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success", response = Void.class) })
+    void testQueryParameterCollectionFormat(@QueryParam("pipe") @NotNull    List<String> pipe,@QueryParam("ioutil") @NotNull    List<String> ioutil,@QueryParam("http") @NotNull    List<String> http,@QueryParam("url") @NotNull    List<String> url,@QueryParam("context") @NotNull    List<String> context);
+
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec-interface/src/main/openapi/openapi.yaml
@@ -1228,6 +1228,62 @@ paths:
       x-accepts: application/json
       x-tags:
       - tag: fake
+  /fake/test-query-paramters:
+    put:
+      description: To test the collection format in query parameters
+      operationId: testQueryParameterCollectionFormat
+      parameters:
+      - explode: false
+        in: query
+        name: pipe
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - in: query
+        name: ioutil
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+      - in: query
+        name: http
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: spaceDelimited
+      - explode: false
+        in: query
+        name: url
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - explode: true
+        in: query
+        name: context
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      responses:
+        200:
+          content: {}
+          description: Success
+      tags:
+      - fake
+      x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeApi.java
@@ -170,6 +170,16 @@ public class FakeApi {
         return Response.ok().entity("magic!").build();
     }
 
+    @PUT
+    @Path("/test-query-paramters")
+    @ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake",  })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success", response = Void.class)
+    })
+    public Response testQueryParameterCollectionFormat(@QueryParam("pipe") @NotNull    List<String> pipe,@QueryParam("ioutil") @NotNull    List<String> ioutil,@QueryParam("http") @NotNull    List<String> http,@QueryParam("url") @NotNull    List<String> url,@QueryParam("context") @NotNull    List<String> context) {
+        return Response.ok().entity("magic!").build();
+    }
+
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-spec/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec/src/main/openapi/openapi.yaml
@@ -1228,6 +1228,62 @@ paths:
       x-accepts: application/json
       x-tags:
       - tag: fake
+  /fake/test-query-paramters:
+    put:
+      description: To test the collection format in query parameters
+      operationId: testQueryParameterCollectionFormat
+      parameters:
+      - explode: false
+        in: query
+        name: pipe
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - in: query
+        name: ioutil
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+      - in: query
+        name: http
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: spaceDelimited
+      - explode: false
+        in: query
+        name: url
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - explode: true
+        in: query
+        name: context
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      responses:
+        200:
+          content: {}
+          description: Success
+      tags:
+      - fake
+      x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/FakeApi.java
@@ -232,7 +232,7 @@ public class FakeApi  {
     @Path("/jsonFormData")
     @Consumes({ "application/x-www-form-urlencoded" })
     
-    @io.swagger.annotations.ApiOperation(value = "test json serialization of form data", notes = "", response = Void.class, tags={ "fake" })
+    @io.swagger.annotations.ApiOperation(value = "test json serialization of form data", notes = "", response = Void.class, tags={ "fake",  })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response testJsonFormData(
@@ -241,5 +241,22 @@ public class FakeApi  {
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testJsonFormData(param,param2,securityContext);
+    }
+    @PUT
+    @Path("/test-query-paramters")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake" })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
+    public Response testQueryParameterCollectionFormat(
+        @ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe,
+        @ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil,
+        @ApiParam(value = "",required=true)@QueryParam("http") List<String> http,
+        @ApiParam(value = "",required=true)@QueryParam("url") List<String> url,
+        @ApiParam(value = "",required=true)@QueryParam("context") List<String> context,
+        @Context SecurityContext securityContext)
+    throws NotFoundException {
+        return delegate.testQueryParameterCollectionFormat(pipe,ioutil,http,url,context,securityContext);
     }
 }

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -54,4 +54,6 @@ public abstract class FakeApiService {
       throws NotFoundException;
       public abstract Response testJsonFormData(String param,String param2,SecurityContext securityContext)
       throws NotFoundException;
+      public abstract Response testQueryParameterCollectionFormat( @NotNull List<String> pipe, @NotNull List<String> ioutil, @NotNull List<String> http, @NotNull List<String> url, @NotNull List<String> context,SecurityContext securityContext)
+      throws NotFoundException;
 }

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -106,4 +106,10 @@ public class FakeApiServiceImpl extends FakeApiService {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
+    @Override
+    public Response testQueryParameterCollectionFormat( @NotNull List<String> pipe,  @NotNull List<String> ioutil,  @NotNull List<String> http,  @NotNull List<String> url,  @NotNull List<String> context, SecurityContext securityContext)
+    throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
 }

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/FakeApi.java
@@ -243,6 +243,23 @@ public class FakeApi  {
     throws NotFoundException {
         return delegate.testJsonFormData(param,param2,securityContext);
     }
+    @PUT
+    @Path("/test-query-paramters")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake",  })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
+    public Response testQueryParameterCollectionFormat(
+        @ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe,
+        @ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil,
+        @ApiParam(value = "",required=true)@QueryParam("http") List<String> http,
+        @ApiParam(value = "",required=true)@QueryParam("url") List<String> url,
+        @ApiParam(value = "",required=true)@QueryParam("context") List<String> context,
+        @Context SecurityContext securityContext)
+    throws NotFoundException {
+        return delegate.testQueryParameterCollectionFormat(pipe,ioutil,http,url,context,securityContext);
+    }
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -55,6 +55,8 @@ public abstract class FakeApiService {
       throws NotFoundException;
       public abstract Response testJsonFormData(String param,String param2,SecurityContext securityContext)
       throws NotFoundException;
+      public abstract Response testQueryParameterCollectionFormat( @NotNull List<String> pipe, @NotNull List<String> ioutil, @NotNull List<String> http, @NotNull List<String> url, @NotNull List<String> context,SecurityContext securityContext)
+      throws NotFoundException;
       public abstract Response uploadFileWithRequiredFile(Long petId,InputStream requiredFileInputStream, FormDataContentDisposition requiredFileDetail,String additionalMetadata,SecurityContext securityContext)
       throws NotFoundException;
 }

--- a/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -108,6 +108,12 @@ public class FakeApiServiceImpl extends FakeApiService {
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
     @Override
+    public Response testQueryParameterCollectionFormat( @NotNull List<String> pipe,  @NotNull List<String> ioutil,  @NotNull List<String> http,  @NotNull List<String> url,  @NotNull List<String> context, SecurityContext securityContext)
+    throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+    @Override
     public Response uploadFileWithRequiredFile(Long petId, InputStream requiredFileInputStream, FormDataContentDisposition requiredFileDetail, String additionalMetadata, SecurityContext securityContext)
     throws NotFoundException {
         // do some magic!

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
@@ -254,4 +254,20 @@ public class FakeApi  {
     throws NotFoundException {
         return delegate.testJsonFormData(param, param2, securityContext);
     }
+    @PUT
+    @Path("/test-query-paramters")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe
+,@ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil
+,@ApiParam(value = "",required=true)@QueryParam("http") List<String> http
+,@ApiParam(value = "",required=true)@QueryParam("url") List<String> url
+,@ApiParam(value = "",required=true)@QueryParam("context") List<String> context
+,@Context SecurityContext securityContext)
+    throws NotFoundException {
+        return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, securityContext);
+    }
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -38,4 +38,5 @@ public abstract class FakeApiService {
     public abstract Response testGroupParameters( @NotNull Integer requiredStringGroup, @NotNull Boolean requiredBooleanGroup, @NotNull Long requiredInt64Group,Integer stringGroup,Boolean booleanGroup,Long int64Group,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testInlineAdditionalProperties(Map<String, String> param,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testJsonFormData(String param,String param2,SecurityContext securityContext) throws NotFoundException;
+    public abstract Response testQueryParameterCollectionFormat( @NotNull List<String> pipe, @NotNull List<String> ioutil, @NotNull List<String> http, @NotNull List<String> url, @NotNull List<String> context,SecurityContext securityContext) throws NotFoundException;
 }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -90,4 +90,9 @@ public class FakeApiServiceImpl extends FakeApiService {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
+    @Override
+    public Response testQueryParameterCollectionFormat( @NotNull List<String> pipe,  @NotNull List<String> ioutil,  @NotNull List<String> http,  @NotNull List<String> url,  @NotNull List<String> context, SecurityContext securityContext) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApi.java
@@ -255,6 +255,22 @@ public class FakeApi  {
     throws NotFoundException {
         return delegate.testJsonFormData(param, param2, securityContext);
     }
+    @PUT
+    @Path("/test-query-paramters")
+    
+    
+    @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake", })
+    @io.swagger.annotations.ApiResponses(value = { 
+        @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe
+,@ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil
+,@ApiParam(value = "",required=true)@QueryParam("http") List<String> http
+,@ApiParam(value = "",required=true)@QueryParam("url") List<String> url
+,@ApiParam(value = "",required=true)@QueryParam("context") List<String> context
+,@Context SecurityContext securityContext)
+    throws NotFoundException {
+        return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, securityContext);
+    }
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApiService.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApiService.java
@@ -39,5 +39,6 @@ public abstract class FakeApiService {
     public abstract Response testGroupParameters( @NotNull Integer requiredStringGroup, @NotNull Boolean requiredBooleanGroup, @NotNull Long requiredInt64Group,Integer stringGroup,Boolean booleanGroup,Long int64Group,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testInlineAdditionalProperties(Map<String, String> param,SecurityContext securityContext) throws NotFoundException;
     public abstract Response testJsonFormData(String param,String param2,SecurityContext securityContext) throws NotFoundException;
+    public abstract Response testQueryParameterCollectionFormat( @NotNull List<String> pipe, @NotNull List<String> ioutil, @NotNull List<String> http, @NotNull List<String> url, @NotNull List<String> context,SecurityContext securityContext) throws NotFoundException;
     public abstract Response uploadFileWithRequiredFile(Long petId,InputStream requiredFileInputStream, FormDataContentDisposition requiredFileDetail,String additionalMetadata,SecurityContext securityContext) throws NotFoundException;
 }

--- a/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/main/java/org/openapitools/api/impl/FakeApiServiceImpl.java
@@ -92,6 +92,11 @@ public class FakeApiServiceImpl extends FakeApiService {
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }
     @Override
+    public Response testQueryParameterCollectionFormat( @NotNull List<String> pipe,  @NotNull List<String> ioutil,  @NotNull List<String> http,  @NotNull List<String> url,  @NotNull List<String> context, SecurityContext securityContext) throws NotFoundException {
+        // do some magic!
+        return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
+    }
+    @Override
     public Response uploadFileWithRequiredFile(Long petId, InputStream requiredFileInputStream, FormDataContentDisposition requiredFileDetail, String additionalMetadata, SecurityContext securityContext) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();

--- a/samples/server/petstore/php-lumen/lib/app/Http/Controllers/FakeApi.php
+++ b/samples/server/petstore/php-lumen/lib/app/Http/Controllers/FakeApi.php
@@ -437,4 +437,48 @@ class FakeApi extends Controller
 
         return response('How about implementing fakeOuterStringSerialize as a post method ?');
     }
+    /**
+     * Operation testQueryParameterCollectionFormat
+     *
+     * .
+     *
+     *
+     * @return Http response
+     */
+    public function testQueryParameterCollectionFormat()
+    {
+        $input = Request::all();
+
+        //path params validation
+
+
+        //not path params validation
+        if (!isset($input['pipe'])) {
+            throw new \InvalidArgumentException('Missing the required parameter $pipe when calling testQueryParameterCollectionFormat');
+        }
+        $pipe = $input['pipe'];
+
+        if (!isset($input['ioutil'])) {
+            throw new \InvalidArgumentException('Missing the required parameter $ioutil when calling testQueryParameterCollectionFormat');
+        }
+        $ioutil = $input['ioutil'];
+
+        if (!isset($input['http'])) {
+            throw new \InvalidArgumentException('Missing the required parameter $http when calling testQueryParameterCollectionFormat');
+        }
+        $http = $input['http'];
+
+        if (!isset($input['url'])) {
+            throw new \InvalidArgumentException('Missing the required parameter $url when calling testQueryParameterCollectionFormat');
+        }
+        $url = $input['url'];
+
+        if (!isset($input['context'])) {
+            throw new \InvalidArgumentException('Missing the required parameter $context when calling testQueryParameterCollectionFormat');
+        }
+        $context = $input['context'];
+
+
+        return response('How about implementing testQueryParameterCollectionFormat as a put method ?');
+    }
 }

--- a/samples/server/petstore/php-lumen/lib/routes/web.php
+++ b/samples/server/petstore/php-lumen/lib/routes/web.php
@@ -106,6 +106,12 @@ $router->post('/v2/fake/outer/number', 'FakeApi@fakeOuterNumberSerialize');
  */
 $router->post('/v2/fake/outer/string', 'FakeApi@fakeOuterStringSerialize');
 /**
+ * put testQueryParameterCollectionFormat
+ * Summary: 
+ * Notes: To test the collection format in query parameters
+ */
+$router->put('/v2/fake/test-query-paramters', 'FakeApi@testQueryParameterCollectionFormat');
+/**
  * patch testClassname
  * Summary: To test class name in snake case
  * Notes: To test class name in snake case

--- a/samples/server/petstore/php-slim/README.md
+++ b/samples/server/petstore/php-slim/README.md
@@ -133,6 +133,7 @@ Class | Method | HTTP request | Description
 *AbstractFakeApi* | **testGroupParameters** | **DELETE** /fake | Fake endpoint to test group parameters (optional)
 *AbstractFakeApi* | **testInlineAdditionalProperties** | **POST** /fake/inline-additionalProperties | test inline additionalProperties
 *AbstractFakeApi* | **testJsonFormData** | **GET** /fake/jsonFormData | test json serialization of form data
+*AbstractFakeApi* | **testQueryParameterCollectionFormat** | **PUT** /fake/test-query-paramters | 
 *AbstractFakeClassnameTags123Api* | **testClassname** | **PATCH** /fake_classname_test | To test class name in snake case
 *AbstractPetApi* | **addPet** | **POST** /pet | Add a new pet to the store
 *AbstractPetApi* | **findPetsByStatus** | **GET** /pet/findByStatus | Finds Pets by status

--- a/samples/server/petstore/php-slim/lib/Api/AbstractFakeApi.php
+++ b/samples/server/petstore/php-slim/lib/Api/AbstractFakeApi.php
@@ -355,4 +355,29 @@ abstract class AbstractFakeApi
 
         return $response->write($message)->withStatus(501);
     }
+
+    /**
+     * PUT testQueryParameterCollectionFormat
+     * Notes: To test the collection format in query parameters
+     *
+     * @param ServerRequestInterface $request  Request
+     * @param ResponseInterface      $response Response
+     * @param array|null             $args     Path arguments
+     *
+     * @return ResponseInterface
+     * @throws Exception to force implementation class to override this method
+     */
+    public function testQueryParameterCollectionFormat(ServerRequestInterface $request, ResponseInterface $response, array $args)
+    {
+        $queryParams = $request->getQueryParams();
+        $pipe = $request->getQueryParam('pipe');
+        $ioutil = $request->getQueryParam('ioutil');
+        $http = $request->getQueryParam('http');
+        $url = $request->getQueryParam('url');
+        $context = $request->getQueryParam('context');
+        $message = "How about implementing testQueryParameterCollectionFormat as a PUT method in OpenAPIServer\Api\FakeApi class?";
+        throw new Exception($message);
+
+        return $response->write($message)->withStatus(501);
+    }
 }

--- a/samples/server/petstore/php-slim/lib/SlimRouter.php
+++ b/samples/server/petstore/php-slim/lib/SlimRouter.php
@@ -211,6 +211,17 @@ class SlimRouter
             ],
         ],
         [
+            'httpMethod' => 'PUT',
+            'basePathWithoutHost' => '/v2',
+            'path' => '/fake/test-query-paramters',
+            'apiPackage' => 'OpenAPIServer\Api',
+            'classname' => 'AbstractFakeApi',
+            'userClassname' => 'FakeApi',
+            'operationId' => 'testQueryParameterCollectionFormat',
+            'authMethods' => [
+            ],
+        ],
+        [
             'httpMethod' => 'PATCH',
             'basePathWithoutHost' => '/v2',
             'path' => '/fake_classname_test',

--- a/samples/server/petstore/php-ze-ph/application/config/path_handler.yml
+++ b/samples/server/petstore/php-ze-ph/application/config/path_handler.yml
@@ -12,6 +12,7 @@ Articus\PathHandler\RouteInjection\Factory:
     - App\Handler\FakeOuterComposite
     - App\Handler\FakeOuterNumber
     - App\Handler\FakeOuterString
+    - App\Handler\FakeTestQueryParamters
     - App\Handler\FakePetIdUploadImageWithRequiredFile
     - App\Handler\FakeClassnameTest
     - App\Handler\Pet
@@ -53,6 +54,7 @@ Zend\ServiceManager\AbstractFactory\ConfigAbstractFactory:
   App\Handler\FakeOuterComposite: []
   App\Handler\FakeOuterNumber: []
   App\Handler\FakeOuterString: []
+  App\Handler\FakeTestQueryParamters: []
   App\Handler\FakePetIdUploadImageWithRequiredFile: []
   App\Handler\FakeClassnameTest: []
   App\Handler\Pet: []

--- a/samples/server/petstore/php-ze-ph/src/App/Handler/FakeTestQueryParamters.php
+++ b/samples/server/petstore/php-ze-ph/src/App/Handler/FakeTestQueryParamters.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Handler;
+
+use Articus\PathHandler\Annotation as PHA;
+use Articus\PathHandler\Consumer as PHConsumer;
+use Articus\PathHandler\Producer as PHProducer;
+use Articus\PathHandler\Attribute as PHAttribute;
+use Articus\PathHandler\Exception as PHException;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @PHA\Route(pattern="/fake/test-query-paramters")
+ */
+class FakeTestQueryParamters
+{
+    /**
+     * @PHA\Put()
+     * @param ServerRequestInterface $request
+     *
+     * @throws PHException\HttpCode 501 if the method is not implemented
+     */
+    public function testQueryParameterCollectionFormat(ServerRequestInterface $request)
+    {
+        //TODO implement method
+        throw new PHException\HttpCode(501, "Not implemented");
+    }
+}

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/api/FakeApi.java
@@ -226,6 +226,17 @@ public interface FakeApi {
     }
 
 
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    default CompletableFuture<ResponseEntity<Void>> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context) {
+        return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED));
+
+    }
+
+
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/api/FakeApi.java
@@ -221,6 +221,17 @@ public interface FakeApi {
     }
 
 
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    default ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+
+    }
+
+
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeApi.java
@@ -158,6 +158,14 @@ public interface FakeApi {
     ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestParam(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestParam(value="param2", required=true)  String param2);
 
 
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context);
+
+
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/api/FakeApiController.java
@@ -118,6 +118,11 @@ public class FakeApiController implements FakeApi {
 
     }
 
+    public ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+
+    }
+
     public ResponseEntity<ModelApiResponse> uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile requiredFile,@ApiParam(value = "Additional data to pass to server") @RequestParam(value="additionalMetadata", required=false)  String additionalMetadata) {
         for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApi.java
@@ -158,6 +158,14 @@ public interface FakeApi {
     ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestParam(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestParam(value="param2", required=true)  String param2);
 
 
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context);
+
+
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/FakeApiController.java
@@ -118,6 +118,11 @@ public class FakeApiController implements FakeApi {
 
     }
 
+    public ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+
+    }
+
     public ResponseEntity<ModelApiResponse> uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile requiredFile,@ApiParam(value = "Additional data to pass to server") @RequestParam(value="additionalMetadata", required=false)  String additionalMetadata) {
         for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
             if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApi.java
@@ -188,6 +188,16 @@ public interface FakeApi {
     }
 
 
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    default ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context) {
+        return getDelegate().testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+    }
+
+
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/FakeApiDelegate.java
@@ -181,6 +181,18 @@ public interface FakeApiDelegate {
     }
 
     /**
+     * @see FakeApi#testQueryParameterCollectionFormat
+     */
+    default ResponseEntity<Void> testQueryParameterCollectionFormat(List<String> pipe,
+        List<String> ioutil,
+        List<String> http,
+        List<String> url,
+        List<String> context) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+
+    }
+
+    /**
      * @see FakeApi#uploadFileWithRequiredFile
      */
     default ResponseEntity<ModelApiResponse> uploadFileWithRequiredFile(Long petId,

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApi.java
@@ -158,6 +158,14 @@ public interface FakeApi {
     ResponseEntity<Void> testJsonFormData(@ApiParam(value = "field1", required=true) @RequestParam(value="param", required=true)  String param,@ApiParam(value = "field2", required=true) @RequestParam(value="param2", required=true)  String param2);
 
 
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context);
+
+
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApiController.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApiController.java
@@ -91,6 +91,10 @@ public class FakeApiController implements FakeApi {
         return delegate.testJsonFormData(param, param2);
     }
 
+    public ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context) {
+        return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context);
+    }
+
     public ResponseEntity<ModelApiResponse> uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update",required=true) @PathVariable("petId") Long petId,@ApiParam(value = "file detail") @Valid @RequestPart("file") MultipartFile requiredFile,@ApiParam(value = "Additional data to pass to server") @RequestParam(value="additionalMetadata", required=false)  String additionalMetadata) {
         return delegate.uploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
     }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApiDelegate.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApiDelegate.java
@@ -118,6 +118,15 @@ public interface FakeApiDelegate {
         String param2);
 
     /**
+     * @see FakeApi#testQueryParameterCollectionFormat
+     */
+    ResponseEntity<Void> testQueryParameterCollectionFormat(List<String> pipe,
+        List<String> ioutil,
+        List<String> http,
+        List<String> url,
+        List<String> context);
+
+    /**
      * @see FakeApi#uploadFileWithRequiredFile
      */
     ResponseEntity<ModelApiResponse> uploadFileWithRequiredFile(Long petId,

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApi.java
@@ -251,6 +251,19 @@ public interface FakeApi {
     }
 
 
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @ApiImplicitParams({
+    })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    default ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+
+    }
+
+
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApi.java
@@ -191,6 +191,16 @@ public interface FakeApi {
     }
 
 
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    default Mono<ResponseEntity<Void>> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context, ServerWebExchange exchange) {
+        return getDelegate().testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, exchange);
+    }
+
+
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApiDelegate.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/api/FakeApiDelegate.java
@@ -219,6 +219,21 @@ public interface FakeApiDelegate {
     }
 
     /**
+     * @see FakeApi#testQueryParameterCollectionFormat
+     */
+    default Mono<ResponseEntity<Void>> testQueryParameterCollectionFormat(List<String> pipe,
+        List<String> ioutil,
+        List<String> http,
+        List<String> url,
+        List<String> context,
+        ServerWebExchange exchange) {
+        Mono<Void> result = Mono.empty();
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_IMPLEMENTED);
+        return result.then(Mono.empty());
+
+    }
+
+    /**
      * @see FakeApi#uploadFileWithRequiredFile
      */
     default Mono<ResponseEntity<ModelApiResponse>> uploadFileWithRequiredFile(Long petId,

--- a/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
@@ -1228,6 +1228,62 @@ paths:
       x-accepts: application/json
       x-tags:
       - tag: fake
+  /fake/test-query-paramters:
+    put:
+      description: To test the collection format in query parameters
+      operationId: testQueryParameterCollectionFormat
+      parameters:
+      - explode: false
+        in: query
+        name: pipe
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - in: query
+        name: ioutil
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+      - in: query
+        name: http
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: spaceDelimited
+      - explode: false
+        in: query
+        name: url
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - explode: true
+        in: query
+        name: context
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      responses:
+        200:
+          content: {}
+          description: Success
+      tags:
+      - fake
+      x-accepts: application/json
+      x-tags:
+      - tag: fake
   /fake/{petId}/uploadImageWithRequiredFile:
     post:
       operationId: uploadFileWithRequiredFile

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/FakeApi.java
@@ -221,6 +221,17 @@ public interface FakeApi {
     }
 
 
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    default ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+
+    }
+
+
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeApi.java
@@ -238,6 +238,18 @@ public interface FakeApi {
 
 
     @ApiVirtual
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    default ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+
+    }
+
+
+    @ApiVirtual
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/FakeApi.java
@@ -221,6 +221,17 @@ public interface FakeApi {
     }
 
 
+    @ApiOperation(value = "", nickname = "testQueryParameterCollectionFormat", notes = "To test the collection format in query parameters", tags={ "fake", })
+    @ApiResponses(value = { 
+        @ApiResponse(code = 200, message = "Success") })
+    @RequestMapping(value = "/fake/test-query-paramters",
+        method = RequestMethod.PUT)
+    default ResponseEntity<Void> testQueryParameterCollectionFormat(@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "pipe", required = true) List<String> pipe,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "ioutil", required = true) List<String> ioutil,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "http", required = true) List<String> http,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "url", required = true) List<String> url,@NotNull @ApiParam(value = "", required = true) @Valid @RequestParam(value = "context", required = true) List<String> context) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+
+    }
+
+
     @ApiOperation(value = "uploads an image (required)", nickname = "uploadFileWithRequiredFile", notes = "", response = ModelApiResponse.class, authorizations = {
         @Authorization(value = "petstore_auth", scopes = {
             @AuthorizationScope(scope = "write:pets", description = "modify pets in your account"),


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- add test cases to cover different collection formats
- test variable naming for Go generator
- add "space" (collection format) support to Haskell client generator (cc @jonschoning)