### PR TITLE
Fix runtime error in the model's `valid?` of Ruby client (#3670)

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_model_generic.mustache
@@ -246,14 +246,14 @@
       {{#anyOf}}
       {{#-first}}
       _any_of_found = false
-      openapi_any_of.each do |_class|
+      self.class.openapi_any_of.each do |_class|
         _any_of = {{moduleName}}.const_get(_class).build_from_hash(self.to_hash)
         if _any_of.valid?
           _any_of_found = true
         end
       end
 
-      if !_any_of_found?
+      if !_any_of_found
         return false
       end
 
@@ -262,10 +262,10 @@
       {{#oneOf}}
       {{#-first}}
       _one_of_found = false
-      openapi_one_of.each do |_class|
+      self.class.openapi_one_of.each do |_class|
         _one_of = {{moduleName}}.const_get(_class).build_from_hash(self.to_hash)
         if _one_of.valid?
-          if _one_of_found?
+          if _one_of_found
             return false
           else
             _one_of_found = true
@@ -273,7 +273,7 @@
         end
       end
 
-      if !_one_of_found?
+      if !_one_of_found
         return false
       end
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
  @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)

### Description of the PR

Fix #3670.

- Fix accessing to `openapi_one_of` and `openapi_any_of`
- Fix usage of `_one_of_found` and `_any_of_found`
