### PR TITLE
[Ruby][faraday] Properly pass verify_mode to faraday

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -6,7 +6,7 @@
       ssl_options = {
         :ca_file => @config.ssl_ca_file,
         :verify => @config.ssl_verify,
-        :verify => @config.ssl_verify_mode,
+        :verify_mode => @config.ssl_verify_mode,
         :client_cert => @config.ssl_client_cert,
         :client_key => @config.ssl_client_key
       }

--- a/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/openapi3/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -49,7 +49,7 @@ module Petstore
       ssl_options = {
         :ca_file => @config.ssl_ca_file,
         :verify => @config.ssl_verify,
-        :verify => @config.ssl_verify_mode,
+        :verify_mode => @config.ssl_verify_mode,
         :client_cert => @config.ssl_client_cert,
         :client_key => @config.ssl_client_key
       }


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This seems to be the correct attribute based on the faraday ssl options here:
https://github.com/lostisland/faraday/blob/1c3bf50d8a28d71b11fca897ebdc71577c33ec6a/lib/faraday/options/ssl_options.rb#L15

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

