### PR TITLE
[csharp-netcore] Fixing the XML documentation warnings.

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
@@ -74,10 +74,10 @@ namespace {{packageName}}.Client
         }
 
         /// <summary>
-        ///  Copies the items of the Multimap to an array,
+        ///  Copies items of the Multimap to an array,
         ///     starting at a particular array index.
         /// </summary>
-        /// <param name="array">The array that is the destination of the elements copied
+        /// <param name="array">The array that is the destination of the items copied
         ///     from Multimap. The array must have zero-based indexing.</param>
         /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         /// <exception cref="NotImplementedException">Method needs to be implemented</exception>

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
@@ -74,7 +74,7 @@ namespace {{packageName}}.Client
         }
 
         /// <summary>
-        ///  Copies items of the Multimap to an array,
+        ///  Copy items of the Multimap to an array,
         ///     starting at a particular array index.
         /// </summary>
         /// <param name="array">The array that is the destination of the items copied
@@ -216,7 +216,7 @@ namespace {{packageName}}.Client
         }
 
         /// <summary>
-        ///  Copies the items of the Multimap to an System.Array,
+        ///  Copy the items of the Multimap to an System.Array,
         ///     starting at a particular System.Array index.
         /// </summary>
         /// <param name="array">The one-dimensional System.Array that is the destination of the items copied

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
@@ -67,7 +67,7 @@ namespace {{packageName}}.Client
         /// </summary>
         /// <param name="item">Key value pair</param>
         /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
-        /// <returns>true if the Multimap contains the element; otherwise, false.</returns>
+        /// <returns>true if the Multimap contains the item; otherwise, false.</returns>
         public bool Contains(KeyValuePair<T, IList<TValue>> item)
         {
             throw new NotImplementedException();
@@ -158,7 +158,7 @@ namespace {{packageName}}.Client
         /// Removes item with the specified key from the Multimap.
         /// </summary>
         /// <param name="key">The key to locate in the Multimap.</param>
-        /// <returns>true if the element is successfully removed; otherwise, false.</returns>
+        /// <returns>true if the item is successfully removed; otherwise, false.</returns>
         public bool Remove(T key)
         {
             IList<TValue> list;

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
@@ -62,21 +62,44 @@ namespace {{packageName}}.Client
             _dictionary.Clear();
         }
 
+        /// <summary>
+        /// Determines whether Multimap contains the specified item.
+        /// </summary>
+        /// <param name="item">Key value pair</param>
+        /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
+        /// <returns>true if the Multimap contains the element; otherwise, false.</returns>
         public bool Contains(KeyValuePair<T, IList<TValue>> item)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        ///  Copies the items of the Multimap to an array,
+        ///     starting at a particular array index.
+        /// </summary>
+        /// <param name="array">The array that is the destination of the elements copied
+        ///     from Multimap. The array must have zero-based indexing.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
+        /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
         public void CopyTo(KeyValuePair<T, IList<TValue>>[] array, int arrayIndex)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Removes the specified item from the Multimap.
+        /// </summary>
+        /// <param name="item">Key value pair</param>
+        /// <returns>true if the item is successfully removed; otherwise, false.</returns>
+        /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
         public bool Remove(KeyValuePair<T, IList<TValue>> item)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Gets the number of items contained in the Multimap.
+        /// </summary>
         public int Count
         {
             get
@@ -85,6 +108,9 @@ namespace {{packageName}}.Client
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the Multimap is read-only.
+        /// </summary>
         public bool IsReadOnly
         {
             get
@@ -93,6 +119,12 @@ namespace {{packageName}}.Client
             }
         }
 
+        /// <summary>
+        /// Adds an item with the provided key and value to the Multimap.
+        /// </summary>
+        /// <param name="key">The object to use as the key of the item to add.</param>
+        /// <param name="value">The object to use as the value of the item to add.</param>
+        /// <exception cref="InvalidOperationException">Thrown when couldn't add the value to Multimap.</exception>
         public void Add(T key, IList<TValue> value)
         {
             if (value != null && value.Count > 0)
@@ -111,22 +143,47 @@ namespace {{packageName}}.Client
             }
         }
 
+        /// <summary>
+        /// Determines whether the Multimap contains an item with the specified key.
+        /// </summary>
+        /// <param name="key">The key to locate in the Multimap.</param>
+        /// <returns>true if the Multimap contains an item with
+        ///     the key; otherwise, false.</returns>
         public bool ContainsKey(T key)
         {
             return _dictionary.ContainsKey(key);
         }
 
+        /// <summary>
+        /// Removes item with the specified key from the Multimap.
+        /// </summary>
+        /// <param name="key">The key to locate in the Multimap.</param>
+        /// <returns>true if the element is successfully removed; otherwise, false.</returns>
         public bool Remove(T key)
         {
             IList<TValue> list;
             return TryRemove(key, out list);
         }
 
+        /// <summary>
+        /// Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key whose value to get.</param>
+        /// <param name="value">When this method returns, the value associated with the specified key, if the
+        ///     key is found; otherwise, the default value for the type of the value parameter.
+        ///     This parameter is passed uninitialized.</param>
+        /// <returns> true if the object that implements Multimap contains
+        ///     an item with the specified key; otherwise, false.</returns>
         public bool TryGetValue(T key, out IList<TValue> value)
         {
             return _dictionary.TryGetValue(key, out value);
         }
 
+        /// <summary>
+        /// Gets or sets the item with the specified key.
+        /// </summary>
+        /// <param name="key">The key of the item to get or set.</param>
+        /// <returns>The value of the specified key.</returns>
         public IList<TValue> this[T key]
         {
             get
@@ -136,6 +193,9 @@ namespace {{packageName}}.Client
             set { _dictionary[key] = value; }
         }
 
+        /// <summary>
+        /// Gets a System.Collections.Generic.ICollection containing the keys of the Multimap.
+        /// </summary>
         public ICollection<T> Keys
         {
             get
@@ -144,6 +204,9 @@ namespace {{packageName}}.Client
             }
         }
 
+        /// <summary>
+        /// Gets a System.Collections.Generic.ICollection containing the values of the Multimap.
+        /// </summary>
         public ICollection<IList<TValue>> Values
         {
             get
@@ -152,11 +215,24 @@ namespace {{packageName}}.Client
             }
         }
 
+        /// <summary>
+        ///  Copies the items of the Multimap to an System.Array,
+        ///     starting at a particular System.Array index.
+        /// </summary>
+        /// <param name="array">The one-dimensional System.Array that is the destination of the items copied
+        ///     from Multimap. The System.Array must have zero-based indexing.</param>
+        /// <param name="index">The zero-based index in array at which copying begins.</param>
         public void CopyTo(Array array, int index)
         {
             ((ICollection) _dictionary).CopyTo(array, index);
         }
 
+        /// <summary>
+        /// Adds an item with the provided key and value to the Multimap.
+        /// </summary>
+        /// <param name="key">The object to use as the key of the item to add.</param>
+        /// <param name="value">The object to use as the value of the item to add.</param>
+        /// <exception cref="InvalidOperationException">Thrown when couldn't add value to Multimap.</exception>
         public void Add(T key, TValue value)
         {
             if (value != null)

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/api.mustache
@@ -138,7 +138,7 @@ namespace {{packageName}}.{{apiPackage}}
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="{{classname}}"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>{{#supportsAsync}}

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="AnotherFakeApi"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -809,7 +809,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="FakeApi"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="FakeClassnameTags123Api"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -261,7 +261,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="StoreApi"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Api/UserApi.cs
@@ -437,7 +437,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="UserApi"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <param name="item">Key value pair</param>
         /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
-        /// <returns>true if the Multimap contains the element; otherwise, false.</returns>
+        /// <returns>true if the Multimap contains the item; otherwise, false.</returns>
         public bool Contains(KeyValuePair<T, IList<TValue>> item)
         {
             throw new NotImplementedException();
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Client
         /// Removes item with the specified key from the Multimap.
         /// </summary>
         /// <param name="key">The key to locate in the Multimap.</param>
-        /// <returns>true if the element is successfully removed; otherwise, false.</returns>
+        /// <returns>true if the item is successfully removed; otherwise, false.</returns>
         public bool Remove(T key)
         {
             IList<TValue> list;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
@@ -83,10 +83,10 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        ///  Copies the items of the Multimap to an array,
+        ///  Copies items of the Multimap to an array,
         ///     starting at a particular array index.
         /// </summary>
-        /// <param name="array">The array that is the destination of the elements copied
+        /// <param name="array">The array that is the destination of the items copied
         ///     from Multimap. The array must have zero-based indexing.</param>
         /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         /// <exception cref="NotImplementedException">Method needs to be implemented</exception>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        ///  Copies items of the Multimap to an array,
+        ///  Copy items of the Multimap to an array,
         ///     starting at a particular array index.
         /// </summary>
         /// <param name="array">The array that is the destination of the items copied
@@ -225,7 +225,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        ///  Copies the items of the Multimap to an System.Array,
+        ///  Copy the items of the Multimap to an System.Array,
         ///     starting at a particular System.Array index.
         /// </summary>
         /// <param name="array">The one-dimensional System.Array that is the destination of the items copied

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
@@ -71,21 +71,44 @@ namespace Org.OpenAPITools.Client
             _dictionary.Clear();
         }
 
+        /// <summary>
+        /// Determines whether Multimap contains the specified item.
+        /// </summary>
+        /// <param name="item">Key value pair</param>
+        /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
+        /// <returns>true if the Multimap contains the element; otherwise, false.</returns>
         public bool Contains(KeyValuePair<T, IList<TValue>> item)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        ///  Copies the items of the Multimap to an array,
+        ///     starting at a particular array index.
+        /// </summary>
+        /// <param name="array">The array that is the destination of the elements copied
+        ///     from Multimap. The array must have zero-based indexing.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
+        /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
         public void CopyTo(KeyValuePair<T, IList<TValue>>[] array, int arrayIndex)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Removes the specified item from the Multimap.
+        /// </summary>
+        /// <param name="item">Key value pair</param>
+        /// <returns>true if the item is successfully removed; otherwise, false.</returns>
+        /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
         public bool Remove(KeyValuePair<T, IList<TValue>> item)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Gets the number of items contained in the Multimap.
+        /// </summary>
         public int Count
         {
             get
@@ -94,6 +117,9 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the Multimap is read-only.
+        /// </summary>
         public bool IsReadOnly
         {
             get
@@ -102,6 +128,12 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        /// Adds an item with the provided key and value to the Multimap.
+        /// </summary>
+        /// <param name="key">The object to use as the key of the item to add.</param>
+        /// <param name="value">The object to use as the value of the item to add.</param>
+        /// <exception cref="InvalidOperationException">Thrown when couldn't add the value to Multimap.</exception>
         public void Add(T key, IList<TValue> value)
         {
             if (value != null && value.Count > 0)
@@ -120,22 +152,47 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        /// Determines whether the Multimap contains an item with the specified key.
+        /// </summary>
+        /// <param name="key">The key to locate in the Multimap.</param>
+        /// <returns>true if the Multimap contains an item with
+        ///     the key; otherwise, false.</returns>
         public bool ContainsKey(T key)
         {
             return _dictionary.ContainsKey(key);
         }
 
+        /// <summary>
+        /// Removes item with the specified key from the Multimap.
+        /// </summary>
+        /// <param name="key">The key to locate in the Multimap.</param>
+        /// <returns>true if the element is successfully removed; otherwise, false.</returns>
         public bool Remove(T key)
         {
             IList<TValue> list;
             return TryRemove(key, out list);
         }
 
+        /// <summary>
+        /// Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key whose value to get.</param>
+        /// <param name="value">When this method returns, the value associated with the specified key, if the
+        ///     key is found; otherwise, the default value for the type of the value parameter.
+        ///     This parameter is passed uninitialized.</param>
+        /// <returns> true if the object that implements Multimap contains
+        ///     an item with the specified key; otherwise, false.</returns>
         public bool TryGetValue(T key, out IList<TValue> value)
         {
             return _dictionary.TryGetValue(key, out value);
         }
 
+        /// <summary>
+        /// Gets or sets the item with the specified key.
+        /// </summary>
+        /// <param name="key">The key of the item to get or set.</param>
+        /// <returns>The value of the specified key.</returns>
         public IList<TValue> this[T key]
         {
             get
@@ -145,6 +202,9 @@ namespace Org.OpenAPITools.Client
             set { _dictionary[key] = value; }
         }
 
+        /// <summary>
+        /// Gets a System.Collections.Generic.ICollection containing the keys of the Multimap.
+        /// </summary>
         public ICollection<T> Keys
         {
             get
@@ -153,6 +213,9 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        /// Gets a System.Collections.Generic.ICollection containing the values of the Multimap.
+        /// </summary>
         public ICollection<IList<TValue>> Values
         {
             get
@@ -161,11 +224,24 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        ///  Copies the items of the Multimap to an System.Array,
+        ///     starting at a particular System.Array index.
+        /// </summary>
+        /// <param name="array">The one-dimensional System.Array that is the destination of the items copied
+        ///     from Multimap. The System.Array must have zero-based indexing.</param>
+        /// <param name="index">The zero-based index in array at which copying begins.</param>
         public void CopyTo(Array array, int index)
         {
             ((ICollection) _dictionary).CopyTo(array, index);
         }
 
+        /// <summary>
+        /// Adds an item with the provided key and value to the Multimap.
+        /// </summary>
+        /// <param name="key">The object to use as the key of the item to add.</param>
+        /// <param name="value">The object to use as the value of the item to add.</param>
+        /// <exception cref="InvalidOperationException">Thrown when couldn't add value to Multimap.</exception>
         public void Add(T key, TValue value)
         {
             if (value != null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="AnotherFakeApi"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -809,7 +809,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="FakeApi"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -139,7 +139,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="FakeClassnameTags123Api"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -261,7 +261,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="StoreApi"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Api/UserApi.cs
@@ -437,7 +437,7 @@ namespace Org.OpenAPITools.Api
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PetApi"/> class
+        /// Initializes a new instance of the <see cref="UserApi"/> class
         /// using a Configuration object and client instance.
         /// </summary>
         /// <param name="client">The client interface for synchronous API access.</param>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Multimap.cs
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <param name="item">Key value pair</param>
         /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
-        /// <returns>true if the Multimap contains the element; otherwise, false.</returns>
+        /// <returns>true if the Multimap contains the item; otherwise, false.</returns>
         public bool Contains(KeyValuePair<T, IList<TValue>> item)
         {
             throw new NotImplementedException();
@@ -167,7 +167,7 @@ namespace Org.OpenAPITools.Client
         /// Removes item with the specified key from the Multimap.
         /// </summary>
         /// <param name="key">The key to locate in the Multimap.</param>
-        /// <returns>true if the element is successfully removed; otherwise, false.</returns>
+        /// <returns>true if the item is successfully removed; otherwise, false.</returns>
         public bool Remove(T key)
         {
             IList<TValue> list;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Multimap.cs
@@ -83,10 +83,10 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        ///  Copies the items of the Multimap to an array,
+        ///  Copies items of the Multimap to an array,
         ///     starting at a particular array index.
         /// </summary>
-        /// <param name="array">The array that is the destination of the elements copied
+        /// <param name="array">The array that is the destination of the items copied
         ///     from Multimap. The array must have zero-based indexing.</param>
         /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
         /// <exception cref="NotImplementedException">Method needs to be implemented</exception>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Multimap.cs
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        ///  Copies items of the Multimap to an array,
+        ///  Copy items of the Multimap to an array,
         ///     starting at a particular array index.
         /// </summary>
         /// <param name="array">The array that is the destination of the items copied
@@ -225,7 +225,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <summary>
-        ///  Copies the items of the Multimap to an System.Array,
+        ///  Copy the items of the Multimap to an System.Array,
         ///     starting at a particular System.Array index.
         /// </summary>
         /// <param name="array">The one-dimensional System.Array that is the destination of the items copied

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Multimap.cs
@@ -71,21 +71,44 @@ namespace Org.OpenAPITools.Client
             _dictionary.Clear();
         }
 
+        /// <summary>
+        /// Determines whether Multimap contains the specified item.
+        /// </summary>
+        /// <param name="item">Key value pair</param>
+        /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
+        /// <returns>true if the Multimap contains the element; otherwise, false.</returns>
         public bool Contains(KeyValuePair<T, IList<TValue>> item)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        ///  Copies the items of the Multimap to an array,
+        ///     starting at a particular array index.
+        /// </summary>
+        /// <param name="array">The array that is the destination of the elements copied
+        ///     from Multimap. The array must have zero-based indexing.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
+        /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
         public void CopyTo(KeyValuePair<T, IList<TValue>>[] array, int arrayIndex)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Removes the specified item from the Multimap.
+        /// </summary>
+        /// <param name="item">Key value pair</param>
+        /// <returns>true if the item is successfully removed; otherwise, false.</returns>
+        /// <exception cref="NotImplementedException">Method needs to be implemented</exception>
         public bool Remove(KeyValuePair<T, IList<TValue>> item)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Gets the number of items contained in the Multimap.
+        /// </summary>
         public int Count
         {
             get
@@ -94,6 +117,9 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the Multimap is read-only.
+        /// </summary>
         public bool IsReadOnly
         {
             get
@@ -102,6 +128,12 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        /// Adds an item with the provided key and value to the Multimap.
+        /// </summary>
+        /// <param name="key">The object to use as the key of the item to add.</param>
+        /// <param name="value">The object to use as the value of the item to add.</param>
+        /// <exception cref="InvalidOperationException">Thrown when couldn't add the value to Multimap.</exception>
         public void Add(T key, IList<TValue> value)
         {
             if (value != null && value.Count > 0)
@@ -120,22 +152,47 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        /// Determines whether the Multimap contains an item with the specified key.
+        /// </summary>
+        /// <param name="key">The key to locate in the Multimap.</param>
+        /// <returns>true if the Multimap contains an item with
+        ///     the key; otherwise, false.</returns>
         public bool ContainsKey(T key)
         {
             return _dictionary.ContainsKey(key);
         }
 
+        /// <summary>
+        /// Removes item with the specified key from the Multimap.
+        /// </summary>
+        /// <param name="key">The key to locate in the Multimap.</param>
+        /// <returns>true if the element is successfully removed; otherwise, false.</returns>
         public bool Remove(T key)
         {
             IList<TValue> list;
             return TryRemove(key, out list);
         }
 
+        /// <summary>
+        /// Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key whose value to get.</param>
+        /// <param name="value">When this method returns, the value associated with the specified key, if the
+        ///     key is found; otherwise, the default value for the type of the value parameter.
+        ///     This parameter is passed uninitialized.</param>
+        /// <returns> true if the object that implements Multimap contains
+        ///     an item with the specified key; otherwise, false.</returns>
         public bool TryGetValue(T key, out IList<TValue> value)
         {
             return _dictionary.TryGetValue(key, out value);
         }
 
+        /// <summary>
+        /// Gets or sets the item with the specified key.
+        /// </summary>
+        /// <param name="key">The key of the item to get or set.</param>
+        /// <returns>The value of the specified key.</returns>
         public IList<TValue> this[T key]
         {
             get
@@ -145,6 +202,9 @@ namespace Org.OpenAPITools.Client
             set { _dictionary[key] = value; }
         }
 
+        /// <summary>
+        /// Gets a System.Collections.Generic.ICollection containing the keys of the Multimap.
+        /// </summary>
         public ICollection<T> Keys
         {
             get
@@ -153,6 +213,9 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        /// Gets a System.Collections.Generic.ICollection containing the values of the Multimap.
+        /// </summary>
         public ICollection<IList<TValue>> Values
         {
             get
@@ -161,11 +224,24 @@ namespace Org.OpenAPITools.Client
             }
         }
 
+        /// <summary>
+        ///  Copies the items of the Multimap to an System.Array,
+        ///     starting at a particular System.Array index.
+        /// </summary>
+        /// <param name="array">The one-dimensional System.Array that is the destination of the items copied
+        ///     from Multimap. The System.Array must have zero-based indexing.</param>
+        /// <param name="index">The zero-based index in array at which copying begins.</param>
         public void CopyTo(Array array, int index)
         {
             ((ICollection) _dictionary).CopyTo(array, index);
         }
 
+        /// <summary>
+        /// Adds an item with the provided key and value to the Multimap.
+        /// </summary>
+        /// <param name="key">The object to use as the key of the item to add.</param>
+        /// <param name="value">The object to use as the value of the item to add.</param>
+        /// <exception cref="InvalidOperationException">Thrown when couldn't add value to Multimap.</exception>
         public void Add(T key, TValue value)
         {
             if (value != null)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Fixes #3673 
* Fix XML documentation warnings that are being shown while building the package.
* Fix the hard-coded `PetApi` class name in api.mustache.

@mandrean (2017/08), @jimschubert (2017/09)