### PR TITLE
Issue: 1347 Fixed bug where nullApi.java is generated instead of DefaultApi.java. 

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -239,6 +239,9 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     public String toApiName(final String name) {
         String computed = name;
         if (computed.length() == 0) {
+            if (primaryResourceName == null) {
+                return "DefaultApi";
+            }
             return primaryResourceName + "Api";
         }
         computed = sanitizeName(computed);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -286,4 +286,30 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
 
         output.deleteOnExit();
     }
+
+    @Test
+    public void testGenerateApiWithPreceedingPathParameter_issue1347() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(JavaClientCodegen.JAVA8_MODE, true);
+        properties.put(JavaJAXRSSpecServerCodegen.OPEN_API_SPEC_FILE_LOCATION, "openapi.yml");
+
+        File output = Files.createTempDirectory("test").toFile();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("jaxrs-spec")
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/issue_1347.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        MockDefaultGenerator generator = new MockDefaultGenerator();
+        generator.opts(clientOptInput).generate();
+
+        Map<String, String> generatedFiles = generator.getFiles();
+        validateJavaSourceFiles(generatedFiles);
+        TestUtils.ensureContainsFile(generatedFiles, output, "openapi.yml");
+        TestUtils.ensureContainsFile(generatedFiles, output, "src/gen/java/org/openapitools/api/DefaultApi.java");
+
+        output.deleteOnExit();
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_1347.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_1347.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.2
+info:
+  title: Name demo
+  version: 1.0
+paths:
+  /{country}/document:
+    get:
+      summary: Get a document
+      tags:
+      - document
+      operationId: getDocument
+      parameters:
+      - name: country
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "201":
+          description: The document
+        "500":
+          description: Server error
+tags:
+- name: document
+  description: Document tag


### PR DESCRIPTION
Fixed bug where nullApi.java is generated instead of DefaultApi.java to match the default path /{pathParam}

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)

To fix https://github.com/OpenAPITools/openapi-generator/issues/1347