### PR TITLE
[Rust Server] Support types with additional properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -51,9 +51,19 @@ impl ::std::str::FromStr for {{{classname}}} {
         }
     }
 }
-{{/isEnum}}{{^isEnum}}{{#dataType}}{{! newtype}}#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+{{/isEnum}}
+{{^isEnum}}
+{{#dataType}}
+{{#isMapModel}}
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+{{/isMapModel}}
+{{^isMapModel}}
+#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+{{/isMapModel}}
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
-{{#xmlName}}#[serde(rename = "{{{xmlName}}}")]{{/xmlName}}
+{{#xmlName}}
+#[serde(rename = "{{{xmlName}}}")]
+{{/xmlName}}
 pub struct {{{classname}}}({{{dataType}}});
 
 impl ::std::convert::From<{{{dataType}}}> for {{{classname}}} {

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -221,7 +221,6 @@ impl DuplicateXmlObject {
 /// Test a model containing a UUID
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
-
 pub struct UuidObject(uuid::Uuid);
 
 impl ::std::convert::From<uuid::Uuid> for UuidObject {

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -1066,7 +1066,6 @@ impl Order {
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
-
 pub struct OuterBoolean(bool);
 
 impl ::std::convert::From<bool> for OuterBoolean {
@@ -1190,7 +1189,6 @@ impl OuterEnum {
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
-
 pub struct OuterNumber(f64);
 
 impl ::std::convert::From<f64> for OuterNumber {
@@ -1231,7 +1229,6 @@ impl OuterNumber {
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
-
 pub struct OuterString(String);
 
 impl ::std::convert::From<String> for OuterString {

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
@@ -36,15 +36,34 @@ impl ANullableContainer {
 /// An additionalPropertiesObject
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
-pub struct AdditionalPropertiesObject {
-}
+pub struct AdditionalPropertiesObject(HashMap<String, String>);
 
-impl AdditionalPropertiesObject {
-    pub fn new() -> AdditionalPropertiesObject {
-        AdditionalPropertiesObject {
-        }
+impl ::std::convert::From<HashMap<String, String>> for AdditionalPropertiesObject {
+    fn from(x: HashMap<String, String>) -> Self {
+        AdditionalPropertiesObject(x)
     }
 }
+
+
+impl ::std::convert::From<AdditionalPropertiesObject> for HashMap<String, String> {
+    fn from(x: AdditionalPropertiesObject) -> Self {
+        x.0
+    }
+}
+
+impl ::std::ops::Deref for AdditionalPropertiesObject {
+    type Target = HashMap<String, String>;
+    fn deref(&self) -> &HashMap<String, String> {
+        &self.0
+    }
+}
+
+impl ::std::ops::DerefMut for AdditionalPropertiesObject {
+    fn deref_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.0
+    }
+}
+
 
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

   - @frol, @farcaller, @bjgill 

### Description of the PR

This adds support for types which only contain additional properties, which is a common use case. It doesn't handle the thornier case of additional properties within a type with defined properties, which is allowed by the OpenAPI spec, but is more dubious API design in practice (as the API is mixing schema-ed and un-schema-ed data).

Note, this will also only fix the case where the type is defined (e.g. string) - if it's untyped, it remains unsupported.

This thus partially fixes https://github.com/OpenAPITools/openapi-generator/issues/318

An example of something this will support is already defined in the sample API:

```
  additionalPropertiesObject:
    description: An additionalPropertiesObject
    type: object
    additionalProperties:
      type: string
```