### PR TITLE
[java-client][jersey2][resteasy] add support for OPTIONS method

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -721,6 +721,8 @@ public class ApiClient {
         response = invocationBuilder.method("PATCH", entity);
       } else if ("HEAD".equals(method)) {
         response = invocationBuilder.head();
+      } else if ("OPTIONS".equals(method)) {
+        response = invocationBuilder.options();
       } else if ("TRACE".equals(method)) {
         response = invocationBuilder.trace();
       } else {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -666,6 +666,8 @@ public class ApiClient {
       response = invocationBuilder.header("X-HTTP-Method-Override", "PATCH").post(entity);
     } else if ("HEAD".equals(method)) {
       response = invocationBuilder.head();
+    } else if ("OPTIONS".equals(method)) {
+      response = invocationBuilder.options();
     } else if ("TRACE".equals(method)) {
       response = invocationBuilder.trace();
     } else {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiClient.java
@@ -705,6 +705,8 @@ public class ApiClient {
         response = invocationBuilder.method("PATCH", entity);
       } else if ("HEAD".equals(method)) {
         response = invocationBuilder.head();
+      } else if ("OPTIONS".equals(method)) {
+        response = invocationBuilder.options();
       } else if ("TRACE".equals(method)) {
         response = invocationBuilder.trace();
       } else {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -705,6 +705,8 @@ public class ApiClient {
         response = invocationBuilder.method("PATCH", entity);
       } else if ("HEAD".equals(method)) {
         response = invocationBuilder.head();
+      } else if ("OPTIONS".equals(method)) {
+        response = invocationBuilder.options();
       } else if ("TRACE".equals(method)) {
         response = invocationBuilder.trace();
       } else {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java
@@ -705,6 +705,8 @@ public class ApiClient {
         response = invocationBuilder.method("PATCH", entity);
       } else if ("HEAD".equals(method)) {
         response = invocationBuilder.head();
+      } else if ("OPTIONS".equals(method)) {
+        response = invocationBuilder.options();
       } else if ("TRACE".equals(method)) {
         response = invocationBuilder.trace();
       } else {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
@@ -657,6 +657,8 @@ public class ApiClient {
       response = invocationBuilder.header("X-HTTP-Method-Override", "PATCH").post(entity);
     } else if ("HEAD".equals(method)) {
       response = invocationBuilder.head();
+    } else if ("OPTIONS".equals(method)) {
+      response = invocationBuilder.options();
     } else if ("TRACE".equals(method)) {
       response = invocationBuilder.trace();
     } else {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. Java: @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)

### Description of the PR

This PR add support for OPTIONS http-method to `jersey2` and `resteasy` java-clients.

This was not supported in following switches:

https://github.com/OpenAPITools/openapi-generator/blob/a5ab60bec8df9dfd7bfcba21fabd6fb710e990ff/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java#L696-L712

And:

https://github.com/OpenAPITools/openapi-generator/blob/a5ab60bec8df9dfd7bfcba21fabd6fb710e990ff/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java#L648-L664

Before the change there was an exception like this (in the rest-easy case):

```
<package-name>.resteasy.ApiException: unknown method type OPTIONS
	at <package-name>.resteasy.ApiClient.invokeAPI(ApiClient.java:648)
```


