### PR TITLE
[core] [regression] set parentName when a single possible parent exists

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -896,6 +896,8 @@ public class ModelUtils {
     public static String getParentName(ComposedSchema composedSchema, Map<String, Schema> allSchemas) {
         List<Schema> interfaces = getInterfaces(composedSchema);
 
+        List<String> refedParentNames = new ArrayList<>();
+
         if (interfaces != null && !interfaces.isEmpty()) {
             for (Schema schema : interfaces) {
                 // get the actual schema
@@ -911,11 +913,19 @@ public class ModelUtils {
                     } else {
                         LOGGER.debug("Not a parent since discriminator.propertyName is not set {}", s.get$ref());
                         // not a parent since discriminator.propertyName is not set
+                        refedParentNames.add(parentName);
                     }
                 } else {
                     // not a ref, doing nothing
                 }
             }
+        }
+
+        // parent name only makes sense when there is a single obvious parent
+        if (refedParentNames.size() == 1) {
+            LOGGER.warn("[deprecated] inheritance without use of 'discriminator.propertyName' is deprecated " +
+                    "and will be removed in a future release. Generating model for {}", composedSchema.getName());
+            return refedParentNames.get(0);
         }
 
         return null;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaInheritanceTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaInheritanceTest.java
@@ -32,9 +32,10 @@ import org.testng.annotations.Test;
 
 public class JavaInheritanceTest {
 
-    @Test(description = "convert a composed model without discriminator")
+
+    @Test(description = "convert a composed model with parent")
     public void javaInheritanceTest() {
-        final Schema allOfModel = new Schema().name("Base");
+        final Schema parentModel = new Schema().name("Base");
 
         final Schema schema = new ComposedSchema()
                 .addAllOfItem(new Schema().$ref("Base"))
@@ -42,7 +43,7 @@ public class JavaInheritanceTest {
 
         OpenAPI openAPI = TestUtils.createOpenAPI();
         openAPI.setComponents(new Components()
-                .addSchemas(allOfModel.getName(), allOfModel)
+                .addSchemas(parentModel.getName(),parentModel)
                 .addSchemas(schema.getName(), schema)
         );
 
@@ -52,7 +53,7 @@ public class JavaInheritanceTest {
 
         Assert.assertEquals(cm.name, "sample");
         Assert.assertEquals(cm.classname, "Sample");
-        Assert.assertEquals(cm.parent, null);
+        Assert.assertEquals(cm.parent, "Base");
         Assert.assertEquals(cm.imports, Sets.newHashSet("Base"));
     }
 


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
Whilst the spec states that the 'allOf' relationship does not imply a hierarchy:

> While composition offers model extensibility, it does not imply a hierarchy between the models.
> To support polymorphism, the OpenAPI Specification adds the discriminator field.

Unfortunately this does not make sense for many existing use cases, that were supported by older
versions of the generator. Therefore, I've restored the older behavior, specifically
in the case that only a single possible parent schema is present.

I think a more complete solution would generate interfaces for the composed schemas,
and mark the generated class as implementing these.

@wing328 I guess you're probably the best person to review this, given that you overhauled the support for `anyOf`, `allOf`, `oneOf` originally. 

I'd be interested if you had an alternative suggestion for achieving this without requiring the parent schema to know the identity of all the extending schema's - in our real definition collection, we have a set of common models that many different entities extend from in other definition files, and we have also build some common library functions that we use on the generated sub classes that accept objects extending from the parent.

Admittedly, our method of using allOf to express this feels awkward. Ideally I'd like a way to generate a generic `Page<T>` class that could then be used as `Page<Cat>`, `Page<Dog>`, etc but I'm not aware of anyway to do this with the openapi spec / code gen tooling.

Example YAML:
```
openapi: 3.0.0
info:
  title: example
  description: example
  version: 0.0.0
paths:
  /test:
    get:
      tags:
        - Test
      summary: test
      description: test
      operationId: getCats
      responses:
        '200':
          description: successful
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/PagedCats'
components:
  schemas:
    Page:
      properties:
        page:
          type: integer
      required:
        - page
    Cat:
      properties:
        id:
          type: string
          format: uuid
        required:
          - id
    Dog:
      properties:
        id:
          type: string
          format: uuid
        required:
          - id
    PagedCats:
      allOf:
        - $ref: '#/components/schemas/Page'
        - properties:
            items:
              type: array
              items:
                $ref: '#/components/schemas/Cat'
          required:
            - items
    PagedDogs:
      allOf:
        - $ref: '#/components/schemas/Page'
        - properties:
            items:
              type: array
              items:
                $ref: '#/components/schemas/Dog'
          required:
            - items
```

fixes #2845, and fixes #3523