### PR TITLE
no need to use regex for this replacement - regexp fails on windows b…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NodeJSExpressServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NodeJSExpressServerCodegen.java
@@ -163,11 +163,11 @@ public class NodeJSExpressServerCodegen extends DefaultCodegen implements Codege
         if (templateName.equals("service.mustache")) {
             String stringToMatch = File.separator + "controllers" + File.separator;
             String replacement = File.separator + implFolder + File.separator;
-            result = result.replaceAll(Pattern.quote(stringToMatch), replacement);
-            
+            result = result.replace(stringToMatch, replacement);
+
             stringToMatch = "Controller.js";
             replacement = "Service.js";
-            result = result.replaceAll(Pattern.quote(stringToMatch), replacement);
+            result = result.replace(stringToMatch, replacement);
         }
         return result;
     }


### PR DESCRIPTION
…ecuase of backslashes in the path

### PR checklist

- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

