### PR TITLE
cpp-qt5-client: fix memory leak in api-body

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -102,7 +102,7 @@ void
       }
     }
     {{/collectionFormat}}{{/queryParams}}
-    {{prefix}}HttpRequestWorker *worker = new {{prefix}}HttpRequestWorker();
+    {{prefix}}HttpRequestWorker *worker = new {{prefix}}HttpRequestWorker(this);
     worker->setTimeOut(timeout);
     {{prefix}}HttpRequestInput input(fullPath, "{{httpMethod}}");
     {{#formParams}}

--- a/samples/client/petstore/cpp-qt5/client/OAIPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIPetApi.cpp
@@ -56,7 +56,7 @@ OAIPetApi::addPet(const OAIPet& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/pet");
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "POST");
 
@@ -108,7 +108,7 @@ OAIPetApi::deletePet(const qint64& pet_id, const QString& api_key) {
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(pet_id)));
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "DELETE");
 
@@ -196,7 +196,7 @@ OAIPetApi::findPetsByStatus(const QList<QString>& status) {
       }
     }
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "GET");
 
@@ -291,7 +291,7 @@ OAIPetApi::findPetsByTags(const QList<QString>& tags) {
       }
     }
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "GET");
 
@@ -349,7 +349,7 @@ OAIPetApi::getPetById(const qint64& pet_id) {
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(pet_id)));
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "GET");
 
@@ -395,7 +395,7 @@ OAIPetApi::updatePet(const OAIPet& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/pet");
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "PUT");
 
@@ -447,7 +447,7 @@ OAIPetApi::updatePetWithForm(const qint64& pet_id, const QString& name, const QS
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(pet_id)));
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "POST");
     if (name != nullptr) {
@@ -501,7 +501,7 @@ OAIPetApi::uploadFile(const qint64& pet_id, const QString& additional_metadata, 
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(pet_id)));
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "POST");
     if (additional_metadata != nullptr) {

--- a/samples/client/petstore/cpp-qt5/client/OAIStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIStoreApi.cpp
@@ -59,7 +59,7 @@ OAIStoreApi::deleteOrder(const QString& order_id) {
     order_idPathParam.append("orderId").append("}");
     fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(order_id)));
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "DELETE");
 
@@ -104,7 +104,7 @@ OAIStoreApi::getInventory() {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/store/inventory");
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "GET");
 
@@ -162,7 +162,7 @@ OAIStoreApi::getOrderById(const qint64& order_id) {
     order_idPathParam.append("orderId").append("}");
     fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(order_id)));
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "GET");
 
@@ -208,7 +208,7 @@ OAIStoreApi::placeOrder(const OAIOrder& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/store/order");
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "POST");
 

--- a/samples/client/petstore/cpp-qt5/client/OAIUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/OAIUserApi.cpp
@@ -56,7 +56,7 @@ OAIUserApi::createUser(const OAIUser& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/user");
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "POST");
 
@@ -105,7 +105,7 @@ OAIUserApi::createUsersWithArrayInput(const QList<OAIUser>& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/user/createWithArray");
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "POST");
 
@@ -155,7 +155,7 @@ OAIUserApi::createUsersWithListInput(const QList<OAIUser>& body) {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/user/createWithList");
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "POST");
 
@@ -208,7 +208,7 @@ OAIUserApi::deleteUser(const QString& username) {
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(username)));
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "DELETE");
 
@@ -256,7 +256,7 @@ OAIUserApi::getUserByName(const QString& username) {
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(username)));
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "GET");
 
@@ -318,7 +318,7 @@ OAIUserApi::loginUser(const QString& username, const QString& password) {
         .append("=")
         .append(QUrl::toPercentEncoding(::OpenAPI::toStringValue(password)));
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "GET");
 
@@ -365,7 +365,7 @@ OAIUserApi::logoutUser() {
     QString fullPath;
     fullPath.append(this->host).append(this->basePath).append("/user/logout");
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "GET");
 
@@ -413,7 +413,7 @@ OAIUserApi::updateUser(const QString& username, const OAIUser& body) {
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::OpenAPI::toStringValue(username)));
     
-    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker();
+    OAIHttpRequestWorker *worker = new OAIHttpRequestWorker(this);
     worker->setTimeOut(timeout);
     OAIHttpRequestInput input(fullPath, "PUT");
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

I found a memory leak thanks to [valgrind](http://www.valgrind.org). Eventually it could be possible to use valgrind in the CI to make sure that the change doesn't bring more memory leaks.

@ravinikam @stkrwork @etherealjoy @muttleyxd