### PR TITLE
[BUG][Python-Flask] Primitive type bytearray deserialization missing in util.py. #2724

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-flask/util.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/util.mustache
@@ -16,7 +16,7 @@ def _deserialize(data, klass):
     if data is None:
         return None
 
-    if klass in six.integer_types or klass in (float, str, bool):
+    if klass in six.integer_types or klass in (float, str, bool, bytearray):
         return _deserialize_primitive(data, klass)
     elif klass == object:
         return _deserialize_object(data)

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/controllers/pet_controller.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/controllers/pet_controller.py
@@ -49,15 +49,13 @@ def find_pets_by_status(status):  # noqa: E501
     return 'do some magic!'
 
 
-def find_pets_by_tags(tags, max_count=None):  # noqa: E501
+def find_pets_by_tags(tags):  # noqa: E501
     """Finds Pets by tags
 
     Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing. # noqa: E501
 
     :param tags: Tags to filter by
     :type tags: List[str]
-    :param max_count: Maximum number of items to return
-    :type max_count: int
 
     :rtype: List[Pet]
     """

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/openapi/openapi.yaml
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/openapi/openapi.yaml
@@ -115,15 +115,6 @@ paths:
             type: string
           type: array
         style: form
-      - description: Maximum number of items to return
-        explode: true
-        in: query
-        name: maxCount
-        required: false
-        schema:
-          format: int32
-          type: integer
-        style: form
       responses:
         200:
           content:

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/test/test_pet_controller.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/test/test_pet_controller.py
@@ -89,8 +89,7 @@ class TestPetController(BaseTestCase):
 
         Finds Pets by tags
         """
-        query_string = [('tags', 'tags_example'),
-                        ('maxCount', 56)]
+        query_string = [('tags', 'tags_example')]
         headers = { 
             'Accept': 'application/json',
             'Authorization': 'Bearer special-key',

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/util.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/util.py
@@ -16,7 +16,7 @@ def _deserialize(data, klass):
     if data is None:
         return None
 
-    if klass in six.integer_types or klass in (float, str, bool):
+    if klass in six.integer_types or klass in (float, str, bool, bytearray):
         return _deserialize_primitive(data, klass)
     elif klass == object:
         return _deserialize_object(data)

--- a/samples/server/petstore/python-flask/openapi_server/util.py
+++ b/samples/server/petstore/python-flask/openapi_server/util.py
@@ -16,7 +16,7 @@ def _deserialize(data, klass):
     if data is None:
         return None
 
-    if klass in six.integer_types or klass in (float, str, bool):
+    if klass in six.integer_types or klass in (float, str, bool, bytearray):
         return _deserialize_primitive(data, klass)
     elif klass == object:
         return _deserialize_object(data)


### PR DESCRIPTION
### PR checklist

- [ X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01)

### Description of the PR

This PR fixes the issue #2724 using the suggested fix from @dannmartens adding "bytearray" to the template for util.py
