### PR TITLE
[Go] add option to use class as enum prefix

### DIFF
--- a/docs/generators/go-experimental.md
+++ b/docs/generators/go-experimental.md
@@ -13,4 +13,5 @@ sidebar_label: go-experimental
 |isGoSubmodule|whether the generated Go module is a submodule| |false|
 |withGoCodegenComment|whether to include Go codegen comment to disable Go Lint and collapse by default GitHub in PRs and diffs| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
+|enumClassPrefix|Prefix enum with class name| |false|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -13,4 +13,5 @@ sidebar_label: go
 |isGoSubmodule|whether the generated Go module is a submodule| |false|
 |withGoCodegenComment|whether to include Go codegen comment to disable Go Lint and collapse by default GitHub in PRs and diffs| |false|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
+|enumClassPrefix|Prefix enum with class name| |false|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -257,7 +257,7 @@ public class CodegenConstants {
     public static final String GENERATE_MODEL_TESTS_DESC = "Specifies that model tests are to be generated.";
 
     public static final String HIDE_GENERATION_TIMESTAMP = "hideGenerationTimestamp";
-     public static final String HIDE_GENERATION_TIMESTAMP_DESC = "Hides the generation timestamp when files are generated.";
+    public static final String HIDE_GENERATION_TIMESTAMP_DESC = "Hides the generation timestamp when files are generated.";
 
     public static final String GENERATE_PROPERTY_CHANGED = "generatePropertyChanged";
     public static final String GENERATE_PROPERTY_CHANGED_DESC = "Specifies that models support raising property changed events.";
@@ -310,4 +310,5 @@ public class CodegenConstants {
     public static final String EXCEPTION_ON_FAILURE_DESC = "Throw an exception on non success response codes";
 
     public static final String ENUM_CLASS_PREFIX = "enumClassPrefix";
-    public static final String ENUM_CLASS_PREFIX_DESC = "Prefix enum with class name"; }
+    public static final String ENUM_CLASS_PREFIX_DESC = "Prefix enum with class name";
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -257,7 +257,7 @@ public class CodegenConstants {
     public static final String GENERATE_MODEL_TESTS_DESC = "Specifies that model tests are to be generated.";
 
     public static final String HIDE_GENERATION_TIMESTAMP = "hideGenerationTimestamp";
-    public static final String HIDE_GENERATION_TIMESTAMP_DESC = "Hides the generation timestamp when files are generated.";
+     public static final String HIDE_GENERATION_TIMESTAMP_DESC = "Hides the generation timestamp when files are generated.";
 
     public static final String GENERATE_PROPERTY_CHANGED = "generatePropertyChanged";
     public static final String GENERATE_PROPERTY_CHANGED_DESC = "Specifies that models support raising property changed events.";
@@ -308,4 +308,6 @@ public class CodegenConstants {
 
     public static final String EXCEPTION_ON_FAILURE = "returnExceptionOnFailure";
     public static final String EXCEPTION_ON_FAILURE_DESC = "Throw an exception on non success response codes";
-}
+
+    public static final String ENUM_CLASS_PREFIX = "enumClassPrefix";
+    public static final String ENUM_CLASS_PREFIX_DESC = "Prefix enum with class name"; }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -38,6 +38,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     protected boolean withGoCodegenComment = false;
     protected boolean withXml = false;
+    protected boolean enumClassPrefix = false;
 
     protected String packageName = "openapi";
 
@@ -616,6 +617,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     public void setWithXml(boolean withXml) {
         this.withXml = withXml;
+    }
+
+    public void setEnumClassPrefix(boolean enumClassPrefix) {
+        this.enumClassPrefix = enumClassPrefix;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -36,6 +36,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
     protected boolean isGoSubmodule = false;
     public static final String WITH_GO_CODEGEN_COMMENT = "withGoCodegenComment";
     public static final String WITH_XML = "withXml";
+    public static final String ENUM_CLASS_PREFIX = "enumClassPrefix";
 
     public GoClientCodegen() {
         super();
@@ -55,7 +56,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         cliOptions.add(CliOption.newBoolean(CodegenConstants.IS_GO_SUBMODULE, CodegenConstants.IS_GO_SUBMODULE_DESC));
         cliOptions.add(CliOption.newBoolean(WITH_GO_CODEGEN_COMMENT, "whether to include Go codegen comment to disable Go Lint and collapse by default GitHub in PRs and diffs"));
         cliOptions.add(CliOption.newBoolean(WITH_XML, "whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)"));
-
+        cliOptions.add(CliOption.newBoolean(ENUM_CLASS_PREFIX, "Prefix enum with class name"));
 
         // option to change the order of form/body parameter
         cliOptions.add(CliOption.newBoolean(
@@ -111,6 +112,13 @@ public class GoClientCodegen extends AbstractGoCodegen {
             setWithXml(Boolean.parseBoolean(additionalProperties.get(WITH_XML).toString()));
             if (withXml) {
                 additionalProperties.put(WITH_XML, "true");
+            }
+        }
+
+        if (additionalProperties.containsKey(ENUM_CLASS_PREFIX)) {
+            setEnumClassPrefix(Boolean.parseBoolean(additionalProperties.get(ENUM_CLASS_PREFIX).toString()));
+            if (enumClassPrefix) {
+                additionalProperties.put(ENUM_CLASS_PREFIX, "true");
             }
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -36,7 +36,6 @@ public class GoClientCodegen extends AbstractGoCodegen {
     protected boolean isGoSubmodule = false;
     public static final String WITH_GO_CODEGEN_COMMENT = "withGoCodegenComment";
     public static final String WITH_XML = "withXml";
-    public static final String ENUM_CLASS_PREFIX = "enumClassPrefix";
 
     public GoClientCodegen() {
         super();
@@ -56,7 +55,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         cliOptions.add(CliOption.newBoolean(CodegenConstants.IS_GO_SUBMODULE, CodegenConstants.IS_GO_SUBMODULE_DESC));
         cliOptions.add(CliOption.newBoolean(WITH_GO_CODEGEN_COMMENT, "whether to include Go codegen comment to disable Go Lint and collapse by default GitHub in PRs and diffs"));
         cliOptions.add(CliOption.newBoolean(WITH_XML, "whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)"));
-        cliOptions.add(CliOption.newBoolean(ENUM_CLASS_PREFIX, "Prefix enum with class name"));
+        cliOptions.add(CliOption.newBoolean(CodegenConstants.ENUM_CLASS_PREFIX, CodegenConstants.ENUM_CLASS_PREFIX_DESC));
 
         // option to change the order of form/body parameter
         cliOptions.add(CliOption.newBoolean(
@@ -115,10 +114,10 @@ public class GoClientCodegen extends AbstractGoCodegen {
             }
         }
 
-        if (additionalProperties.containsKey(ENUM_CLASS_PREFIX)) {
-            setEnumClassPrefix(Boolean.parseBoolean(additionalProperties.get(ENUM_CLASS_PREFIX).toString()));
+        if (additionalProperties.containsKey(CodegenConstants.ENUM_CLASS_PREFIX)) {
+            setEnumClassPrefix(Boolean.parseBoolean(additionalProperties.get(CodegenConstants.ENUM_CLASS_PREFIX).toString()));
             if (enumClassPrefix) {
-                additionalProperties.put(ENUM_CLASS_PREFIX, "true");
+                additionalProperties.put(CodegenConstants.ENUM_CLASS_PREFIX, "true");
             }
         }
 

--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -23,7 +23,7 @@ const (
 	{{#enumVars}}
 	{{^-first}}
 	{{/-first}}
-	{{{classname.toUpperCase}}}_{{name}} {{{classname}}} = "{{{value}}}"
+	{{#enumClassPrefix}}{{{classname.toUpperCase}}}_{{/enumClassPrefix}}{{name}} {{{classname}}} = "{{{value}}}"
 	{{/enumVars}}
 	{{/allowableValues}}
 ){{/isEnum}}{{^isEnum}}{{#description}}
@@ -36,7 +36,7 @@ type {{classname}} struct {
 	// {{{description}}}
 {{/description}}
 	{{name}} *{{{dataType}}} `json:"{{baseName}},omitempty"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
-{{#isNullable}}    isExplicitNull{{name}} bool `json:"-"{{#withXml}} xml:"-"{{/withXml}}`{{/isNullable}}
+{{#isNullable}}	isExplicitNull{{name}} bool `json:"-"{{#withXml}} xml:"-"{{/withXml}}`{{/isNullable}}
 {{/vars}}
 }
 {{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/go/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model.mustache
@@ -23,7 +23,7 @@ const (
 	{{#enumVars}}
 	{{^-first}}
 	{{/-first}}
-	{{{classname.toUpperCase}}}_{{name}} {{{classname}}} = "{{{value}}}"
+	{{#enumClassPrefix}}{{{classname.toUpperCase}}}_{{/enumClassPrefix}}{{name}} {{{classname}}} = "{{{value}}}"
 	{{/enumVars}}
 	{{/allowableValues}}
 ){{/isEnum}}{{^isEnum}}{{#description}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
@@ -50,6 +50,8 @@ public class GoClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setWithXml(GoClientOptionsProvider.WITH_XML_VALUE);
             times = 1;
+            clientCodegen.setWithXml(GoClientOptionsProvider.ENUM_CLASS_PREFIX_VALUE);
+            times = 1;
             clientCodegen.setPrependFormOrBodyParameters(Boolean.valueOf(GoClientOptionsProvider.PREPEND_FORM_OR_BODY_PARAMETERS_VALUE));
             times = 1;
             clientCodegen.setIsGoSubmodule(Boolean.valueOf(GoClientOptionsProvider.IS_GO_SUBMODULE_VALUE));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/GoClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/GoClientOptionsProvider.java
@@ -28,6 +28,7 @@ public class GoClientOptionsProvider implements OptionsProvider {
     public static final String PACKAGE_NAME_VALUE = "Go";
     public static final boolean WITH_GO_CODEGEN_COMMENT_VALUE = true;
     public static final boolean WITH_XML_VALUE = true;
+    public static final boolean ENUM_CLASS_PREFIX_VALUE = true;
     public static final Boolean PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = true;
     public static final boolean IS_GO_SUBMODULE_VALUE = true;
 
@@ -45,6 +46,7 @@ public class GoClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true")
                 .put(CodegenConstants.WITH_GO_CODEGEN_COMMENT, "true")
                 .put(CodegenConstants.WITH_XML, "true")
+                .put(CodegenConstants.ENUM_CLASS_PREFIX, "true")
                 .put(CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, "true")
                 .put(CodegenConstants.IS_GO_SUBMODULE, "true")
                 .build();

--- a/samples/client/petstore/go/go-petstore-withXml/model_enum_class.go
+++ b/samples/client/petstore/go/go-petstore-withXml/model_enum_class.go
@@ -13,7 +13,7 @@ type EnumClass string
 
 // List of EnumClass
 const (
-	ENUMCLASS_ABC EnumClass = "_abc"
-	ENUMCLASS_EFG EnumClass = "-efg"
-	ENUMCLASS_XYZ EnumClass = "(xyz)"
+	ABC EnumClass = "_abc"
+	EFG EnumClass = "-efg"
+	XYZ EnumClass = "(xyz)"
 )

--- a/samples/client/petstore/go/go-petstore-withXml/model_outer_enum.go
+++ b/samples/client/petstore/go/go-petstore-withXml/model_outer_enum.go
@@ -13,7 +13,7 @@ type OuterEnum string
 
 // List of OuterEnum
 const (
-	OUTERENUM_PLACED OuterEnum = "placed"
-	OUTERENUM_APPROVED OuterEnum = "approved"
-	OUTERENUM_DELIVERED OuterEnum = "delivered"
+	PLACED OuterEnum = "placed"
+	APPROVED OuterEnum = "approved"
+	DELIVERED OuterEnum = "delivered"
 )

--- a/samples/client/petstore/go/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_class.go
@@ -12,7 +12,7 @@ type EnumClass string
 
 // List of EnumClass
 const (
-	ENUMCLASS_ABC EnumClass = "_abc"
-	ENUMCLASS_EFG EnumClass = "-efg"
-	ENUMCLASS_XYZ EnumClass = "(xyz)"
+	ABC EnumClass = "_abc"
+	EFG EnumClass = "-efg"
+	XYZ EnumClass = "(xyz)"
 )

--- a/samples/client/petstore/go/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go/go-petstore/model_outer_enum.go
@@ -12,7 +12,7 @@ type OuterEnum string
 
 // List of OuterEnum
 const (
-	OUTERENUM_PLACED OuterEnum = "placed"
-	OUTERENUM_APPROVED OuterEnum = "approved"
-	OUTERENUM_DELIVERED OuterEnum = "delivered"
+	PLACED OuterEnum = "placed"
+	APPROVED OuterEnum = "approved"
+	DELIVERED OuterEnum = "delivered"
 )


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add the option `enumClassPrefix` to determine the name of the enum class.

cc @antihax @bvwells @grokify @kemokemo @bkabrda 


