### PR TITLE
[csharp-netcore] Making HTTP response headers dictionary case-insensitive

### DIFF
--- a/docs/generators/csharp-netcore.md
+++ b/docs/generators/csharp-netcore.md
@@ -26,3 +26,4 @@ sidebar_label: csharp-netcore
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |netCoreProjectFile|Use the new format (.NET Core) for .NET project files (.csproj).| |false|
 |validatable|Generates self-validatable models.| |true|
+|caseInsensitiveResponseHeaders|Make API response's headers case-insensitive| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
@@ -78,6 +78,8 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
     // By default, generated code is considered public
     protected boolean nonPublicApi = Boolean.FALSE;
 
+    protected boolean caseInsensitiveResponseHeaders = Boolean.FALSE;
+
     public CSharpNetCoreClientCodegen() {
         super();
 
@@ -205,6 +207,10 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
         addSwitch(CodegenConstants.VALIDATABLE,
                 CodegenConstants.VALIDATABLE_DESC,
                 this.validatable);
+
+        addSwitch(CodegenConstants.CASE_INSENSITIVE_RESPONSE_HEADERS,
+                CodegenConstants.CASE_INSENSITIVE_RESPONSE_HEADERS_DESC,
+                this.caseInsensitiveResponseHeaders);
 
         regexModifiers = new HashMap<>();
         regexModifiers.put('i', "IgnoreCase");
@@ -638,6 +644,10 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
 
     public void setValidatable(boolean validatable) {
         this.validatable = validatable;
+    }
+
+    public void setCaseInsensitiveResponseHeaders(final Boolean caseInsensitiveResponseHeaders) {
+        this.caseInsensitiveResponseHeaders = caseInsensitiveResponseHeaders;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -347,7 +347,7 @@ namespace {{packageName}}.Client
         private ApiResponse<T> toApiResponse<T>({{#supportsAsync}}IRestResponse<T> response{{/supportsAsync}}{{^supportsAsync}}IRestResponse response, CustomJsonCodec des{{/supportsAsync}})
         {
             T result = {{#supportsAsync}}response.Data{{/supportsAsync}}{{^supportsAsync}}(T)des.Deserialize(response, typeof(T)){{/supportsAsync}};
-            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result)
+            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result)
             {
                 ErrorText = response.ErrorMessage,
                 Cookies = new List<Cookie>()

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
@@ -21,6 +21,26 @@ namespace {{packageName}}.Client
 
         #endregion Private Fields
 
+        #region Constructors
+
+        /// <summary>
+        /// Empty Constructor.
+        /// </summary>
+        public Multimap()
+        {
+            _dictionary = new {{^net35}}Concurrent{{/net35}}Dictionary<T, IList<TValue>>();
+        }
+
+        /// <summary>
+        /// Constructor with comparer.
+        /// </summary>
+        /// <param name="comparer"></param>
+        public Multimap(IEqualityComparer<T> comparer) {
+            _dictionary = new {{^net35}}Concurrent{{/net35}}Dictionary<T, IList<TValue>>(comparer);
+        }
+
+        #endregion Constructors
+
         #region Enumerators
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
@@ -30,6 +30,26 @@ namespace Org.OpenAPITools.Client
 
         #endregion Private Fields
 
+        #region Constructors
+
+        /// <summary>
+        /// Empty Constructor.
+        /// </summary>
+        public Multimap()
+        {
+            _dictionary = new ConcurrentDictionary<T, IList<TValue>>();
+        }
+
+        /// <summary>
+        /// Constructor with comparer.
+        /// </summary>
+        /// <param name="comparer"></param>
+        public Multimap(IEqualityComparer<T> comparer) {
+            _dictionary = new ConcurrentDictionary<T, IList<TValue>>(comparer);
+        }
+
+        #endregion Constructors
+
         #region Enumerators
 
         /// <summary>

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Multimap.cs
@@ -30,6 +30,26 @@ namespace Org.OpenAPITools.Client
 
         #endregion Private Fields
 
+        #region Constructors
+
+        /// <summary>
+        /// Empty Constructor.
+        /// </summary>
+        public Multimap()
+        {
+            _dictionary = new ConcurrentDictionary<T, IList<TValue>>();
+        }
+
+        /// <summary>
+        /// Constructor with comparer.
+        /// </summary>
+        /// <param name="comparer"></param>
+        public Multimap(IEqualityComparer<T> comparer) {
+            _dictionary = new ConcurrentDictionary<T, IList<TValue>>(comparer);
+        }
+
+        #endregion Constructors
+
         #region Enumerators
 
         /// <summary>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

