### PR TITLE
Add flutter web support on jaguar dart

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-jaguar/apilib.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-jaguar/apilib.mustache
@@ -1,6 +1,6 @@
 library {{pubName}}.api;
 
-import 'package:http/io_client.dart';
+import 'package:http/http.dart' as http;
 import 'package:jaguar_serializer/jaguar_serializer.dart';
 {{#protoFormat}}
 import 'package:jaguar_serializer_protobuf/proto_repo.dart';
@@ -52,7 +52,7 @@ class {{clientName}} {
     * Add custom global interceptors, put overrideInterceptors to true to set your interceptors only (auth interceptors will not be added)
     */
     {{clientName}}({List<Interceptor> interceptors, bool overrideInterceptors = false, String baseUrl, this.timeout = const Duration(minutes: 2)}) {
-        _baseRoute = Route(baseUrl ?? basePath).withClient(globalClient ?? IOClient());
+        _baseRoute = Route(baseUrl ?? basePath).withClient(globalClient ?? http.Client());
         if(interceptors == null) {
             this.interceptors = _defaultInterceptors;
         }

--- a/samples/client/petstore/dart-jaguar/flutter_petstore/openapi/lib/api.dart
+++ b/samples/client/petstore/dart-jaguar/flutter_petstore/openapi/lib/api.dart
@@ -1,6 +1,6 @@
 library openapi.api;
 
-import 'package:http/io_client.dart';
+import 'package:http/http.dart' as http;
 import 'package:jaguar_serializer/jaguar_serializer.dart';
 import 'package:jaguar_retrofit/jaguar_retrofit.dart';
 import 'package:openapi/auth/api_key_auth.dart';
@@ -47,7 +47,7 @@ class Openapi {
     * Add custom global interceptors, put overrideInterceptors to true to set your interceptors only (auth interceptors will not be added)
     */
     Openapi({List<Interceptor> interceptors, bool overrideInterceptors = false, String baseUrl, this.timeout = const Duration(minutes: 2)}) {
-        _baseRoute = Route(baseUrl ?? basePath).withClient(globalClient ?? IOClient());
+        _baseRoute = Route(baseUrl ?? basePath).withClient(globalClient ?? http.Client());
         if(interceptors == null) {
             this.interceptors = _defaultInterceptors;
         }

--- a/samples/client/petstore/dart-jaguar/flutter_proto_petstore/openapi/lib/api.dart
+++ b/samples/client/petstore/dart-jaguar/flutter_proto_petstore/openapi/lib/api.dart
@@ -1,6 +1,6 @@
 library openapi.api;
 
-import 'package:http/io_client.dart';
+import 'package:http/http.dart' as http;
 import 'package:jaguar_serializer/jaguar_serializer.dart';
 import 'package:jaguar_serializer_protobuf/proto_repo.dart';
 import 'package:jaguar_retrofit/jaguar_retrofit.dart';
@@ -57,7 +57,7 @@ class Openapi {
     * Add custom global interceptors, put overrideInterceptors to true to set your interceptors only (auth interceptors will not be added)
     */
     Openapi({List<Interceptor> interceptors, bool overrideInterceptors = false, String baseUrl, this.timeout = const Duration(minutes: 2)}) {
-        _baseRoute = Route(baseUrl ?? basePath).withClient(globalClient ?? IOClient());
+        _baseRoute = Route(baseUrl ?? basePath).withClient(globalClient ?? http.Client());
         if(interceptors == null) {
             this.interceptors = _defaultInterceptors;
         }

--- a/samples/client/petstore/dart-jaguar/openapi/lib/api.dart
+++ b/samples/client/petstore/dart-jaguar/openapi/lib/api.dart
@@ -1,6 +1,6 @@
 library openapi.api;
 
-import 'package:http/io_client.dart';
+import 'package:http/http.dart' as http;
 import 'package:jaguar_serializer/jaguar_serializer.dart';
 import 'package:jaguar_retrofit/jaguar_retrofit.dart';
 import 'package:openapi/auth/api_key_auth.dart';
@@ -47,7 +47,7 @@ class Openapi {
     * Add custom global interceptors, put overrideInterceptors to true to set your interceptors only (auth interceptors will not be added)
     */
     Openapi({List<Interceptor> interceptors, bool overrideInterceptors = false, String baseUrl, this.timeout = const Duration(minutes: 2)}) {
-        _baseRoute = Route(baseUrl ?? basePath).withClient(globalClient ?? IOClient());
+        _baseRoute = Route(baseUrl ?? basePath).withClient(globalClient ?? http.Client());
         if(interceptors == null) {
             this.interceptors = _defaultInterceptors;
         }

--- a/samples/client/petstore/dart-jaguar/openapi_proto/lib/api.dart
+++ b/samples/client/petstore/dart-jaguar/openapi_proto/lib/api.dart
@@ -1,6 +1,6 @@
 library openapi.api;
 
-import 'package:http/io_client.dart';
+import 'package:http/http.dart' as http;
 import 'package:jaguar_serializer/jaguar_serializer.dart';
 import 'package:jaguar_serializer_protobuf/proto_repo.dart';
 import 'package:jaguar_retrofit/jaguar_retrofit.dart';
@@ -57,7 +57,7 @@ class Openapi {
     * Add custom global interceptors, put overrideInterceptors to true to set your interceptors only (auth interceptors will not be added)
     */
     Openapi({List<Interceptor> interceptors, bool overrideInterceptors = false, String baseUrl, this.timeout = const Duration(minutes: 2)}) {
-        _baseRoute = Route(baseUrl ?? basePath).withClient(globalClient ?? IOClient());
+        _baseRoute = Route(baseUrl ?? basePath).withClient(globalClient ?? http.Client());
         if(interceptors == null) {
             this.interceptors = _defaultInterceptors;
         }


### PR DESCRIPTION
IOClient was for pure dart, now we need to use `Client` that will use either IOClient or Browserclient 
 