### PR TITLE
Two tiny fixes for Java Vertx client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -441,7 +441,7 @@ public class ApiClient {
 
         updateParamsForAuth(authNames, queryParams, headerParams);
 
-        if (accepts != null) {
+        if (accepts != null && accepts.length > 0) {
             headerParams.add(HttpHeaders.ACCEPT, selectHeaderAccept(accepts));
         }
 
@@ -576,7 +576,7 @@ public class ApiClient {
                             return;
                         } else {
                             try {
-                                resultContent = Json.mapper.readValue(httpResponse.bodyAsString(), returnType);
+                                resultContent = this.objectMapper.readValue(httpResponse.bodyAsString(), returnType);
                                 result = Future.succeededFuture(resultContent);
                             } catch (Exception e) {
                                 result =  ApiException.fail(new DecodeException("Failed to decode:" + e.getMessage(), e));

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
@@ -437,7 +437,7 @@ public class ApiClient {
 
         updateParamsForAuth(authNames, queryParams, headerParams);
 
-        if (accepts != null) {
+        if (accepts != null && accepts.length > 0) {
             headerParams.add(HttpHeaders.ACCEPT, selectHeaderAccept(accepts));
         }
 
@@ -572,7 +572,7 @@ public class ApiClient {
                             return;
                         } else {
                             try {
-                                resultContent = Json.mapper.readValue(httpResponse.bodyAsString(), returnType);
+                                resultContent = this.objectMapper.readValue(httpResponse.bodyAsString(), returnType);
                                 result = Future.succeededFuture(resultContent);
                             } catch (Exception e) {
                                 result =  ApiException.fail(new DecodeException("Failed to decode:" + e.getMessage(), e));


### PR DESCRIPTION
# PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC: @bbdouglas, @sreeshas, @jfiala, @lukoyanov, @cbornet, @jeff9finger, @karismann @Zomzog

### Description of the PR

1.) ApiClient already defines and configures an objectMapper to not fail on unknown properties, but it is not used when parsing the response. The fix uses the pre-configured object mapper instead of the vertx default one

2.) When an operation has no response (or just ones without content), the accept array passed to ApiClient is emtpy. This makes the null check in ApiClient useless, as it still tries to set a null Accept header, which is refused with an NPE. Amend the check with .length > 0 to catch this case.

This fix is for 4.1, which I believe is the version currently living on master, so filing the PR against this branch.

