### PR TITLE
Following up for #3440 (1792 fix remote spec handling and hash calculation)

### DIFF
--- a/modules/openapi-generator-maven-plugin/examples/java-client.xml
+++ b/modules/openapi-generator-maven-plugin/examples/java-client.xml
@@ -17,6 +17,7 @@
                 <!-- /RELEASE_VERSION -->
                 <executions>
                     <execution>
+                        <id>default</id>
                         <goals>
                             <goal>generate</goal>
                         </goals>
@@ -37,6 +38,36 @@
 
                             <!-- override the default library to jersey2 -->
                             <library>jersey2</library>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>remote</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <!-- specify the swagger yaml -->
+                            <inputSpec>https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml</inputSpec>
+
+                            <!-- target to generate java client code -->
+                            <generatorName>java</generatorName>
+
+                            <!-- hint: if you want to generate java server code, e.g. based on Spring Boot,
+                                 you can use the following target: <generatorName>spring</generatorName> -->
+
+                            <!-- pass any necessary config options -->
+                            <configOptions>
+                                <dateLibrary>joda</dateLibrary>
+                            </configOptions>
+
+                            <!-- override the default library to jersey2 -->
+                            <library>jersey2</library>
+
+                            <output>${project.build.directory}/generated-sources/remote-openapi</output>
+                            <apiPackage>remote.org.openapitools.client.api</apiPackage>
+                            <modelPackage>remote.org.openapitools.client.model</modelPackage>
+                            <invokerPackage>remote.org.openapitools.client</invokerPackage>
                         </configuration>
                     </execution>
                 </executions>

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -21,6 +21,15 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.openapitools.codegen.config.CodegenConfiguratorUtils.*;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -429,7 +438,7 @@ public class CodeGenMojo extends AbstractMojo {
                 if (inputSpecFile.exists()) {
                     File storedInputSpecHashFile = getHashFile(inputSpecFile);
                     if(storedInputSpecHashFile.exists()) {
-                        String inputSpecHash = Files.asByteSource(inputSpecFile).hash(Hashing.sha256()).toString();
+                        String inputSpecHash = calculateInputSpecHash(inputSpecFile);
                         String storedInputSpecHash = Files.asCharSource(storedInputSpecHashFile, Charsets.UTF_8).read();
                         if (inputSpecHash.equals(storedInputSpecHash)) {
                             getLog().info(
@@ -720,12 +729,7 @@ public class CodeGenMojo extends AbstractMojo {
 
             // Store a checksum of the input spec
             File storedInputSpecHashFile = getHashFile(inputSpecFile);
-            ByteSource inputSpecByteSource =
-                inputSpecFile.exists()
-                    ? Files.asByteSource(inputSpecFile)
-                    : CharSource.wrap(ClasspathHelper.loadFileFromClasspath(inputSpecFile.toString().replaceAll("\\\\","/")))
-                        .asByteSource(Charsets.UTF_8);
-            String  inputSpecHash =inputSpecByteSource.hash(Hashing.sha256()).toString();
+            String inputSpecHash = calculateInputSpecHash(inputSpecFile);
 
             if (storedInputSpecHashFile.getParent() != null && !new File(storedInputSpecHashFile.getParent()).exists()) {
                 File parent = new File(storedInputSpecHashFile.getParent());
@@ -746,8 +750,70 @@ public class CodeGenMojo extends AbstractMojo {
         }
     }
 
+    /**
+     * Calculate openapi specification file hash. If specification is hosted on remote resource it is downloaded first
+     *
+     * @param inputSpecFile - Openapi specification input file to calculate it's hash.
+     *                        Does not taken into account if input spec is hosted on remote resource
+     * @return openapi specification file hash
+     * @throws IOException
+     */
+    private String calculateInputSpecHash(File inputSpecFile) throws IOException {
+
+        URL inputSpecRemoteUrl = inputSpecRemoteUrl();
+
+        File inputSpecTempFile = inputSpecFile;
+
+        if (inputSpecRemoteUrl != null) {
+            inputSpecTempFile = File.createTempFile("openapi-spec", ".tmp");
+
+            ReadableByteChannel readableByteChannel = Channels.newChannel(inputSpecRemoteUrl.openStream());
+
+            FileOutputStream fileOutputStream = new FileOutputStream(inputSpecTempFile);
+            FileChannel fileChannel = fileOutputStream.getChannel();
+
+            fileChannel.transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+        }
+
+        ByteSource inputSpecByteSource =
+                inputSpecTempFile.exists()
+                        ? Files.asByteSource(inputSpecTempFile)
+                        : CharSource.wrap(ClasspathHelper.loadFileFromClasspath(inputSpecTempFile.toString().replaceAll("\\\\","/")))
+                        .asByteSource(Charsets.UTF_8);
+
+        return inputSpecByteSource.hash(Hashing.sha256()).toString();
+    }
+
+    /**
+     * Try to parse inputSpec setting string into URL
+     * @return A valid URL or null if inputSpec is not a valid URL
+     */
+    private URL inputSpecRemoteUrl(){
+        try {
+            return new URI(inputSpec).toURL();
+        } catch (URISyntaxException e) {
+            return null;
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Get specification hash file
+     * @param inputSpecFile - Openapi specification input file to calculate it's hash.
+     *                        Does not taken into account if input spec is hosted on remote resource
+     * @return a file with previously calculated hash
+     */
     private File getHashFile(File inputSpecFile) {
-        return new File(output.getPath() + File.separator + ".openapi-generator" + File.separator + inputSpecFile.getName() + ".sha256");
+        String name = inputSpecFile.getName();
+
+        URL url = inputSpecRemoteUrl();
+        if (url != null) {
+            String[] segments = url.getPath().split("/");
+            name = Files.getNameWithoutExtension(segments[segments.length - 1]);
+        }
+
+        return new File(output.getPath() + File.separator + ".openapi-generator" + File.separator + name + ".sha256");
     }
 
     private String getCompileSourceRoot() {
@@ -757,8 +823,7 @@ public class CodeGenMojo extends AbstractMojo {
         final String sourceFolder =
                 sourceFolderObject == null ? "src/main/java" : sourceFolderObject.toString();
 
-        String sourceJavaFolder = output.toString() + "/" + sourceFolder;
-        return sourceJavaFolder;
+        return output.toString() + "/" + sourceFolder;
     }
 
     private void addCompileSourceRootIfConfigured() {

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -801,9 +801,7 @@ public class CodeGenMojo extends AbstractMojo {
     private URL inputSpecRemoteUrl(){
         try {
             return new URI(inputSpec).toURL();
-        } catch (URISyntaxException e) {
-            return null;
-        } catch (MalformedURLException e) {
+        } catch (URISyntaxException | MalformedURLException | IllegalArgumentException e) {
             return null;
         }
     }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
This is a following up PR of #3440 to fix the #1792 bug, supporting auth.
Before review & merging this PR, please have a look at and merge #3440.

We have #1792 bug since 3.x, but we had workround at that time.
However the workaround doesn't work well for 4.x, and it still prevents us from upgrading to 4.x.

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

