### PR TITLE
[java] fix ClassCastException in toDefaultValue()

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -718,7 +718,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     public String toDefaultValue(Schema p) {
         p = ModelUtils.getReferencedSchema(this.openAPI, p);
         if (ModelUtils.isArraySchema(p)) {
-            final ArraySchema ap = (ArraySchema) p;
             final String pattern;
             if (fullJavaUtil) {
                 pattern = "new java.util.ArrayList<%s>()";
@@ -726,13 +725,15 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                 pattern = "new ArrayList<%s>()";
             }
 
-            if (ap.getItems() == null) {
-                LOGGER.error("`{}` (array property) does not have a proper inner type defined. Default to type:string", ap.getName());
-                Schema inner = new StringSchema().description("TODO default missing array inner type to string");
-                ap.setItems(inner);
+            Schema<?> items;
+            if (p instanceof ArraySchema && ((ArraySchema) p).getItems() != null) {
+                items = ((ArraySchema) p).getItems();
+            } else {
+                LOGGER.error("`{}` (array property) does not have a proper inner type defined. Default to type:string", p.getName());
+                items = new StringSchema().description("TODO default missing array inner type to string");
             }
 
-            String typeDeclaration = getTypeDeclaration(ap.getItems());
+            String typeDeclaration = getTypeDeclaration(items);
             Object java8obj = additionalProperties.get("java8");
             if (java8obj != null) {
                 Boolean java8 = Boolean.valueOf(java8obj.toString());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -18,6 +18,10 @@
 package org.openapitools.codegen.java;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.TestUtils;
@@ -300,6 +304,17 @@ public class AbstractJavaCodegenTest {
         codegen.preprocessOpenAPI(api);
 
         Assert.assertEquals(codegen.getArtifactVersion(), "1.0.0-SNAPSHOT");
+    }
+
+    @Test
+    public void toDefaultValueTest() {
+        final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+
+        Schema schema = new ObjectSchema()
+                .addProperties("id", new IntegerSchema().format("int32"))
+                .minItems(1);
+        String defaultValue = codegen.toDefaultValue(schema);
+        Assert.assertEquals(defaultValue, "new ArrayList<String>()");
     }
 
     private static class P_AbstractJavaCodegen extends AbstractJavaCodegen {


### PR DESCRIPTION
Fixes #3761

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. **java**: @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)

### Description of the PR

This PR fixes the `java.lang.ClassCastException`:
```
java.lang.ClassCastException: io.swagger.v3.oas.models.media.ObjectSchema cannot be cast to io.swagger.v3.oas.models.media.ArraySchema
	at org.openapitools.codegen.languages.AbstractJavaCodegen.toDefaultValue(AbstractJavaCodegen.java:721)
	at org.openapitools.codegen.DefaultCodegen.fromProperty(DefaultCodegen.java:2058)
	at org.openapitools.codegen.DefaultCodegen.fromProperty(DefaultCodegen.java:2271)
	at org.openapitools.codegen.DefaultCodegen.addVars(DefaultCodegen.java:3706)
	at org.openapitools.codegen.DefaultCodegen.addVars(DefaultCodegen.java:3654)
	at org.openapitools.codegen.DefaultCodegen.fromModel(DefaultCodegen.java:1918)
	at org.openapitools.codegen.languages.AbstractJavaCodegen.fromModel(AbstractJavaCodegen.java:942)
	at org.openapitools.codegen.DefaultGenerator.processModels(DefaultGenerator.java:1198)
	at org.openapitools.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:465)
```