### PR TITLE
[csharp] Update UserAgent in the async version of ClientAPI execute method.

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -58,7 +58,6 @@ namespace {{packageName}}.Client
             {{#netStandard}}
             RestClient.IgnoreResponseStatusCode = true;
             {{/netStandard}}
-            RestClient.UserAgent = Configuration.UserAgent;
         }
 
         /// <summary>
@@ -74,7 +73,6 @@ namespace {{packageName}}.Client
             {{#netStandard}}
             RestClient.IgnoreResponseStatusCode = true;
             {{/netStandard}}
-            RestClient.UserAgent = Configuration.UserAgent;
         }
 
         /// <summary>
@@ -205,7 +203,7 @@ namespace {{packageName}}.Client
             {{#netStandard}}RestClient.Timeout = TimeSpan.FromMilliseconds(Configuration.Timeout);{{/netStandard}}
             {{^netStandard}}RestClient.Timeout = Configuration.Timeout;{{/netStandard}}
             // set user agent
-
+            RestClient.UserAgent = Configuration.UserAgent;
             InterceptRequest(request);
             {{#netStandard}}
             var response = RestClient.Execute(request).Result;
@@ -246,6 +244,7 @@ namespace {{packageName}}.Client
             var request = PrepareRequest(
                 path, method, queryParams, postBody, headerParams, formParams, fileParams,
                 pathParams, contentType);
+            RestClient.UserAgent = Configuration.UserAgent;
             InterceptRequest(request);
             var response = await RestClient.Execute{{^netStandard}}TaskAsync{{/netStandard}}(request);
             InterceptResponse(request, response);

--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -58,6 +58,7 @@ namespace {{packageName}}.Client
             {{#netStandard}}
             RestClient.IgnoreResponseStatusCode = true;
             {{/netStandard}}
+            RestClient.UserAgent = Configuration.UserAgent;
         }
 
         /// <summary>
@@ -203,7 +204,6 @@ namespace {{packageName}}.Client
             {{#netStandard}}RestClient.Timeout = TimeSpan.FromMilliseconds(Configuration.Timeout);{{/netStandard}}
             {{^netStandard}}RestClient.Timeout = Configuration.Timeout;{{/netStandard}}
             // set user agent
-            RestClient.UserAgent = Configuration.UserAgent;
 
             InterceptRequest(request);
             {{#netStandard}}

--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -204,6 +204,7 @@ namespace {{packageName}}.Client
             {{^netStandard}}RestClient.Timeout = Configuration.Timeout;{{/netStandard}}
             // set user agent
             RestClient.UserAgent = Configuration.UserAgent;
+
             InterceptRequest(request);
             {{#netStandard}}
             var response = RestClient.Execute(request).Result;

--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -74,6 +74,7 @@ namespace {{packageName}}.Client
             {{#netStandard}}
             RestClient.IgnoreResponseStatusCode = true;
             {{/netStandard}}
+            RestClient.UserAgent = Configuration.UserAgent;
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -202,6 +202,7 @@ namespace Org.OpenAPITools.Client
             var request = PrepareRequest(
                 path, method, queryParams, postBody, headerParams, formParams, fileParams,
                 pathParams, contentType);
+            RestClient.UserAgent = Configuration.UserAgent;
             InterceptRequest(request);
             var response = await RestClient.ExecuteTaskAsync(request);
             InterceptResponse(request, response);


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@mandrean , @jimschubert 

### Description of the PR

This is a simple change which adds the UserAgent to CallApiAsync method, just like it is set in the CallApi method.

This resolves #3595, but there still is some discussion which I'd like to have on the interaction and circular definition on the Configuration object and the RestClient. 
