### PR TITLE
[java-client][jersey2][resteasy] add support for TRACE method

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -721,6 +721,8 @@ public class ApiClient {
         response = invocationBuilder.method("PATCH", entity);
       } else if ("HEAD".equals(method)) {
         response = invocationBuilder.head();
+      } else if ("TRACE".equals(method)) {
+        response = invocationBuilder.trace();
       } else {
         throw new ApiException(500, "unknown method type " + method);
       }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -666,6 +666,8 @@ public class ApiClient {
       response = invocationBuilder.header("X-HTTP-Method-Override", "PATCH").post(entity);
     } else if ("HEAD".equals(method)) {
       response = invocationBuilder.head();
+    } else if ("TRACE".equals(method)) {
+      response = invocationBuilder.trace();
     } else {
       throw new ApiException(500, "unknown method type " + method);
     }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiClient.java
@@ -705,6 +705,8 @@ public class ApiClient {
         response = invocationBuilder.method("PATCH", entity);
       } else if ("HEAD".equals(method)) {
         response = invocationBuilder.head();
+      } else if ("TRACE".equals(method)) {
+        response = invocationBuilder.trace();
       } else {
         throw new ApiException(500, "unknown method type " + method);
       }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -705,6 +705,8 @@ public class ApiClient {
         response = invocationBuilder.method("PATCH", entity);
       } else if ("HEAD".equals(method)) {
         response = invocationBuilder.head();
+      } else if ("TRACE".equals(method)) {
+        response = invocationBuilder.trace();
       } else {
         throw new ApiException(500, "unknown method type " + method);
       }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java
@@ -705,6 +705,8 @@ public class ApiClient {
         response = invocationBuilder.method("PATCH", entity);
       } else if ("HEAD".equals(method)) {
         response = invocationBuilder.head();
+      } else if ("TRACE".equals(method)) {
+        response = invocationBuilder.trace();
       } else {
         throw new ApiException(500, "unknown method type " + method);
       }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
@@ -657,6 +657,8 @@ public class ApiClient {
       response = invocationBuilder.header("X-HTTP-Method-Override", "PATCH").post(entity);
     } else if ("HEAD".equals(method)) {
       response = invocationBuilder.head();
+    } else if ("TRACE".equals(method)) {
+      response = invocationBuilder.trace();
     } else {
       throw new ApiException(500, "unknown method type " + method);
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala  (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01)  @karismann (2019/03) @Zomzog (2019/04)


### Description of the PR

See issue #3647

Follow up of #3648 for java client generators.