### PR TITLE
Re-enable kotlin client tests in Shippable CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1243,9 +1243,9 @@
                 <module>samples/client/petstore/elixir</module>
                 <module>samples/client/petstore/erlang-client</module>
                 <module>samples/client/petstore/erlang-proper</module>
-                <!--<module>samples/client/petstore/kotlin/</module>
+                <module>samples/client/petstore/kotlin/</module>
                 <module>samples/client/petstore/kotlin-threetenbp/</module>
-                <module>samples/client/petstore/kotlin-string/</module>-->
+                <module>samples/client/petstore/kotlin-string/</module>
                 <!-- servers -->
                 <module>samples/server/petstore/erlang-server</module>
                 <module>samples/server/petstore/jaxrs/jersey2</module>

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -74,10 +74,12 @@ open class ApiClient(val baseUrl: String) {
 
     protected fun updateAuthParams(requestConfig: RequestConfig) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
-            if (apiKeyPrefix["api_key"] != null) {
-                requestConfig.headers["api_key"] = apiKeyPrefix["api_key"] + " " + apiKey["api_key"]
-            } else {
-                requestConfig.headers["api_key"] = apiKey["api_key"]
+            if (apiKey["api_key"] != null) {
+                if (apiKeyPrefix["api_key"] != null) {
+                    requestConfig.headers["api_key"] = apiKeyPrefix["api_key"]!! + " " + apiKey["api_key"]!!
+                } else {
+                    requestConfig.headers["api_key"] = apiKey["api_key"]!!
+                }
             }
         }
         if (requestConfig.headers[Authorization].isNullOrEmpty()) {

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -74,10 +74,12 @@ open class ApiClient(val baseUrl: String) {
 
     protected fun updateAuthParams(requestConfig: RequestConfig) {
         if (requestConfig.headers["api_key"].isNullOrEmpty()) {
-            if (apiKeyPrefix["api_key"] != null) {
-                requestConfig.headers["api_key"] = apiKeyPrefix["api_key"] + " " + apiKey["api_key"]
-            } else {
-                requestConfig.headers["api_key"] = apiKey["api_key"]
+            if (apiKey["api_key"] != null) {
+                if (apiKeyPrefix["api_key"] != null) {
+                    requestConfig.headers["api_key"] = apiKeyPrefix["api_key"]!! + " " + apiKey["api_key"]!!
+                } else {
+                    requestConfig.headers["api_key"] = apiKey["api_key"]!!
+                }
             }
         }
         if (requestConfig.headers[Authorization].isNullOrEmpty()) {


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

cc @jimschubert (2017/09, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04)

