### PR TITLE
Simple spelling error in dotnet core comments

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Multimap.mustache
@@ -277,7 +277,7 @@ namespace {{packageName}}.Client
         #region Private Members
 
         /**
-         * Helper method to encapsulate generator differences between dictioary types.
+         * Helper method to encapsulate generator differences between dictionary types.
          */
         private bool TryRemove(T key, out IList<TValue> value)
         {
@@ -299,7 +299,7 @@ namespace {{packageName}}.Client
         }
 
         /**
-         * Helper method to encapsulate generator differences between dictioary types.
+         * Helper method to encapsulate generator differences between dictionary types.
          */
         private bool TryAdd(T key, IList<TValue> value)
         {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Multimap.cs
@@ -286,7 +286,7 @@ namespace Org.OpenAPITools.Client
         #region Private Members
 
         /**
-         * Helper method to encapsulate generator differences between dictioary types.
+         * Helper method to encapsulate generator differences between dictionary types.
          */
         private bool TryRemove(T key, out IList<TValue> value)
         {
@@ -295,7 +295,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /**
-         * Helper method to encapsulate generator differences between dictioary types.
+         * Helper method to encapsulate generator differences between dictionary types.
          */
         private bool TryAdd(T key, IList<TValue> value)
         {


### PR DESCRIPTION
Dictioary -> Dictionary

### PR checklist

- [ x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ x ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Just a simple spelling error fix.

CC/ @mandrean  @jimschubert

