### PR TITLE
Remove dollar sign from Java const name

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen.languages;
 
+import com.google.common.base.CaseFormat;
 import com.google.common.base.Strings;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -984,6 +985,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             model.imports.add("ApiModelProperty");
             model.imports.add("ApiModel");
         }
+
+        // add java constancct name
+        property.vendorExtensions.put("x-java-const-name", CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, property.nameInCamelCase.replaceAll("\\$", "")));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -986,7 +986,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             model.imports.add("ApiModel");
         }
 
-        // add java constancct name
+        // store java constant property name in vendor extension, remove dollar sign from the constant name
         property.vendorExtensions.put("x-java-const-name", CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, property.nameInCamelCase.replaceAll("\\$", "")));
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/jackson_annotations.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/jackson_annotations.mustache
@@ -4,7 +4,7 @@
  * If the field is required, always include it, even if it is null.
  * Else use custom behaviour, IOW use whatever is defined on the object mapper
  }}
-  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
+  @JsonProperty(JSON_PROPERTY_{{vendorExtensions.x-java-const-name}})
   @JsonInclude({{#isMapContainer}}{{#items.isNullable}}content = JsonInclude.Include.ALWAYS, {{/items.isNullable}}{{/isMapContainer}}value = JsonInclude.Include.{{#required}}ALWAYS{{/required}}{{^required}}USE_DEFAULTS{{/required}})
   {{#withXml}}
     {{^isContainer}}

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -41,11 +41,11 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{/isXmlAttribute}}
   {{/withXml}}
   {{#gson}}
-  public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
-  @SerializedName(SERIALIZED_NAME_{{nameInSnakeCase}})
+  public static final String SERIALIZED_NAME_{{vendorExtensions.x-java-const-name}} = "{{baseName}}";
+  @SerializedName(SERIALIZED_NAME_{{vendorExtensions.x-java-const-name}})
   {{/gson}}
   {{#jackson}}
-  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
+  public static final String JSON_PROPERTY_{{vendorExtensions.x-java-const-name}} = "{{baseName}}";
   {{/jackson}}
   {{#vendorExtensions.isJacksonOptionalNullable}}
   {{#isContainer}}
@@ -197,7 +197,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
 
   {{^isReadOnly}}
   {{#vendorExtensions.isJacksonOptionalNullable}}
-  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
+  @JsonProperty(JSON_PROPERTY_{{vendorExtensions.x-java-const-name}})
   public void {{setter}}_JsonNullable(JsonNullable<{{{datatypeWithEnum}}}> {{name}}) {
     this.{{name}} = {{name}};
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -42,7 +42,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -31,8 +31,8 @@ import android.os.Parcel;
  */
 
 public class SpecialModelName implements Parcelable {
-  public static final String SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
+  public static final String SERIALIZED_NAME_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @SerializedName(SERIALIZED_NAME_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
   public SpecialModelName() {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -29,8 +29,8 @@ import java.io.IOException;
  */
 
 public class SpecialModelName {
-  public static final String SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
+  public static final String SERIALIZED_NAME_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @SerializedName(SERIALIZED_NAME_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -29,8 +29,8 @@ import java.io.IOException;
  */
 
 public class SpecialModelName {
-  public static final String SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
+  public static final String SERIALIZED_NAME_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @SerializedName(SERIALIZED_NAME_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -33,7 +33,7 @@ import javax.xml.bind.annotation.*;
 @JacksonXmlRootElement(localName = "$special[model.name]")
 public class SpecialModelName {
   @XmlElement(name = "$special[property.name]")
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -49,7 +49,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   @JacksonXmlProperty(localName = "$special[property.name]")
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -29,8 +29,8 @@ import java.io.IOException;
  */
 
 public class SpecialModelName {
-  public static final String SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
+  public static final String SERIALIZED_NAME_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @SerializedName(SERIALIZED_NAME_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -29,7 +29,7 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -45,7 +45,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -29,7 +29,7 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -45,7 +45,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -29,7 +29,7 @@ import javax.validation.Valid;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -45,7 +45,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -29,8 +29,8 @@ import java.io.IOException;
  */
 
 public class SpecialModelName {
-  public static final String SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
+  public static final String SERIALIZED_NAME_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @SerializedName(SERIALIZED_NAME_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -29,8 +29,8 @@ import java.io.IOException;
  */
 
 public class SpecialModelName {
-  public static final String SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
+  public static final String SERIALIZED_NAME_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @SerializedName(SERIALIZED_NAME_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
 

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -29,8 +29,8 @@ import java.io.IOException;
  */
 
 public class SpecialModelName {
-  public static final String SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
-  @SerializedName(SERIALIZED_NAME_$_SPECIAL_PROPERTY_NAME)
+  public static final String SERIALIZED_NAME_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @SerializedName(SERIALIZED_NAME_SPECIAL_PROPERTY_NAME)
   private Long $specialPropertyName;
 
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 public class SpecialModelName {
-  public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  public static final String JSON_PROPERTY_SPECIAL_PROPERTY_NAME = "$special[property.name]";
   private Long $specialPropertyName;
 
 
@@ -43,7 +43,7 @@ public class SpecialModelName {
   **/
   @javax.annotation.Nullable
   @ApiModelProperty(value = "")
-  @JsonProperty(JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME)
+  @JsonProperty(JSON_PROPERTY_SPECIAL_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
   public Long get$SpecialPropertyName() {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Remove dollar sign from Java constant name as only letters and underscore are allowed: https://google.github.io/styleguide/javaguide.html#s5.2.4-constant-names

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)



