### PR TITLE
[typescript-fetch]: Fix package.json main.

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
@@ -3,8 +3,8 @@
   "version": "{{npmVersion}}",
   "description": "OpenAPI client for {{npmName}}",
   "author": "OpenAPI-Generator",
-  "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "main": "./dist/src/index.js",
+  "typings": "./dist/src/index.d.ts",
   "scripts" : {
     "build": "tsc",
     "prepare": "npm run build"

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "OpenAPI client for @openapitools/typescript-fetch-petstore",
   "author": "OpenAPI-Generator",
-  "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "main": "./dist/src/index.js",
+  "typings": "./dist/src/index.d.ts",
   "scripts" : {
     "build": "tsc",
     "prepare": "npm run build"

--- a/samples/client/petstore/typescript-fetch/builds/namespace-parameter-interfaces/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/namespace-parameter-interfaces/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "OpenAPI client for @openapitools/typescript-fetch-petstore",
   "author": "OpenAPI-Generator",
-  "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "main": "./dist/src/index.js",
+  "typings": "./dist/src/index.d.ts",
   "scripts" : {
     "build": "tsc",
     "prepare": "npm run build"

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "OpenAPI client for @openapitools/typescript-fetch-petstore",
   "author": "OpenAPI-Generator",
-  "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "main": "./dist/src/index.js",
+  "typings": "./dist/src/index.d.ts",
   "scripts" : {
     "build": "tsc",
     "prepare": "npm run build"


### PR DESCRIPTION
The "main" and "typings" files are generated under "./dist/src", not
"./dist".

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Update the "main" and "typings" properties in package.json to match the files actually generated.

