### PR TITLE
Fix warnings in the csharp-netcore client

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -317,7 +317,7 @@ namespace {{packageName}}.Client
                     request.RequestFormat = DataFormat.Json;
                 }
 
-                request.AddBody(options.Data);
+                request.AddJsonBody(options.Data);
             }
 
             if (options.FileParameters != null)

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
@@ -400,7 +400,7 @@ namespace {{packageName}}.Client
             {
                 ApiKey = apiKey,
                 ApiKeyPrefix = apiKeyPrefix,
-                DefaultHeader = defaultHeaders,
+                DefaultHeaders = defaultHeaders,
                 BasePath = second.BasePath ?? first.BasePath,
                 Timeout = second.Timeout,
                 UserAgent = second.UserAgent ?? first.UserAgent,

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -320,7 +320,7 @@ namespace Org.OpenAPITools.Client
                     request.RequestFormat = DataFormat.Json;
                 }
 
-                request.AddBody(options.Data);
+                request.AddJsonBody(options.Data);
             }
 
             if (options.FileParameters != null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
@@ -395,7 +395,7 @@ namespace Org.OpenAPITools.Client
             {
                 ApiKey = apiKey,
                 ApiKeyPrefix = apiKeyPrefix,
-                DefaultHeader = defaultHeaders,
+                DefaultHeaders = defaultHeaders,
                 BasePath = second.BasePath ?? first.BasePath,
                 Timeout = second.Timeout,
                 UserAgent = second.UserAgent ?? first.UserAgent,

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -321,7 +321,7 @@ namespace Org.OpenAPITools.Client
                     request.RequestFormat = DataFormat.Json;
                 }
 
-                request.AddBody(options.Data);
+                request.AddJsonBody(options.Data);
             }
 
             if (options.FileParameters != null)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
@@ -400,7 +400,7 @@ namespace Org.OpenAPITools.Client
             {
                 ApiKey = apiKey,
                 ApiKeyPrefix = apiKeyPrefix,
-                DefaultHeader = defaultHeaders,
+                DefaultHeaders = defaultHeaders,
                 BasePath = second.BasePath ?? first.BasePath,
                 Timeout = second.Timeout,
                 UserAgent = second.UserAgent ?? first.UserAgent,


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- replace deprecated `AddBody` with `AddJsonBody`
- use DefaultHeaders to replace DefaultHeader (deprecated)

cc @mandrean (2017/08), @jimschubert (2017/09)

