### PR TITLE
cpp-qt5-client: add valgrind memory test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,8 @@ before_install:
   # - Rely on `kerl` for [pre-compiled versions available](https://docs.travis-ci.com/user/languages/erlang#Choosing-OTP-releases-to-test-against). Rely on installation path chosen by [`travis-erlang-builder`](https://github.com/travis-ci/travis-erlang-builder/blob/e6d016b1a91ca7ecac5a5a46395bde917ea13d36/bin/compile#L18).
   # - . ~/otp/18.2.1/activate && erl -version
   #- curl -f -L -o ./rebar3 https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3 && ./rebar3 version && export PATH="${TRAVIS_BUILD_DIR}:$PATH"
+  # install valgrind for C++ memory test
+  - sudo apt-get install valgrind
   # install Qt 5.10
   - sudo add-apt-repository --yes ppa:beineri/opt-qt-5.10.1-trusty
   - sudo apt-get update -qq

--- a/samples/client/petstore/cpp-qt5/PetStore/PetStore.pro
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetStore.pro
@@ -26,3 +26,6 @@ SOURCES += main.cpp \
 HEADERS += PetApiTests.h \
            StoreApiTests.h \
            UserApiTests.h
+
+# Disable optimisation for better valgrind report
+QMAKE_CXXFLAGS_DEBUG += -O0

--- a/samples/client/petstore/cpp-qt5/build-and-test.bash
+++ b/samples/client/petstore/cpp-qt5/build-and-test.bash
@@ -2,10 +2,41 @@
 
 set -e
 
-mkdir build
+mkdir -p build
 cd build
 
-qmake ../PetStore/PetStore.pro
+qmake ../PetStore/PetStore.pro CONFIG+=debug
+
 make
 
-./PetStore
+valgrind --leak-check=full ./PetStore |& tee result.log || exit 1
+
+echo "Make sure the tests are launched:"
+testCount=$(cat result.log | grep 'Finished testing of' | wc -l)
+if [ $testCount == 3 ]
+then
+  echo "Ok"
+else
+  echo "The tests were not run!!!"
+  exit 1
+fi
+
+echo "Make sure the tests passed:"
+successCount=$(cat result.log | grep '0 failed' | wc -l)
+if [ $successCount == 3 ]
+then
+  echo "Ok"
+else
+  echo "The tests failed!!!"
+  exit 1
+fi
+
+echo "Check if no memory leaks occured:"
+leakCount=$(cat result.log | grep 'lost: 0 bytes in 0 blocks' | wc -l)
+if [ $leakCount == 3 ]
+then
+  echo "Ok"
+else
+  echo "There was memory leaks!!!"
+  exit 1
+fi


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR perfoms valgrind test for Qt5 client test. https://github.com/OpenAPITools/openapi-generator/pull/3661 is not merge so it should fail (I'll rebase once it is merged).

What do you think of the way I handle valgrind result?

@ravinikam @stkrwork @etherealjoy @muttleyxd