### PR TITLE
cpp-qt5-client: Improve tests

### DIFF
--- a/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
@@ -1,15 +1,7 @@
 #include "PetApiTests.h"
 
-#include <QJsonDocument>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
-#include <QDebug>
-
-PetApiTests::PetApiTests () {}
-
-PetApiTests::~PetApiTests () {
-
-}
+#include <QTest>
+#include <QTimer>
 
 OAIPetApi* PetApiTests::getApi() {
     auto api = new OAIPetApi();
@@ -20,96 +12,65 @@ OAIPetApi* PetApiTests::getApi() {
 OAIPet PetApiTests::createRandomPet() {
     OAIPet pet;
     qint64 id = QDateTime::currentMSecsSinceEpoch();
-    pet.setName(QString("monster"));
+    pet.setName("monster");
     pet.setId(id);
-    pet.setStatus(QString("freaky"));
+    pet.setStatus("freaky");
     return pet;
-}
-
-void PetApiTests::runTests() {
-    PetApiTests* tests = new PetApiTests();
-    QTest::qExec(tests);
-    delete tests;
 }
 
 void PetApiTests::findPetsByStatusTest() {
     OAIPetApi* api = getApi();
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(14000);
-    timer.setSingleShot(true);
+    bool petFound = false;
 
-    auto validator = [this](QList<OAIPet> pets) {
+    connect(api, &OAIPetApi::findPetsByStatusSignal, [&](QList<OAIPet> pets) {
+        petFound = true;
         foreach(OAIPet pet, pets) {
             QVERIFY(pet.getStatus().startsWith("available") || pet.getStatus().startsWith("sold"));
         }
-        emit quit();
-    };
-    auto finalizer = [&]() {
         loop.quit();
-    };
-    connect(this, &PetApiTests::quit, finalizer);
-    connect(api, &OAIPetApi::findPetsByStatusSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    });
 
-    QList<QString> status;
-    QString available("available");
-    QString sold("sold");
-    status.append(available);
-    status.append(sold);
-    api->findPetsByStatus(status);
-    timer.start();
+    api->findPetsByStatus({"available", "sold"});
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(petFound, "didn't finish within timeout");
     delete api;
 }
 
 void PetApiTests::createAndGetPetTest() {
     OAIPetApi* api = getApi();
-
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(14000);
-    timer.setSingleShot(true);
+    bool petCreated = false;
 
-    auto validator = [this]() {
+    connect(api, &OAIPetApi::addPetSignal, [&]() {
         // pet created
-        emit quit();
-    };
-
-    auto finalizer = [&]() {
+        petCreated = true;
         loop.quit();
-    };
-    connect(this, &PetApiTests::quit, finalizer);
-    connect(api, &OAIPetApi::addPetSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    });
 
     OAIPet pet = createRandomPet();
     qint64 id = pet.getId();
 
     api->addPet(pet);
-    timer.start();
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
+    QVERIFY2(petCreated, "didn't finish within timeout");
 
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
+    bool petFetched = false;
 
-    auto getPetValidator = [this](OAIPet pet) {
+    connect(api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
         QVERIFY(pet.getId() > 0);
         QVERIFY(pet.getStatus().compare("freaky") == 0);
-        emit quit();
-    };
-
-    connect(api, &OAIPetApi::getPetByIdSignal, this, getPetValidator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+        loop.quit();
+        petFetched = true;
+    });
 
     api->getPetById(id);
-    timer.start();
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(petFetched, "didn't finish within timeout");
+
     delete api;
 }
 
@@ -120,76 +81,61 @@ void PetApiTests::updatePetTest() {
     OAIPet petToCheck;
     qint64 id = pet.getId();
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(100000);
-    timer.setSingleShot(true);
+    bool petAdded = false;
 
-    auto validator = [this]() {
-        emit quit();
-    };
-    auto finalizer = [&]() {
+    connect(api, &OAIPetApi::addPetSignal, [&](){
+        petAdded = true;
         loop.quit();
-    };
-    connect(this, &PetApiTests::quit, finalizer);
-    connect(api, &OAIPetApi::addPetSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    });
 
     // create pet
     api->addPet(pet);
-    timer.start();
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
+    QVERIFY2(petAdded, "didn't finish within timeout");
 
     // fetch it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
 
-    auto fetchPet = [&](OAIPet pet) {
-        petToCheck = pet;
-        emit quit();
-    };
-    connect(api, &OAIPetApi::getPetByIdSignal, this, fetchPet);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    bool petFetched = false;
+    connect(api, &OAIPetApi::getPetByIdSignal, this, [&](OAIPet pet) {
+            petFetched = true;
+            petToCheck = pet;
+            loop.quit();
+    });
 
     // create pet
     api->getPetById(id);
-    timer.start();
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
+    QVERIFY2(petFetched, "didn't finish within timeout");
 
     // update it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
-    auto updatePetTest = [this]() {
-        emit quit();
-    };
-
-    connect(api, &OAIPetApi::updatePetSignal, this, updatePetTest);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    bool petUpdated = false;
+    connect(api, &OAIPetApi::updatePetSignal, [&]() {
+        petUpdated = true;
+        loop.quit();
+    });
 
     // update pet
     petToCheck.setStatus(QString("scary"));
     api->updatePet(petToCheck);
-    timer.start();
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
+    QVERIFY2(petUpdated, "didn't finish within timeout");
 
     // check it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
-
-    auto fetchPet2 = [&](OAIPet pet) {
+    bool petFetched2 = false;
+    connect(api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
+        petFetched2 = true;
         QVERIFY(pet.getId() == petToCheck.getId());
         QVERIFY(pet.getStatus().compare(petToCheck.getStatus()) == 0);
-        emit quit();
-    };
-    connect(api, &OAIPetApi::getPetByIdSignal, this, fetchPet2);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+        loop.quit();
+    });
     api->getPetById(id);
-    timer.start();
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(petFetched2, "didn't finish within timeout");
+
     delete api;
 }
 
@@ -200,70 +146,57 @@ void PetApiTests::updatePetWithFormTest() {
     OAIPet petToCheck;
     qint64 id = pet.getId();
     QEventLoop loop;
-    QTimer timer;
 
     // create pet
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
-
-    auto validator = [this ]() {
-        emit quit();
-    };
-    auto finalizer = [&]() {
+    bool petAdded = false;
+    connect(api, &OAIPetApi::addPetSignal, [&](){
+        petAdded = true;
         loop.quit();
-    };
-    connect(this, &PetApiTests::quit, finalizer);
-    connect(api, &OAIPetApi::addPetSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    });
+
     api->addPet(pet);
-    timer.start();
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
+    QVERIFY2(petAdded, "didn't finish within timeout");
 
     // fetch it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
-
-    auto fetchPet = [&](OAIPet pet) {
+    bool petFetched = false;
+    connect(api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
+        petFetched = true;
         petToCheck = pet;
-        emit quit();
-    };
-    connect(api, &OAIPetApi::getPetByIdSignal, this, fetchPet);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+        loop.quit();
+    });
 
     api->getPetById(id);
-    timer.start();
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
+    QVERIFY2(petFetched, "didn't finish within timeout");
 
     // update it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
-
-    connect(api, &OAIPetApi::updatePetWithFormSignal, this, [this](){emit quit();});
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    bool petUpdated = false;
+    connect(api, &OAIPetApi::updatePetWithFormSignal, [&](){
+        petUpdated = true;
+        loop.quit();
+    });
 
     QString name("gorilla");
     api->updatePetWithForm(id, name, nullptr);
-    timer.start();
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
+    QVERIFY2(petUpdated, "didn't finish within timeout");
 
     // fetch it
-    timer.setInterval(1000);
-    timer.setSingleShot(true);
-
-    auto fetchUpdatedPet = [this](OAIPet pet) {
+    bool petUpdated2 = false;
+    connect(api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
+        petUpdated2 = true;
         QVERIFY(pet.getName().compare(QString("gorilla")) == 0);
-        emit quit();
-    };
-    connect(api, &OAIPetApi::getPetByIdSignal, this, fetchUpdatedPet);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+        loop.quit();
+    });
 
     api->getPetById(id);
-    timer.start();
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(petUpdated2, "didn't finish within timeout");
+
     delete api;
 }

--- a/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.h
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.h
@@ -1,28 +1,14 @@
-#ifndef PETAPITESTS_H
-#define PETAPITESTS_H
-
-#include <QtTest/QtTest>
-#include <QTimer>
+#pragma once
 
 #include "../client/OAIPetApi.h"
 
 using namespace OpenAPI;
 
 class PetApiTests: public QObject {
-Q_OBJECT
-public:
-    PetApiTests();
-    virtual ~PetApiTests();
+    Q_OBJECT
 
-    static void runTests();
-
-private:
     OAIPetApi* getApi();
     OAIPet createRandomPet();
-
-signals:
-    void quit();
-    bool success();
 
 private slots:
     void findPetsByStatusTest();
@@ -30,5 +16,3 @@ private slots:
     void updatePetTest();
     void updatePetWithFormTest();
 };
-
-#endif // PETAPITESTS_H

--- a/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.cpp
@@ -1,15 +1,8 @@
 #include "StoreApiTests.h"
 
-#include <QJsonDocument>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
+#include <QTest>
+#include <QTimer>
 #include <QDebug>
-
-StoreApiTests::StoreApiTests () {}
-
-StoreApiTests::~StoreApiTests () {
-
-}
 
 OAIStoreApi* StoreApiTests::getApi() {
     auto api = new OAIStoreApi();
@@ -17,101 +10,76 @@ OAIStoreApi* StoreApiTests::getApi() {
     return api;
 }
 
-void StoreApiTests::runTests() {
-    StoreApiTests* tests = new StoreApiTests();
-    QTest::qExec(tests);
-    delete tests;
-}
-
 void StoreApiTests::placeOrderTest() {
     auto api = getApi();
-
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(14000);
-    timer.setSingleShot(true);
+    bool orderPlaced = false;
 
-    auto validator = [this](OAIOrder order) {
+    connect(api, &OAIStoreApi::placeOrderSignal, [&](OAIOrder order) {
+        orderPlaced = true;
         QVERIFY(order.getPetId() == 10000);
         QVERIFY((order.getId() == 500));
         qDebug() << order.getShipDate();
-        emit quit();
-    };
-    auto finalizer = [&]() {
         loop.quit();
-    };
-    connect(this, &StoreApiTests::quit, finalizer);
-    connect(api, &OAIStoreApi::placeOrderSignal, this, validator);
-    connect(api, &OAIStoreApi::placeOrderSignalE, this, finalizer);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    });
+    connect(api, &OAIStoreApi::placeOrderSignalE, [&](){
+        QFAIL("shouldn't trigger error");
+        loop.quit();
+    });
 
     OAIOrder order;
     order.setId(500);
     order.setQuantity(10);
     order.setPetId(10000);
     order.setComplete(false);
-    order.setStatus(QString("shipping"));
+    order.setStatus("shipping");
     order.setShipDate(QDateTime::currentDateTime());
     api->placeOrder(order);
-    timer.start();
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(orderPlaced, "didn't finish within timeout");
+
     delete api;
 }
 
 void StoreApiTests::getOrderByIdTest() {
     auto api = getApi();
-
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(14000);
-    timer.setSingleShot(true);
+    bool orderFetched = false;
 
-    auto validator = [this](OAIOrder order) {
+    connect(api, &OAIStoreApi::getOrderByIdSignal, [&](OAIOrder order) {
+        orderFetched = true;
         QVERIFY(order.getPetId() == 10000);
         QVERIFY((order.getId() == 500));
         qDebug() << order.getShipDate();
-        emit quit();
-    };
-    auto finalizer = [&]() {
         loop.quit();
-    };
-    connect(this, &StoreApiTests::quit, finalizer);
-    connect(api, &OAIStoreApi::getOrderByIdSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    });
+
     api->getOrderById(500);
-    timer.start();
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(orderFetched, "didn't finish within timeout");
+
     delete api;
 }
 
 void StoreApiTests::getInventoryTest() {
     auto api = getApi();
-
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(14000);
-    timer.setSingleShot(true);
+    bool inventoryFetched = false;
 
-    auto validator = [this](QMap<QString, qint32> status) {
+    connect(api, &OAIStoreApi::getInventorySignal, [&](QMap<QString, qint32> status) {
+        inventoryFetched = true;
         for(const auto& key : status.keys()) {
             qDebug() << (key) << " Quantities " << status.value(key);
         }
-        emit quit();
-    };
-    auto finalizer = [&]() {
         loop.quit();
-    };
-    connect(this, &StoreApiTests::quit, finalizer);
-    connect(api, &OAIStoreApi::getInventorySignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    });
+
     api->getInventory();
-    timer.start();
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(inventoryFetched, "didn't finish within timeout");
+
     delete api;
 }

--- a/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.h
+++ b/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.h
@@ -1,30 +1,16 @@
-#ifndef STOREAPITESTS_H
-#define STOREAPITESTS_H
-#include <QtTest/QtTest>
-#include <QTimer>
+#pragma once
 
 #include "../client/OAIStoreApi.h"
 
 using namespace OpenAPI;
 
 class StoreApiTests: public QObject {
-Q_OBJECT
-public:
-    StoreApiTests();
-    virtual ~StoreApiTests();
+    Q_OBJECT
 
-    static void runTests();
-
-private:
     OAIStoreApi* getApi();
-signals:
-    void quit();
-    bool success();
 
 private slots:
     void placeOrderTest();
     void getOrderByIdTest();
     void getInventoryTest();
 };
-
-#endif // STOREAPITESTS_H

--- a/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.cpp
@@ -1,16 +1,8 @@
 #include "UserApiTests.h"
 
-#include <stdlib.h>
-#include <QJsonDocument>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
+#include <QTest>
+#include <QTimer>
 #include <QDebug>
-
-UserApiTests::UserApiTests () {}
-
-UserApiTests::~UserApiTests () {
-    exit(0);
-}
 
 OAIUserApi* UserApiTests::getApi() {
     auto api = new OAIUserApi();
@@ -18,21 +10,15 @@ OAIUserApi* UserApiTests::getApi() {
     return api;
 }
 
-void UserApiTests::runTests() {
-    UserApiTests* tests = new UserApiTests();
-    QTest::qExec(tests);
-    delete tests;
-}
-
 OAIUser UserApiTests::createRandomUser() {
     OAIUser user;
     user.setId(QDateTime::currentMSecsSinceEpoch());
-    user.setEmail(QString("Jane.Doe@openapitools.io"));
-    user.setFirstName(QString("Jane"));
-    user.setLastName(QString("Doe"));
-    user.setPhone(QString("123456789"));
-    user.setUsername(QString("janedoe"));
-    user.setPassword(QString("secretPassword"));
+    user.setEmail("Jane.Doe@openapitools.io");
+    user.setFirstName("Jane");
+    user.setLastName("Doe");
+    user.setPhone("123456789");
+    user.setUsername("janedoe");
+    user.setPassword("secretPassword");
     user.setUserStatus(static_cast<int>(rand()));
     return user;
 }
@@ -40,213 +26,160 @@ OAIUser UserApiTests::createRandomUser() {
 void UserApiTests::createUserTest(){
     auto api = getApi();
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(14000);
-    timer.setSingleShot(true);
+    bool userCreated = false;
 
-    auto validator = [this]() {
-        emit quit();
-    };
-    auto finalizer = [&]() {
-        loop.quit();
-    };
-    connect(this, &UserApiTests::quit, finalizer);
-    connect(api, &OAIUserApi::createUserSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    connect(api, &OAIUserApi::createUserSignal, [&](){
+            userCreated = true;
+            loop.quit();
+    });
 
     api->createUser(createRandomUser());
-    timer.start();
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(userCreated, "didn't finish within timeout");
+
     delete api;
 }
 
 void UserApiTests::createUsersWithArrayInputTest(){
     auto api = getApi();
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(14000);
-    timer.setSingleShot(true);
+    bool usersCreated = false;
 
-    auto validator = [this]() {
-        emit quit();
-    };
-    auto finalizer = [&]() {
-        loop.quit();
-    };
-    connect(this, &UserApiTests::quit, finalizer);
-    connect(api, &OAIUserApi::createUsersWithArrayInputSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    connect(api, &OAIUserApi::createUsersWithArrayInputSignal, [&](){
+            usersCreated = true;
+            loop.quit();
+    });
+
     QList<OAIUser> users;
     users.append(createRandomUser());
     users.append(createRandomUser());
     users.append(createRandomUser());
     api->createUsersWithArrayInput(users);
-    timer.start();
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(usersCreated, "didn't finish within timeout");
+
     delete api;
 }
 
 void UserApiTests::createUsersWithListInputTest(){
     auto api = getApi();
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(14000);
-    timer.setSingleShot(true);
+    bool usersCreated = false;
 
-    auto validator = [this]() {
-        emit quit();
-    };
-    auto finalizer = [&]() {
-        loop.quit();
-    };
-    connect(this, &UserApiTests::quit, finalizer);
-    connect(api, &OAIUserApi::createUsersWithListInputSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    connect(api, &OAIUserApi::createUsersWithListInputSignal, [&](){
+            usersCreated = true;
+            loop.quit();
+    });
+
     QList<OAIUser> users;
     auto johndoe = createRandomUser();
-    johndoe.setUsername(QString("johndoe"));
+    johndoe.setUsername("johndoe");
     auto rambo = createRandomUser();
-    rambo.setUsername(QString("rambo"));
+    rambo.setUsername("rambo");
     users.append(johndoe);
     users.append(rambo);
     users.append(createRandomUser());
     api->createUsersWithListInput(users);
-    timer.start();
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(usersCreated, "didn't finish within timeout");
+
     delete api;
 }
 
 void UserApiTests::deleteUserTest(){
     auto api = getApi();
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(14000);
-    timer.setSingleShot(true);
+    bool userDeleted = false;
 
-    auto validator = [this]() {
-        emit quit();
-    };
-    auto finalizer = [&]() {
-        loop.quit();
-    };
-    connect(this, &UserApiTests::quit, finalizer);
-    connect(api, &OAIUserApi::deleteUserSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    connect(api, &OAIUserApi::deleteUserSignal, [&](){
+            userDeleted = true;
+            loop.quit();
+    });
 
-    api->deleteUser(QString("rambo"));
-    timer.start();
+    api->deleteUser("rambo");
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(userDeleted, "didn't finish within timeout");
+
     delete api;
 }
 
 void UserApiTests::getUserByNameTest(){
     auto api = getApi();
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(30000);
-    timer.setSingleShot(true);
+    bool userFetched = false;
 
-    auto validator = [this](OAIUser summary) {
+    connect(api, &OAIUserApi::getUserByNameSignal, [&](OAIUser summary) {
+        userFetched = true;
         qDebug() << summary.getUsername();
-        emit quit();
-    };
-    auto finalizer = [&]() {
+        QVERIFY(summary.getUsername() == "johndoe");
         loop.quit();
-    };
-    connect(this, &UserApiTests::quit, finalizer);
-    connect(api, &OAIUserApi::getUserByNameSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    });
 
-    api->getUserByName(QString("johndoe"));
-    timer.start();
+    api->getUserByName("johndoe");
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(userFetched, "didn't finish within timeout");
+
     delete api;
 }
 
 void UserApiTests::loginUserTest(){
     auto api = getApi();
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(30000);
-    timer.setSingleShot(true);
+    bool userLogged = false;
 
-    auto validator = [this](QString summary) {
+    connect(api, &OAIUserApi::loginUserSignal, [&](QString summary) {
+        userLogged = true;
         qDebug() << summary;
-        emit quit();
-    };
-    auto finalizer = [&]() {
         loop.quit();
-    };
-    connect(this, &UserApiTests::quit, finalizer);
-    connect(api, &OAIUserApi::loginUserSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    });
 
-    api->loginUser(QString("johndoe"), QString("123456789"));
-    timer.start();
+    api->loginUser("johndoe", "123456789");
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(userLogged, "didn't finish within timeout");
+
     delete api;
 }
 
 void UserApiTests::logoutUserTest(){
     auto api = getApi();
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(30000);
-    timer.setSingleShot(true);
+    bool userLoggedOut = false;
 
-    auto validator = [this]() {
-        emit quit();
-    };
-    auto finalizer = [&]() {
+    connect(api, &OAIUserApi::logoutUserSignal, [&](){
+        userLoggedOut = true;
         loop.quit();
-    };
-    connect(this, &UserApiTests::quit, finalizer);
-    connect(api, &OAIUserApi::logoutUserSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    });
 
     api->logoutUser();
-    timer.start();
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(userLoggedOut, "didn't finish within timeout");
+
     delete api;
 }
 
 void UserApiTests::updateUserTest(){
     auto api = getApi();
     QEventLoop loop;
-    QTimer timer;
-    timer.setInterval(30000);
-    timer.setSingleShot(true);
+    bool userUpdated = false;
 
-    auto validator = [this]() {
-        emit quit();
-    };
-    auto finalizer = [&]() {
-        loop.quit();
-    };
-    connect(this, &UserApiTests::quit, finalizer);
-    connect(api, &OAIUserApi::updateUserSignal, this, validator);
-    connect(&timer, &QTimer::timeout, &loop, finalizer);
+    connect(api, &OAIUserApi::updateUserSignal, [&]() {
+            userUpdated = true;
+            loop.quit();
+    });
 
     auto johndoe = createRandomUser();
-    johndoe.setUsername(QString("johndoe"));
-    api->updateUser(QString("johndoe"), johndoe);
-    timer.start();
+    johndoe.setUsername("johndoe");
+    api->updateUser("johndoe", johndoe);
+    QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
-    QVERIFY2(timer.isActive(), "didn't finish within timeout");
-    disconnect(this, nullptr, nullptr, nullptr);
+    QVERIFY2(userUpdated, "didn't finish within timeout");
+
     delete api;
 }

--- a/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.h
+++ b/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.h
@@ -1,27 +1,14 @@
-#ifndef USERAPITESTS_H
-#define USERAPITESTS_H
-#include <QtTest/QtTest>
-#include <QTimer>
+#pragma once
 
 #include "../client/OAIUserApi.h"
 
 using namespace OpenAPI;
 
 class UserApiTests: public QObject {
-Q_OBJECT
-public:
-    UserApiTests();
-    virtual ~UserApiTests();
+    Q_OBJECT
 
-    static void runTests();
-
-private:
     OAIUserApi* getApi();
     OAIUser createRandomUser();
-
-signals:
-    void quit();
-    bool success();
 
 private slots:
     void createUserTest();
@@ -33,5 +20,3 @@ private slots:
     void logoutUserTest();
     void updateUserTest();
 };
-
-#endif // USERAPITESTS_H

--- a/samples/client/petstore/cpp-qt5/PetStore/main.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/main.cpp
@@ -1,12 +1,20 @@
 #include <QCoreApplication>
+#include <QTest>
+
 #include "PetApiTests.h"
 #include "StoreApiTests.h"
 #include "UserApiTests.h"
 
 int main(int argc, char *argv[]) {
     QCoreApplication a(argc, argv);
-    PetApiTests::runTests();
-    StoreApiTests::runTests();
-    UserApiTests::runTests();
-    return a.exec();
+    PetApiTests petApiTests;
+    StoreApiTests storeApiTests;
+    UserApiTests userApiTests;
+    int failedTests = 0;
+
+    failedTests += QTest::qExec(&petApiTests);
+    failedTests += QTest::qExec(&storeApiTests);
+    failedTests += QTest::qExec(&userApiTests);
+
+    return failedTests;
 }

--- a/samples/client/petstore/cpp-qt5/build-and-test.bash
+++ b/samples/client/petstore/cpp-qt5/build-and-test.bash
@@ -4,9 +4,8 @@ set -e
 
 mkdir build
 cd build
-# project
-qmake ../PetStore/PetStore.pro
 
+qmake ../PetStore/PetStore.pro
 make
 
 ./PetStore


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This PR refactor the Qt5 client Petstore tests:

- remove unnecessary headers
- remove unnecessary constructor/destructor for test classes
- avoid `QString` constructor when possible
- `PetStore` executable returns the number of failed tests
- Simplify test logic user `QTimer::singleShoot()` static method
- don't declare lambda if used only one time
- use simple connect to lambda form
- replace `QList<QString>` by `{..., ..., ...}`

The idea is to reduce the test code base without altering its readability. All the change are based on my opinions and I'll be totally ok to discard change that doesn't comply with good practice you'll oppose it to! 😃 

@ravinikam @stkrwork @etherealjoy @muttleyxd
