### PR TITLE
Fix Dart2 default template

### DIFF
--- a/bin/dart2-petstore.sh
+++ b/bin/dart2-petstore.sh
@@ -29,18 +29,18 @@ fi
 export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 
 # Generate non-browserClient
-ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart -o samples/client/petstore/dart2/openapi --additional-properties hideGenerationTimestamp=true,browserClient=false  $@"
+ags="generate -t modules/openapi-generator/src/main/resources/dart2 -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart -o samples/client/petstore/dart2/openapi --additional-properties hideGenerationTimestamp=true,browserClient=false  $@"
 
 # then options to generate the library for vm would be:
 #ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart -o samples/client/petstore/dart2/openapi_vm --additional-properties browserClient=false,pubName=openapi_vm $@"
 java $JAVA_OPTS -jar $executable $ags
 
 # Generate browserClient
-ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart -o samples/client/petstore/dart2/openapi-browser-client --additional-properties hideGenerationTimestamp=true,browserClient=true  $@"
+ags="generate -t modules/openapi-generator/src/main/resources/dart2 -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart -o samples/client/petstore/dart2/openapi-browser-client --additional-properties hideGenerationTimestamp=true,browserClient=true  $@"
 java $JAVA_OPTS -jar $executable $ags
 
 # Generate non-browserClient and put it to the flutter sample app
-ags="generate -t modules/openapi-generator/src/main/resources/dart -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart -o samples/client/petstore/dart2/flutter_petstore/openapi --additional-properties hideGenerationTimestamp=true,browserClient=false  $@"
+ags="generate -t modules/openapi-generator/src/main/resources/dart2 -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g dart -o samples/client/petstore/dart2/flutter_petstore/openapi --additional-properties hideGenerationTimestamp=true,browserClient=false  $@"
 java $JAVA_OPTS -jar $executable $ags
 
 # There is a proposal to allow importing different libraries depending on the environment:

--- a/docs/generators/dart-jaguar.md
+++ b/docs/generators/dart-jaguar.md
@@ -17,6 +17,6 @@ sidebar_label: dart-jaguar
 |pubDescription|Description in generated pubspec| |null|
 |useEnumExtension|Allow the 'x-enum-values' extension for enums| |null|
 |sourceFolder|Source folder for generated code| |null|
-|supportDart2|Support Dart 2.x| |true|
+|supportDart2|Support Dart 2.x (Dart 1.x support has been deprecated)| |true|
 |nullableFields|Is the null fields should be in the JSON payload| |null|
 |serialization|Choose serialization format JSON or PROTO is supported| |null|

--- a/docs/generators/dart.md
+++ b/docs/generators/dart.md
@@ -17,4 +17,4 @@ sidebar_label: dart
 |pubDescription|Description in generated pubspec| |null|
 |useEnumExtension|Allow the 'x-enum-values' extension for enums| |null|
 |sourceFolder|Source folder for generated code| |null|
-|supportDart2|Support Dart 2.x| |true|
+|supportDart2|Support Dart 2.x (Dart 1.x support has been deprecated)| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -62,7 +62,7 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         outputFolder = "generated-code/dart";
         modelTemplateFiles.put("model.mustache", ".dart");
         apiTemplateFiles.put("api.mustache", ".dart");
-        embeddedTemplateDir = templateDir = "dart";
+        embeddedTemplateDir = templateDir = "dart2";
         apiPackage = "lib.api";
         modelPackage = "lib.model";
         modelDocTemplateFiles.put("object_doc.mustache", ".md");
@@ -124,7 +124,7 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(new CliOption(PUB_DESCRIPTION, "Description in generated pubspec"));
         cliOptions.add(new CliOption(USE_ENUM_EXTENSION, "Allow the 'x-enum-values' extension for enums"));
         cliOptions.add(new CliOption(CodegenConstants.SOURCE_FOLDER, "Source folder for generated code"));
-        cliOptions.add(CliOption.newBoolean(SUPPORT_DART2, "Support Dart 2.x").defaultValue(Boolean.TRUE.toString()));
+        cliOptions.add(CliOption.newBoolean(SUPPORT_DART2, "Support Dart 2.x (Dart 1.x support has been deprecated)").defaultValue(Boolean.TRUE.toString()));
     }
 
     @Override
@@ -139,7 +139,7 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String getHelp() {
-        return "Generates a Dart (1.x or 2.x) client library.";
+        return "Generates a Dart (1.x (deprecated) or 2.x) client library.";
     }
 
     @Override

--- a/samples/client/petstore/dart/flutter_petstore/swagger/.travis.yml
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/.travis.yml
@@ -3,7 +3,7 @@
 language: dart
 dart:
 # Install a specific stable release
-- "2.2.0"
+- "1.24.3"
 install:
 - pub get
 

--- a/samples/client/petstore/dart/flutter_petstore/swagger/README.md
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/README.md
@@ -44,10 +44,10 @@ Please follow the [installation procedure](#installation--usage) and then run th
 import 'package:openapi/api.dart';
 
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
+//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
 
-var api_instance = PetApi();
-var body = Pet(); // Pet | Pet object that needs to be added to the store
+var api_instance = new PetApi();
+var body = new Pet(); // Pet | Pet object that needs to be added to the store
 
 try {
     api_instance.addPet(body);

--- a/samples/client/petstore/dart/flutter_petstore/swagger/docs/PetApi.md
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/docs/PetApi.md
@@ -28,10 +28,10 @@ Add a new pet to the store
 ```dart
 import 'package:openapi/api.dart';
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
+//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
 
-var api_instance = PetApi();
-var body = Pet(); // Pet | Pet object that needs to be added to the store
+var api_instance = new PetApi();
+var body = new Pet(); // Pet | Pet object that needs to be added to the store
 
 try { 
     api_instance.addPet(body);
@@ -70,9 +70,9 @@ Deletes a pet
 ```dart
 import 'package:openapi/api.dart';
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
+//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
 
-var api_instance = PetApi();
+var api_instance = new PetApi();
 var petId = 789; // int | Pet id to delete
 var apiKey = apiKey_example; // String | 
 
@@ -116,9 +116,9 @@ Multiple status values can be provided with comma separated strings
 ```dart
 import 'package:openapi/api.dart';
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
+//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
 
-var api_instance = PetApi();
+var api_instance = new PetApi();
 var status = []; // List<String> | Status values that need to be considered for filter
 
 try { 
@@ -161,9 +161,9 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 ```dart
 import 'package:openapi/api.dart';
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
+//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
 
-var api_instance = PetApi();
+var api_instance = new PetApi();
 var tags = []; // List<String> | Tags to filter by
 
 try { 
@@ -206,11 +206,11 @@ Returns a single pet
 ```dart
 import 'package:openapi/api.dart';
 // TODO Configure API key authorization: api_key
-//defaultApiClient.getAuthentication<ApiKeyAuth>('api_key').apiKey = 'YOUR_API_KEY';
+//openapi.api.Configuration.apiKey{'api_key'} = 'YOUR_API_KEY';
 // uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-//defaultApiClient.getAuthentication<ApiKeyAuth>('api_key').apiKeyPrefix = 'Bearer';
+//openapi.api.Configuration.apiKeyPrefix{'api_key'} = "Bearer";
 
-var api_instance = PetApi();
+var api_instance = new PetApi();
 var petId = 789; // int | ID of pet to return
 
 try { 
@@ -251,10 +251,10 @@ Update an existing pet
 ```dart
 import 'package:openapi/api.dart';
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
+//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
 
-var api_instance = PetApi();
-var body = Pet(); // Pet | Pet object that needs to be added to the store
+var api_instance = new PetApi();
+var body = new Pet(); // Pet | Pet object that needs to be added to the store
 
 try { 
     api_instance.updatePet(body);
@@ -293,9 +293,9 @@ Updates a pet in the store with form data
 ```dart
 import 'package:openapi/api.dart';
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
+//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
 
-var api_instance = PetApi();
+var api_instance = new PetApi();
 var petId = 789; // int | ID of pet that needs to be updated
 var name = name_example; // String | Updated name of the pet
 var status = status_example; // String | Updated status of the pet
@@ -339,9 +339,9 @@ uploads an image
 ```dart
 import 'package:openapi/api.dart';
 // TODO Configure OAuth2 access token for authorization: petstore_auth
-//defaultApiClient.getAuthentication<OAuth>('petstore_auth').accessToken = 'YOUR_ACCESS_TOKEN';
+//openapi.api.Configuration.accessToken = 'YOUR_ACCESS_TOKEN';
 
-var api_instance = PetApi();
+var api_instance = new PetApi();
 var petId = 789; // int | ID of pet to update
 var additionalMetadata = additionalMetadata_example; // String | Additional data to pass to server
 var file = BINARY_DATA_HERE; // MultipartFile | file to upload

--- a/samples/client/petstore/dart/flutter_petstore/swagger/docs/StoreApi.md
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/docs/StoreApi.md
@@ -26,7 +26,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = StoreApi();
+var api_instance = new StoreApi();
 var orderId = orderId_example; // String | ID of the order that needs to be deleted
 
 try { 
@@ -68,11 +68,11 @@ Returns a map of status codes to quantities
 ```dart
 import 'package:openapi/api.dart';
 // TODO Configure API key authorization: api_key
-//defaultApiClient.getAuthentication<ApiKeyAuth>('api_key').apiKey = 'YOUR_API_KEY';
+//openapi.api.Configuration.apiKey{'api_key'} = 'YOUR_API_KEY';
 // uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-//defaultApiClient.getAuthentication<ApiKeyAuth>('api_key').apiKeyPrefix = 'Bearer';
+//openapi.api.Configuration.apiKeyPrefix{'api_key'} = "Bearer";
 
-var api_instance = StoreApi();
+var api_instance = new StoreApi();
 
 try { 
     var result = api_instance.getInventory();
@@ -111,7 +111,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = StoreApi();
+var api_instance = new StoreApi();
 var orderId = 789; // int | ID of pet that needs to be fetched
 
 try { 
@@ -152,8 +152,8 @@ Place an order for a pet
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = StoreApi();
-var body = Order(); // Order | order placed for purchasing the pet
+var api_instance = new StoreApi();
+var body = new Order(); // Order | order placed for purchasing the pet
 
 try { 
     var result = api_instance.placeOrder(body);

--- a/samples/client/petstore/dart/flutter_petstore/swagger/docs/UserApi.md
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/docs/UserApi.md
@@ -30,8 +30,8 @@ This can only be done by the logged in user.
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = UserApi();
-var body = User(); // User | Created user object
+var api_instance = new UserApi();
+var body = new User(); // User | Created user object
 
 try { 
     api_instance.createUser(body);
@@ -70,8 +70,8 @@ Creates list of users with given input array
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = UserApi();
-var body = [List&lt;User&gt;()]; // List<User> | List of user object
+var api_instance = new UserApi();
+var body = [new List&lt;User&gt;()]; // List<User> | List of user object
 
 try { 
     api_instance.createUsersWithArrayInput(body);
@@ -110,8 +110,8 @@ Creates list of users with given input array
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = UserApi();
-var body = [List&lt;User&gt;()]; // List<User> | List of user object
+var api_instance = new UserApi();
+var body = [new List&lt;User&gt;()]; // List<User> | List of user object
 
 try { 
     api_instance.createUsersWithListInput(body);
@@ -152,7 +152,7 @@ This can only be done by the logged in user.
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = UserApi();
+var api_instance = new UserApi();
 var username = username_example; // String | The name that needs to be deleted
 
 try { 
@@ -192,7 +192,7 @@ Get user by user name
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = UserApi();
+var api_instance = new UserApi();
 var username = username_example; // String | The name that needs to be fetched. Use user1 for testing.
 
 try { 
@@ -233,7 +233,7 @@ Logs user into the system
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = UserApi();
+var api_instance = new UserApi();
 var username = username_example; // String | The user name for login
 var password = password_example; // String | The password for login in clear text
 
@@ -276,7 +276,7 @@ Logs out current logged in user session
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = UserApi();
+var api_instance = new UserApi();
 
 try { 
     api_instance.logoutUser();
@@ -314,9 +314,9 @@ This can only be done by the logged in user.
 ```dart
 import 'package:openapi/api.dart';
 
-var api_instance = UserApi();
+var api_instance = new UserApi();
 var username = username_example; // String | name that need to be deleted
-var body = User(); // User | Updated user object
+var body = new User(); // User | Updated user object
 
 try { 
     api_instance.updateUser(username, body);

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api.dart
@@ -24,4 +24,4 @@ part 'model/tag.dart';
 part 'model/user.dart';
 
 
-ApiClient defaultApiClient = ApiClient();
+ApiClient defaultApiClient = new ApiClient();

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/pet_api.dart
@@ -15,7 +15,7 @@ class PetApi {
 
     // verify required params are set
     if(body == null) {
-     throw ApiException(400, "Missing required param: body");
+     throw new ApiException(400, "Missing required param: body");
     }
 
     // create path and map variables
@@ -28,12 +28,12 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -50,7 +50,7 @@ class PetApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;
@@ -60,11 +60,11 @@ class PetApi {
   ///
   /// 
   Future deletePet(int petId, { String apiKey }) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(petId == null) {
-     throw ApiException(400, "Missing required param: petId");
+     throw new ApiException(400, "Missing required param: petId");
     }
 
     // create path and map variables
@@ -78,12 +78,12 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -100,7 +100,7 @@ class PetApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;
@@ -110,11 +110,11 @@ class PetApi {
   ///
   /// Multiple status values can be provided with comma separated strings
   Future<List<Pet>> findPetsByStatus(List<String> status) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(status == null) {
-     throw ApiException(400, "Missing required param: status");
+     throw new ApiException(400, "Missing required param: status");
     }
 
     // create path and map variables
@@ -128,12 +128,12 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -150,7 +150,7 @@ class PetApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
       return (apiClient.deserialize(_decodeBodyBytes(response), 'List<Pet>') as List).map((item) => item as Pet).toList();
     } else {
@@ -161,11 +161,11 @@ class PetApi {
   ///
   /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
   Future<List<Pet>> findPetsByTags(List<String> tags) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(tags == null) {
-     throw ApiException(400, "Missing required param: tags");
+     throw new ApiException(400, "Missing required param: tags");
     }
 
     // create path and map variables
@@ -179,12 +179,12 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -201,7 +201,7 @@ class PetApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
       return (apiClient.deserialize(_decodeBodyBytes(response), 'List<Pet>') as List).map((item) => item as Pet).toList();
     } else {
@@ -212,11 +212,11 @@ class PetApi {
   ///
   /// Returns a single pet
   Future<Pet> getPetById(int petId) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(petId == null) {
-     throw ApiException(400, "Missing required param: petId");
+     throw new ApiException(400, "Missing required param: petId");
     }
 
     // create path and map variables
@@ -229,12 +229,12 @@ class PetApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = ["api_key"];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -251,7 +251,7 @@ class PetApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'Pet') as Pet;
     } else {
@@ -266,7 +266,7 @@ class PetApi {
 
     // verify required params are set
     if(body == null) {
-     throw ApiException(400, "Missing required param: body");
+     throw new ApiException(400, "Missing required param: body");
     }
 
     // create path and map variables
@@ -279,12 +279,12 @@ class PetApi {
 
     List<String> contentTypes = ["application/json","application/xml"];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -301,7 +301,7 @@ class PetApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;
@@ -311,11 +311,11 @@ class PetApi {
   ///
   /// 
   Future updatePetWithForm(int petId, { String name, String status }) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(petId == null) {
-     throw ApiException(400, "Missing required param: petId");
+     throw new ApiException(400, "Missing required param: petId");
     }
 
     // create path and map variables
@@ -328,12 +328,12 @@ class PetApi {
 
     List<String> contentTypes = ["application/x-www-form-urlencoded"];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if (name != null) {
         hasFields = true;
         mp.fields['name'] = parameterToString(name);
@@ -362,7 +362,7 @@ class PetApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;
@@ -372,11 +372,11 @@ class PetApi {
   ///
   /// 
   Future<ApiResponse> uploadFile(int petId, { String additionalMetadata, MultipartFile file }) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(petId == null) {
-     throw ApiException(400, "Missing required param: petId");
+     throw new ApiException(400, "Missing required param: petId");
     }
 
     // create path and map variables
@@ -389,12 +389,12 @@ class PetApi {
 
     List<String> contentTypes = ["multipart/form-data"];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = ["petstore_auth"];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if (additionalMetadata != null) {
         hasFields = true;
         mp.fields['additionalMetadata'] = parameterToString(additionalMetadata);
@@ -422,7 +422,7 @@ class PetApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'ApiResponse') as ApiResponse;
     } else {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/store_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/store_api.dart
@@ -11,11 +11,11 @@ class StoreApi {
   ///
   /// For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
   Future deleteOrder(String orderId) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(orderId == null) {
-     throw ApiException(400, "Missing required param: orderId");
+     throw new ApiException(400, "Missing required param: orderId");
     }
 
     // create path and map variables
@@ -28,12 +28,12 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -50,7 +50,7 @@ class StoreApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;
@@ -60,7 +60,7 @@ class StoreApi {
   ///
   /// Returns a map of status codes to quantities
   Future<Map<String, int>> getInventory() async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
 
@@ -74,12 +74,12 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = ["api_key"];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -96,9 +96,9 @@ class StoreApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
-      return Map<String, int>.from(apiClient.deserialize(_decodeBodyBytes(response), 'Map<String, int>'));
+      return new Map<String, int>.from(apiClient.deserialize(_decodeBodyBytes(response), 'Map<String, int>'));
           ;
     } else {
       return null;
@@ -108,11 +108,11 @@ class StoreApi {
   ///
   /// For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
   Future<Order> getOrderById(int orderId) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(orderId == null) {
-     throw ApiException(400, "Missing required param: orderId");
+     throw new ApiException(400, "Missing required param: orderId");
     }
 
     // create path and map variables
@@ -125,12 +125,12 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -147,7 +147,7 @@ class StoreApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'Order') as Order;
     } else {
@@ -162,7 +162,7 @@ class StoreApi {
 
     // verify required params are set
     if(body == null) {
-     throw ApiException(400, "Missing required param: body");
+     throw new ApiException(400, "Missing required param: body");
     }
 
     // create path and map variables
@@ -175,12 +175,12 @@ class StoreApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -197,7 +197,7 @@ class StoreApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'Order') as Order;
     } else {

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/user_api.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api/user_api.dart
@@ -15,7 +15,7 @@ class UserApi {
 
     // verify required params are set
     if(body == null) {
-     throw ApiException(400, "Missing required param: body");
+     throw new ApiException(400, "Missing required param: body");
     }
 
     // create path and map variables
@@ -28,12 +28,12 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -50,7 +50,7 @@ class UserApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;
@@ -64,7 +64,7 @@ class UserApi {
 
     // verify required params are set
     if(body == null) {
-     throw ApiException(400, "Missing required param: body");
+     throw new ApiException(400, "Missing required param: body");
     }
 
     // create path and map variables
@@ -77,12 +77,12 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -99,7 +99,7 @@ class UserApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;
@@ -113,7 +113,7 @@ class UserApi {
 
     // verify required params are set
     if(body == null) {
-     throw ApiException(400, "Missing required param: body");
+     throw new ApiException(400, "Missing required param: body");
     }
 
     // create path and map variables
@@ -126,12 +126,12 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -148,7 +148,7 @@ class UserApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;
@@ -158,11 +158,11 @@ class UserApi {
   ///
   /// This can only be done by the logged in user.
   Future deleteUser(String username) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(username == null) {
-     throw ApiException(400, "Missing required param: username");
+     throw new ApiException(400, "Missing required param: username");
     }
 
     // create path and map variables
@@ -175,12 +175,12 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -197,7 +197,7 @@ class UserApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;
@@ -207,11 +207,11 @@ class UserApi {
   ///
   /// 
   Future<User> getUserByName(String username) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(username == null) {
-     throw ApiException(400, "Missing required param: username");
+     throw new ApiException(400, "Missing required param: username");
     }
 
     // create path and map variables
@@ -224,12 +224,12 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -246,7 +246,7 @@ class UserApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'User') as User;
     } else {
@@ -257,14 +257,14 @@ class UserApi {
   ///
   /// 
   Future<String> loginUser(String username, String password) async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
     if(username == null) {
-     throw ApiException(400, "Missing required param: username");
+     throw new ApiException(400, "Missing required param: username");
     }
     if(password == null) {
-     throw ApiException(400, "Missing required param: password");
+     throw new ApiException(400, "Missing required param: password");
     }
 
     // create path and map variables
@@ -279,12 +279,12 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -301,7 +301,7 @@ class UserApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
       return apiClient.deserialize(_decodeBodyBytes(response), 'String') as String;
     } else {
@@ -312,7 +312,7 @@ class UserApi {
   ///
   /// 
   Future logoutUser() async {
-    Object postBody;
+    Object postBody = null;
 
     // verify required params are set
 
@@ -326,12 +326,12 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -348,7 +348,7 @@ class UserApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;
@@ -362,10 +362,10 @@ class UserApi {
 
     // verify required params are set
     if(username == null) {
-     throw ApiException(400, "Missing required param: username");
+     throw new ApiException(400, "Missing required param: username");
     }
     if(body == null) {
-     throw ApiException(400, "Missing required param: body");
+     throw new ApiException(400, "Missing required param: body");
     }
 
     // create path and map variables
@@ -378,12 +378,12 @@ class UserApi {
 
     List<String> contentTypes = [];
 
-    String contentType = contentTypes.isNotEmpty ? contentTypes[0] : "application/json";
+    String contentType = contentTypes.length > 0 ? contentTypes[0] : "application/json";
     List<String> authNames = [];
 
     if(contentType.startsWith("multipart/form-data")) {
       bool hasFields = false;
-      MultipartRequest mp = MultipartRequest(null, null);
+      MultipartRequest mp = new MultipartRequest(null, null);
       if(hasFields)
         postBody = mp;
     }
@@ -400,7 +400,7 @@ class UserApi {
                                              authNames);
 
     if(response.statusCode >= 400) {
-      throw ApiException(response.statusCode, _decodeBodyBytes(response));
+      throw new ApiException(response.statusCode, _decodeBodyBytes(response));
     } else if(response.body != null) {
     } else {
       return;

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api_client.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api_client.dart
@@ -10,18 +10,18 @@ class QueryParam {
 class ApiClient {
 
   String basePath;
-  var client = Client();
+  var client = new Client();
 
   Map<String, String> _defaultHeaderMap = {};
   Map<String, Authentication> _authentications = {};
 
-  final _regList = RegExp(r'^List<(.*)>$');
-  final _regMap = RegExp(r'^Map<String,(.*)>$');
+  final _RegList = new RegExp(r'^List<(.*)>$');
+  final _RegMap = new RegExp(r'^Map<String,(.*)>$');
 
-  ApiClient({this.basePath = "http://petstore.swagger.io/v2"}) {
+  ApiClient({this.basePath: "http://petstore.swagger.io/v2"}) {
     // Setup authentications (key: authentication name, value: authentication).
-    _authentications['api_key'] = ApiKeyAuth("header", "api_key");
-    _authentications['petstore_auth'] = OAuth();
+    _authentications['api_key'] = new ApiKeyAuth("header", "api_key");
+    _authentications['petstore_auth'] = new OAuth();
   }
 
   void addDefaultHeader(String key, String value) {
@@ -40,36 +40,36 @@ class ApiClient {
         case 'double':
           return value is double ? value : double.parse('$value');
         case 'ApiResponse':
-          return ApiResponse.fromJson(value);
+          return new ApiResponse.fromJson(value);
         case 'Category':
-          return Category.fromJson(value);
+          return new Category.fromJson(value);
         case 'Order':
-          return Order.fromJson(value);
+          return new Order.fromJson(value);
         case 'Pet':
-          return Pet.fromJson(value);
+          return new Pet.fromJson(value);
         case 'Tag':
-          return Tag.fromJson(value);
+          return new Tag.fromJson(value);
         case 'User':
-          return User.fromJson(value);
+          return new User.fromJson(value);
         default:
           {
             Match match;
             if (value is List &&
-                (match = _regList.firstMatch(targetType)) != null) {
+                (match = _RegList.firstMatch(targetType)) != null) {
               var newTargetType = match[1];
               return value.map((v) => _deserialize(v, newTargetType)).toList();
             } else if (value is Map &&
-                (match = _regMap.firstMatch(targetType)) != null) {
+                (match = _RegMap.firstMatch(targetType)) != null) {
               var newTargetType = match[1];
-              return Map.fromIterables(value.keys,
+              return new Map.fromIterables(value.keys,
                   value.values.map((v) => _deserialize(v, newTargetType)));
             }
           }
       }
-    } on Exception catch (e, stack) {
-      throw ApiException.withInner(500, 'Exception during deserialization.', e, stack);
+    } catch (e, stack) {
+      throw new ApiException.withInner(500, 'Exception during deserialization.', e, stack);
     }
-    throw ApiException(500, 'Could not find a suitable class for deserialization');
+    throw new ApiException(500, 'Could not find a suitable class for deserialization');
   }
 
   dynamic deserialize(String json, String targetType) {
@@ -78,7 +78,7 @@ class ApiClient {
 
     if (targetType == 'String') return json;
 
-    var decodedJson = jsonDecode(json);
+    var decodedJson = JSON.decode(json);
     return _deserialize(decodedJson, targetType);
   }
 
@@ -87,7 +87,7 @@ class ApiClient {
     if (obj == null) {
       serialized = '';
     } else {
-      serialized = json.encode(obj);
+      serialized = JSON.encode(obj);
     }
     return serialized;
   }
@@ -119,7 +119,7 @@ class ApiClient {
     headerParams['Content-Type'] = contentType;
 
     if(body is MultipartRequest) {
-      var request = MultipartRequest(method, Uri.parse(url));
+      var request = new MultipartRequest(method, Uri.parse(url));
       request.fields.addAll(body.fields);
       request.files.addAll(body.files);
       request.headers.addAll(body.headers);
@@ -148,14 +148,16 @@ class ApiClient {
   void _updateParamsForAuth(List<String> authNames, List<QueryParam> queryParams, Map<String, String> headerParams) {
     authNames.forEach((authName) {
       Authentication auth = _authentications[authName];
-      if (auth == null) throw ArgumentError("Authentication undefined: " + authName);
+      if (auth == null) throw new ArgumentError("Authentication undefined: " + authName);
       auth.applyToParams(queryParams, headerParams);
     });
   }
 
-  T getAuthentication<T extends Authentication>(String name) {
-    var authentication = _authentications[name];
-
-    return authentication is T ? authentication : null;
+  void setAccessToken(String accessToken) {
+    _authentications.forEach((key, auth) {
+      if (auth is OAuth) {
+        auth.setAccessToken(accessToken);
+      }
+    });
   }
 }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api_exception.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api_exception.dart
@@ -2,9 +2,9 @@ part of openapi.api;
 
 class ApiException implements Exception {
   int code = 0;
-  String message;
-  Exception innerException;
-  StackTrace stackTrace;
+  String message = null;
+  Exception innerException = null;
+  StackTrace stackTrace = null;
 
   ApiException(this.code, this.message);
 
@@ -17,7 +17,7 @@ class ApiException implements Exception {
       return "ApiException $code: $message";
     }
 
-    return "ApiException $code: $message (Inner exception: $innerException)\n\n" +
+    return "ApiException $code: $message (Inner exception: ${innerException})\n\n" +
         stackTrace.toString();
   }
 }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/api_helper.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/api_helper.dart
@@ -11,7 +11,7 @@ Iterable<QueryParam> _convertParametersForCollectionFormat(
   if (name == null || name.isEmpty || value == null) return params;
 
   if (value is! List) {
-    params.add(QueryParam(name, parameterToString(value)));
+    params.add(new QueryParam(name, parameterToString(value)));
     return params;
   }
 
@@ -23,12 +23,12 @@ Iterable<QueryParam> _convertParametersForCollectionFormat(
                      : collectionFormat; // default: csv
 
   if (collectionFormat == "multi") {
-    return values.map((v) => QueryParam(name, parameterToString(v)));
+    return values.map((v) => new QueryParam(name, parameterToString(v)));
   }
 
   String delimiter = _delimiters[collectionFormat] ?? ",";
 
-  params.add(QueryParam(name, values.map((v) => parameterToString(v)).join(delimiter)));
+  params.add(new QueryParam(name, values.map((v) => parameterToString(v)).join(delimiter)));
   return params;
 }
 

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/auth/api_key_auth.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/auth/api_key_auth.dart
@@ -4,10 +4,8 @@ class ApiKeyAuth implements Authentication {
 
   final String location;
   final String paramName;
-  String _apiKey;
+  String apiKey;
   String apiKeyPrefix;
-
-  set apiKey(String key) => _apiKey = key;
 
   ApiKeyAuth(this.location, this.paramName);
 
@@ -15,13 +13,13 @@ class ApiKeyAuth implements Authentication {
   void applyToParams(List<QueryParam> queryParams, Map<String, String> headerParams) {
     String value;
     if (apiKeyPrefix != null) {
-      value = '$apiKeyPrefix $_apiKey';
+      value = '$apiKeyPrefix $apiKey';
     } else {
-      value = _apiKey;
+      value = apiKey;
     }
 
     if (location == 'query' && value != null) {
-      queryParams.add(QueryParam(paramName, value));
+      queryParams.add(new QueryParam(paramName, value));
     } else if (location == 'header' && value != null) {
       headerParams[paramName] = value;
     }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/auth/http_basic_auth.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/auth/http_basic_auth.dart
@@ -2,15 +2,13 @@ part of openapi.api;
 
 class HttpBasicAuth implements Authentication {
 
-  String _username;
-  String _password;
+  String username;
+  String password;
 
   @override
   void applyToParams(List<QueryParam> queryParams, Map<String, String> headerParams) {
-    String str = (_username == null ? "" : _username) + ":" + (_password == null ? "" : _password);
-    headerParams["Authorization"] = "Basic " + base64.encode(utf8.encode(str));
+    String str = (username == null ? "" : username) + ":" + (password == null ? "" : password);
+    headerParams["Authorization"] = "Basic " + BASE64.encode(UTF8.encode(str));
   }
 
-  set username(String username) => _username = username;
-  set password(String password) => _password = password;
 }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/auth/oauth.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/auth/oauth.dart
@@ -1,16 +1,19 @@
 part of openapi.api;
 
 class OAuth implements Authentication {
-  String _accessToken;
+  String accessToken;
 
-  OAuth({String accessToken}) : _accessToken = accessToken;
+  OAuth({this.accessToken}) {
+  }
 
   @override
   void applyToParams(List<QueryParam> queryParams, Map<String, String> headerParams) {
-    if (_accessToken != null) {
-      headerParams["Authorization"] = "Bearer $_accessToken";
+    if (accessToken != null) {
+      headerParams["Authorization"] = "Bearer " + accessToken;
     }
   }
 
-  set accessToken(String accessToken) => _accessToken = accessToken;
+  void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+  }
 }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/api_response.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/api_response.dart
@@ -16,30 +16,39 @@ class ApiResponse {
 
   ApiResponse.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
-    code = json['code'];
-    type = json['type'];
-    message = json['message'];
+    if (json['code'] == null) {
+      code = null;
+    } else {
+      code = json['code'];
+    }
+    if (json['type'] == null) {
+      type = null;
+    } else {
+      type = json['type'];
+    }
+    if (json['message'] == null) {
+      message = null;
+    } else {
+      message = json['message'];
+    }
   }
 
   Map<String, dynamic> toJson() {
-    Map <String, dynamic> json = {};
-    if (code != null)
-      json['code'] = code;
-    if (type != null)
-      json['type'] = type;
-    if (message != null)
-      json['message'] = message;
-    return json;
+    return {
+      'code': code,
+      'type': type,
+      'message': message
+    };
   }
 
   static List<ApiResponse> listFromJson(List<dynamic> json) {
-    return json == null ? List<ApiResponse>() : json.map((value) => ApiResponse.fromJson(value)).toList();
+    return json == null ? new List<ApiResponse>() : json.map((value) => new ApiResponse.fromJson(value)).toList();
   }
 
-  static Map<String, ApiResponse> mapFromJson(Map<String, dynamic> json) {
-    var map = Map<String, ApiResponse>();
-    if (json != null && json.isNotEmpty) {
-      json.forEach((String key, dynamic value) => map[key] = ApiResponse.fromJson(value));
+  static Map<String, ApiResponse> mapFromJson(Map<String, Map<String, dynamic>> json) {
+    var map = new Map<String, ApiResponse>();
+    if (json != null && json.length > 0) {
+      json.forEach((String key, Map<String, dynamic> value) => map[key] = new ApiResponse.fromJson(value));
     }
     return map;
   }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/category.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/category.dart
@@ -14,27 +14,33 @@ class Category {
 
   Category.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
-    id = json['id'];
-    name = json['name'];
+    if (json['id'] == null) {
+      id = null;
+    } else {
+      id = json['id'];
+    }
+    if (json['name'] == null) {
+      name = null;
+    } else {
+      name = json['name'];
+    }
   }
 
   Map<String, dynamic> toJson() {
-    Map <String, dynamic> json = {};
-    if (id != null)
-      json['id'] = id;
-    if (name != null)
-      json['name'] = name;
-    return json;
+    return {
+      'id': id,
+      'name': name
+    };
   }
 
   static List<Category> listFromJson(List<dynamic> json) {
-    return json == null ? List<Category>() : json.map((value) => Category.fromJson(value)).toList();
+    return json == null ? new List<Category>() : json.map((value) => new Category.fromJson(value)).toList();
   }
 
-  static Map<String, Category> mapFromJson(Map<String, dynamic> json) {
-    var map = Map<String, Category>();
-    if (json != null && json.isNotEmpty) {
-      json.forEach((String key, dynamic value) => map[key] = Category.fromJson(value));
+  static Map<String, Category> mapFromJson(Map<String, Map<String, dynamic>> json) {
+    var map = new Map<String, Category>();
+    if (json != null && json.length > 0) {
+      json.forEach((String key, Map<String, dynamic> value) => map[key] = new Category.fromJson(value));
     }
     return map;
   }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/order.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/order.dart
@@ -23,41 +23,57 @@ class Order {
 
   Order.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
-    id = json['id'];
-    petId = json['petId'];
-    quantity = json['quantity'];
-    shipDate = (json['shipDate'] == null) ?
-      null :
-      DateTime.parse(json['shipDate']);
-    status = json['status'];
-    complete = json['complete'];
+    if (json['id'] == null) {
+      id = null;
+    } else {
+      id = json['id'];
+    }
+    if (json['petId'] == null) {
+      petId = null;
+    } else {
+      petId = json['petId'];
+    }
+    if (json['quantity'] == null) {
+      quantity = null;
+    } else {
+      quantity = json['quantity'];
+    }
+    if (json['shipDate'] == null) {
+      shipDate = null;
+    } else {
+      shipDate = DateTime.parse(json['shipDate']);
+    }
+    if (json['status'] == null) {
+      status = null;
+    } else {
+      status = json['status'];
+    }
+    if (json['complete'] == null) {
+      complete = null;
+    } else {
+      complete = json['complete'];
+    }
   }
 
   Map<String, dynamic> toJson() {
-    Map <String, dynamic> json = {};
-    if (id != null)
-      json['id'] = id;
-    if (petId != null)
-      json['petId'] = petId;
-    if (quantity != null)
-      json['quantity'] = quantity;
-    if (shipDate != null)
-      json['shipDate'] = shipDate == null ? null : shipDate.toUtc().toIso8601String();
-    if (status != null)
-      json['status'] = status;
-    if (complete != null)
-      json['complete'] = complete;
-    return json;
+    return {
+      'id': id,
+      'petId': petId,
+      'quantity': quantity,
+      'shipDate': shipDate == null ? '' : shipDate.toUtc().toIso8601String(),
+      'status': status,
+      'complete': complete
+    };
   }
 
   static List<Order> listFromJson(List<dynamic> json) {
-    return json == null ? List<Order>() : json.map((value) => Order.fromJson(value)).toList();
+    return json == null ? new List<Order>() : json.map((value) => new Order.fromJson(value)).toList();
   }
 
-  static Map<String, Order> mapFromJson(Map<String, dynamic> json) {
-    var map = Map<String, Order>();
-    if (json != null && json.isNotEmpty) {
-      json.forEach((String key, dynamic value) => map[key] = Order.fromJson(value));
+  static Map<String, Order> mapFromJson(Map<String, Map<String, dynamic>> json) {
+    var map = new Map<String, Order>();
+    if (json != null && json.length > 0) {
+      json.forEach((String key, Map<String, dynamic> value) => map[key] = new Order.fromJson(value));
     }
     return map;
   }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/pet.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/pet.dart
@@ -23,45 +23,57 @@ class Pet {
 
   Pet.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
-    id = json['id'];
-    category = (json['category'] == null) ?
-      null :
-      Category.fromJson(json['category']);
-    name = json['name'];
-    photoUrls = (json['photoUrls'] == null) ?
-      null :
-      (json['photoUrls'] as List).cast<String>();
-    tags = (json['tags'] == null) ?
-      null :
-      Tag.listFromJson(json['tags']);
-    status = json['status'];
+    if (json['id'] == null) {
+      id = null;
+    } else {
+      id = json['id'];
+    }
+    if (json['category'] == null) {
+      category = null;
+    } else {
+      category = new Category.fromJson(json['category']);
+    }
+    if (json['name'] == null) {
+      name = null;
+    } else {
+      name = json['name'];
+    }
+    if (json['photoUrls'] == null) {
+      photoUrls = null;
+    } else {
+      photoUrls = (json['photoUrls'] as List).map((item) => item as String).toList();
+    }
+    if (json['tags'] == null) {
+      tags = null;
+    } else {
+      tags = Tag.listFromJson(json['tags']);
+    }
+    if (json['status'] == null) {
+      status = null;
+    } else {
+      status = json['status'];
+    }
   }
 
   Map<String, dynamic> toJson() {
-    Map <String, dynamic> json = {};
-    if (id != null)
-      json['id'] = id;
-    if (category != null)
-      json['category'] = category;
-    if (name != null)
-      json['name'] = name;
-    if (photoUrls != null)
-      json['photoUrls'] = photoUrls;
-    if (tags != null)
-      json['tags'] = tags;
-    if (status != null)
-      json['status'] = status;
-    return json;
+    return {
+      'id': id,
+      'category': category,
+      'name': name,
+      'photoUrls': photoUrls,
+      'tags': tags,
+      'status': status
+    };
   }
 
   static List<Pet> listFromJson(List<dynamic> json) {
-    return json == null ? List<Pet>() : json.map((value) => Pet.fromJson(value)).toList();
+    return json == null ? new List<Pet>() : json.map((value) => new Pet.fromJson(value)).toList();
   }
 
-  static Map<String, Pet> mapFromJson(Map<String, dynamic> json) {
-    var map = Map<String, Pet>();
-    if (json != null && json.isNotEmpty) {
-      json.forEach((String key, dynamic value) => map[key] = Pet.fromJson(value));
+  static Map<String, Pet> mapFromJson(Map<String, Map<String, dynamic>> json) {
+    var map = new Map<String, Pet>();
+    if (json != null && json.length > 0) {
+      json.forEach((String key, Map<String, dynamic> value) => map[key] = new Pet.fromJson(value));
     }
     return map;
   }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/tag.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/tag.dart
@@ -14,27 +14,33 @@ class Tag {
 
   Tag.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
-    id = json['id'];
-    name = json['name'];
+    if (json['id'] == null) {
+      id = null;
+    } else {
+      id = json['id'];
+    }
+    if (json['name'] == null) {
+      name = null;
+    } else {
+      name = json['name'];
+    }
   }
 
   Map<String, dynamic> toJson() {
-    Map <String, dynamic> json = {};
-    if (id != null)
-      json['id'] = id;
-    if (name != null)
-      json['name'] = name;
-    return json;
+    return {
+      'id': id,
+      'name': name
+    };
   }
 
   static List<Tag> listFromJson(List<dynamic> json) {
-    return json == null ? List<Tag>() : json.map((value) => Tag.fromJson(value)).toList();
+    return json == null ? new List<Tag>() : json.map((value) => new Tag.fromJson(value)).toList();
   }
 
-  static Map<String, Tag> mapFromJson(Map<String, dynamic> json) {
-    var map = Map<String, Tag>();
-    if (json != null && json.isNotEmpty) {
-      json.forEach((String key, dynamic value) => map[key] = Tag.fromJson(value));
+  static Map<String, Tag> mapFromJson(Map<String, Map<String, dynamic>> json) {
+    var map = new Map<String, Tag>();
+    if (json != null && json.length > 0) {
+      json.forEach((String key, Map<String, dynamic> value) => map[key] = new Tag.fromJson(value));
     }
     return map;
   }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/user.dart
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/lib/model/user.dart
@@ -26,45 +26,69 @@ class User {
 
   User.fromJson(Map<String, dynamic> json) {
     if (json == null) return;
-    id = json['id'];
-    username = json['username'];
-    firstName = json['firstName'];
-    lastName = json['lastName'];
-    email = json['email'];
-    password = json['password'];
-    phone = json['phone'];
-    userStatus = json['userStatus'];
+    if (json['id'] == null) {
+      id = null;
+    } else {
+      id = json['id'];
+    }
+    if (json['username'] == null) {
+      username = null;
+    } else {
+      username = json['username'];
+    }
+    if (json['firstName'] == null) {
+      firstName = null;
+    } else {
+      firstName = json['firstName'];
+    }
+    if (json['lastName'] == null) {
+      lastName = null;
+    } else {
+      lastName = json['lastName'];
+    }
+    if (json['email'] == null) {
+      email = null;
+    } else {
+      email = json['email'];
+    }
+    if (json['password'] == null) {
+      password = null;
+    } else {
+      password = json['password'];
+    }
+    if (json['phone'] == null) {
+      phone = null;
+    } else {
+      phone = json['phone'];
+    }
+    if (json['userStatus'] == null) {
+      userStatus = null;
+    } else {
+      userStatus = json['userStatus'];
+    }
   }
 
   Map<String, dynamic> toJson() {
-    Map <String, dynamic> json = {};
-    if (id != null)
-      json['id'] = id;
-    if (username != null)
-      json['username'] = username;
-    if (firstName != null)
-      json['firstName'] = firstName;
-    if (lastName != null)
-      json['lastName'] = lastName;
-    if (email != null)
-      json['email'] = email;
-    if (password != null)
-      json['password'] = password;
-    if (phone != null)
-      json['phone'] = phone;
-    if (userStatus != null)
-      json['userStatus'] = userStatus;
-    return json;
+    return {
+      'id': id,
+      'username': username,
+      'firstName': firstName,
+      'lastName': lastName,
+      'email': email,
+      'password': password,
+      'phone': phone,
+      'userStatus': userStatus
+    };
   }
 
   static List<User> listFromJson(List<dynamic> json) {
-    return json == null ? List<User>() : json.map((value) => User.fromJson(value)).toList();
+    return json == null ? new List<User>() : json.map((value) => new User.fromJson(value)).toList();
   }
 
-  static Map<String, User> mapFromJson(Map<String, dynamic> json) {
-    var map = Map<String, User>();
-    if (json != null && json.isNotEmpty) {
-      json.forEach((String key, dynamic value) => map[key] = User.fromJson(value));
+  static Map<String, User> mapFromJson(Map<String, Map<String, dynamic>> json) {
+    var map = new Map<String, User>();
+    if (json != null && json.length > 0) {
+      json.forEach((String key, Map<String, dynamic> value) => map[key] = new User.fromJson(value));
     }
     return map;
   }

--- a/samples/client/petstore/dart/flutter_petstore/swagger/pubspec.yaml
+++ b/samples/client/petstore/dart/flutter_petstore/swagger/pubspec.yaml
@@ -1,9 +1,7 @@
 name: openapi
 version: 1.0.0
 description: OpenAPI API client
-environment:
-  sdk: '>=2.0.0 <3.0.0'
 dependencies:
-  http: '>=0.12.0 <0.13.0'
+  http: '>=0.11.1 <0.13.0'
 dev_dependencies:
   test: ^1.3.0

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/api_response.dart
@@ -43,5 +43,16 @@ class ApiResponse {
     }
     return map;
   }
+
+  // maps a json object with a list of ApiResponse-objects as value to a dart map
+  static Map<String, List<ApiResponse>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<ApiResponse>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = ApiResponse.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/category.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/category.dart
@@ -38,5 +38,16 @@ class Category {
     }
     return map;
   }
+
+  // maps a json object with a list of Category-objects as value to a dart map
+  static Map<String, List<Category>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Category>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Category.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/order.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/order.dart
@@ -61,5 +61,16 @@ class Order {
     }
     return map;
   }
+
+  // maps a json object with a list of Order-objects as value to a dart map
+  static Map<String, List<Order>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Order>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Order.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/pet.dart
@@ -65,5 +65,16 @@ class Pet {
     }
     return map;
   }
+
+  // maps a json object with a list of Pet-objects as value to a dart map
+  static Map<String, List<Pet>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Pet>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Pet.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/tag.dart
@@ -38,5 +38,16 @@ class Tag {
     }
     return map;
   }
+
+  // maps a json object with a list of Tag-objects as value to a dart map
+  static Map<String, List<Tag>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Tag>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Tag.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/user.dart
+++ b/samples/client/petstore/dart2/flutter_petstore/openapi/lib/model/user.dart
@@ -68,5 +68,16 @@ class User {
     }
     return map;
   }
+
+  // maps a json object with a list of User-objects as value to a dart map
+  static Map<String, List<User>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<User>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = User.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/api_response.dart
@@ -43,5 +43,16 @@ class ApiResponse {
     }
     return map;
   }
+
+  // maps a json object with a list of ApiResponse-objects as value to a dart map
+  static Map<String, List<ApiResponse>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<ApiResponse>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = ApiResponse.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/category.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/category.dart
@@ -38,5 +38,16 @@ class Category {
     }
     return map;
   }
+
+  // maps a json object with a list of Category-objects as value to a dart map
+  static Map<String, List<Category>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Category>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Category.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/order.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/order.dart
@@ -61,5 +61,16 @@ class Order {
     }
     return map;
   }
+
+  // maps a json object with a list of Order-objects as value to a dart map
+  static Map<String, List<Order>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Order>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Order.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/pet.dart
@@ -65,5 +65,16 @@ class Pet {
     }
     return map;
   }
+
+  // maps a json object with a list of Pet-objects as value to a dart map
+  static Map<String, List<Pet>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Pet>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Pet.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/tag.dart
@@ -38,5 +38,16 @@ class Tag {
     }
     return map;
   }
+
+  // maps a json object with a list of Tag-objects as value to a dart map
+  static Map<String, List<Tag>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Tag>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Tag.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi-browser-client/lib/model/user.dart
+++ b/samples/client/petstore/dart2/openapi-browser-client/lib/model/user.dart
@@ -68,5 +68,16 @@ class User {
     }
     return map;
   }
+
+  // maps a json object with a list of User-objects as value to a dart map
+  static Map<String, List<User>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<User>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = User.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi/lib/model/api_response.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/api_response.dart
@@ -43,5 +43,16 @@ class ApiResponse {
     }
     return map;
   }
+
+  // maps a json object with a list of ApiResponse-objects as value to a dart map
+  static Map<String, List<ApiResponse>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<ApiResponse>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = ApiResponse.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi/lib/model/category.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/category.dart
@@ -38,5 +38,16 @@ class Category {
     }
     return map;
   }
+
+  // maps a json object with a list of Category-objects as value to a dart map
+  static Map<String, List<Category>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Category>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Category.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi/lib/model/order.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/order.dart
@@ -61,5 +61,16 @@ class Order {
     }
     return map;
   }
+
+  // maps a json object with a list of Order-objects as value to a dart map
+  static Map<String, List<Order>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Order>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Order.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi/lib/model/pet.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/pet.dart
@@ -65,5 +65,16 @@ class Pet {
     }
     return map;
   }
+
+  // maps a json object with a list of Pet-objects as value to a dart map
+  static Map<String, List<Pet>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Pet>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Pet.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi/lib/model/tag.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/tag.dart
@@ -38,5 +38,16 @@ class Tag {
     }
     return map;
   }
+
+  // maps a json object with a list of Tag-objects as value to a dart map
+  static Map<String, List<Tag>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<Tag>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = Tag.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 

--- a/samples/client/petstore/dart2/openapi/lib/model/user.dart
+++ b/samples/client/petstore/dart2/openapi/lib/model/user.dart
@@ -68,5 +68,16 @@ class User {
     }
     return map;
   }
+
+  // maps a json object with a list of User-objects as value to a dart map
+  static Map<String, List<User>> mapListFromJson(Map<String, dynamic> json) {
+    var map = Map<String, List<User>>();
+     if (json != null && json.isNotEmpty) {
+       json.forEach((String key, dynamic value) {
+         map[key] = User.listFromJson(value);
+       });
+     }
+     return map;
+  }
 }
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- fix Dart2 default template
- mark dart 1.x as deprecated

cc @ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09)

