### PR TITLE
[R] skip mkdir error in R petstore tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -85,7 +85,7 @@ jobs:
         - ".git"
         - ~/.stack
         - /home/circleci/OpenAPITools/openapi-generator/samples/client/petstore/haskell-http-client/.stack-work
-        - ~/R
+        - ~/.R
     # Teardown
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
     # Save test results

--- a/samples/client/petstore/R/test_petstore.bash
+++ b/samples/client/petstore/R/test_petstore.bash
@@ -8,7 +8,7 @@ export R_LIBS_USER=$HOME/R
 
 echo "R lib directory: $R_LIBS_USER"
 
-mkdir $R_LIBS_USER || true
+mkdir -p $R_LIBS_USER || true
 
 Rscript -e "install.packages('jsonlite', repos='$REPO', lib='$R_LIBS_USER')"
 Rscript -e "install.packages('httr', repos='$REPO', lib='$R_LIBS_USER')"

--- a/samples/client/petstore/R/test_petstore.bash
+++ b/samples/client/petstore/R/test_petstore.bash
@@ -4,7 +4,7 @@ set -e
 
 REPO=http://cran.revolutionanalytics.com
 
-export R_LIBS_USER=$HOME/R
+export R_LIBS_USER=$HOME/.R
 
 echo "R lib directory: $R_LIBS_USER"
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Skip mkdir error in R petstore tests as reported in the CircleCI errors:

```
[name]
[ERROR] Error fetching link: /home/circleci/OpenAPITools/openapi-generator/modules/openapi-generator/home/circleci/OpenAPITools/openapi-generator/modules/openapi-generator-cli/target/apidocs. Ignored it.
R lib directory: /home/circleci/R
mkdir: cannot create directory ‘/home/circleci/R’: File exists
Too long with no output (exceeded 10m0s)
```
