### PR TITLE
[JAVA][JAXRS] Fix parameters validation

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/bodyParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/bodyParams.mustache
@@ -1,1 +1,13 @@
-{{#isBodyParam}}@ApiParam(value = "{{{description}}}" {{#required}},required=true{{/required}}{{#allowableValues}}, {{> allowableValues }}{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}{{{dataType}}} {{paramName}}{{/isBodyParam}}
+{{#isBodyParam}}{{!
+
+    }}@ApiParam(value = "{{{description}}}"{{!
+        }}{{#required}}, required = true{{/required}}{{!
+        }}{{#allowableValues}}, {{> allowableValues}}{{/allowableValues}}{{!
+        }}{{#defaultValue}}, defaultValue = "{{{defaultValue}}}"{{/defaultValue}}{{!
+    }}){{!
+
+    }}{{#useBeanValidation}} {{>beanValidation}}{{/useBeanValidation}}{{!
+
+    }} {{{dataType}}} {{paramName}}{{!
+
+}}{{/isBodyParam}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pathParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pathParams.mustache
@@ -6,6 +6,10 @@
         }}{{#defaultValue}}, defaultValue = "{{{defaultValue}}}"{{/defaultValue}}{{!
     }}){{!
 
-    }} @PathParam("{{baseName}}") {{{dataType}}} {{paramName}}{{!
+    }} @PathParam("{{baseName}}"){{!
+
+    }}{{#useBeanValidation}} {{>beanValidation}}{{/useBeanValidation}}{{!
+
+    }} {{{dataType}}} {{paramName}}{{!
 
 }}{{/isPathParam}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pathParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pathParams.mustache
@@ -1,1 +1,11 @@
-{{#isPathParam}}@ApiParam(value = "{{{description}}}"{{#required}},required=true{{/required}}{{#allowableValues}}, {{> allowableValues }}{{/allowableValues}}{{#defaultValue}}, defaultValue="{{{defaultValue}}}"{{/defaultValue}}) @PathParam("{{baseName}}") {{{dataType}}} {{paramName}}{{/isPathParam}}
+{{#isPathParam}}{{!
+
+    }}@ApiParam(value = "{{{description}}}"{{!
+        }}{{#required}}, required = true{{/required}}{{!
+        }}{{#allowableValues}}, {{> allowableValues}}{{/allowableValues}}{{!
+        }}{{#defaultValue}}, defaultValue = "{{{defaultValue}}}"{{/defaultValue}}{{!
+    }}){{!
+
+    }} @PathParam("{{baseName}}") {{{dataType}}} {{paramName}}{{!
+
+}}{{/isPathParam}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/queryParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/queryParams.mustache
@@ -26,6 +26,10 @@
         }}{{/defaultValue}}{{!
     }}{{/isContainer}}{{!
 
-    }} @QueryParam("{{baseName}}") {{{dataType}}} {{paramName}}{{!
+    }} @QueryParam("{{baseName}}"){{!
+
+    }}{{#useBeanValidation}} {{>beanValidation}}{{/useBeanValidation}}{{!
+
+    }} {{{dataType}}} {{paramName}}{{!
 
 }}{{/isQueryParam}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/queryParams.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/queryParams.mustache
@@ -1,1 +1,31 @@
-{{#isQueryParam}}@ApiParam(value = "{{{description}}}"{{#required}},required=true{{/required}}{{^isContainer}}{{#allowableValues}}, {{> allowableValues }}{{/allowableValues}}{{#defaultValue}}, defaultValue={{^isString}}"{{/isString}}{{#isString}}{{#isEnum}}"{{/isEnum}}{{/isString}}{{{defaultValue}}}{{^isString}}"{{/isString}}{{#isString}}{{#isEnum}}"{{/isEnum}}{{/isString}}{{/defaultValue}}{{/isContainer}}){{^isContainer}}{{#defaultValue}} @DefaultValue({{^isString}}"{{/isString}}{{#isString}}{{#isEnum}}"{{/isEnum}}{{/isString}}{{{defaultValue}}}{{^isString}}"{{/isString}}{{#isString}}{{#isEnum}}"{{/isEnum}}{{/isString}}){{/defaultValue}}{{/isContainer}}@QueryParam("{{baseName}}") {{{dataType}}} {{paramName}}{{/isQueryParam}}
+{{#isQueryParam}}{{!
+
+    }}@ApiParam(value = "{{{description}}}"{{!
+        }}{{#required}}, required = true{{/required}}{{!
+        }}{{^isContainer}}{{!
+            }}{{#allowableValues}}, {{> allowableValues}}{{/allowableValues}}{{!
+            }}{{#defaultValue}}, defaultValue = {{!
+            }}{{^isString}}"{{/isString}}{{!
+            }}{{#isString}}{{#isEnum}}"{{/isEnum}}{{/isString}}{{!
+            }}{{{defaultValue}}}{{!
+            }}{{^isString}}"{{/isString}}{{!
+            }}{{#isString}}{{#isEnum}}"{{/isEnum}}{{/isString}}{{!
+            }}{{/defaultValue}}{{!
+        }}{{/isContainer}}{{!
+    }}){{!
+
+    }}{{^isContainer}}{{!
+        }}{{#defaultValue}}{{!
+            }} @DefaultValue({{!
+                }}{{^isString}}"{{/isString}}{{!
+                }}{{#isString}}{{#isEnum}}"{{/isEnum}}{{/isString}}{{!
+                }}{{{defaultValue}}}{{!
+                }}{{^isString}}"{{/isString}}{{!
+                }}{{#isString}}{{#isEnum}}"{{/isEnum}}{{/isString}}{{!
+            }}){{!
+        }}{{/defaultValue}}{{!
+    }}{{/isContainer}}{{!
+
+    }} @QueryParam("{{baseName}}") {{{dataType}}} {{paramName}}{{!
+
+}}{{/isQueryParam}}

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -62,7 +62,7 @@ public class AnotherFakeApi  {
     @io.swagger.annotations.ApiOperation(value = "To test special tags", notes = "To test special tags and operation ID starting with number", response = Client.class, tags={ "$another-fake?", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response call123testSpecialTags(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
+    public Response call123testSpecialTags(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.call123testSpecialTags(body, securityContext);

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApi.java
@@ -72,7 +72,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "creates an XmlItem", notes = "this route creates an XmlItem", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createXmlItem(@ApiParam(value = "XmlItem Body" ,required=true) @NotNull @Valid XmlItem xmlItem
+    public Response createXmlItem(@ApiParam(value = "XmlItem Body", required = true) @NotNull @Valid  XmlItem xmlItem
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createXmlItem(xmlItem, securityContext);
@@ -84,7 +84,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer boolean types", response = Boolean.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
-    public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body" ) Boolean body
+    public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body")  Boolean body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterBooleanSerialize(body, securityContext);
@@ -96,7 +96,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of object with outer number type", response = OuterComposite.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
-    public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body" ) @Valid OuterComposite body
+    public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body") @Valid  OuterComposite body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterCompositeSerialize(body, securityContext);
@@ -108,7 +108,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer number types", response = BigDecimal.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
-    public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body" ) BigDecimal body
+    public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body")  BigDecimal body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterNumberSerialize(body, securityContext);
@@ -120,7 +120,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer string types", response = String.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output string", response = String.class) })
-    public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body" ) String body
+    public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body")  String body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterStringSerialize(body, securityContext);
@@ -132,7 +132,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "For this test, the body for this request much reference a schema named `File`.", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testBodyWithFileSchema(@ApiParam(value = "" ,required=true) @NotNull @Valid FileSchemaTestClass body
+    public Response testBodyWithFileSchema(@ApiParam(value = "", required = true) @NotNull @Valid  FileSchemaTestClass body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithFileSchema(body, securityContext);
@@ -144,8 +144,8 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testBodyWithQueryParams(@ApiParam(value = "",required=true)@QueryParam("query") String query
-,@ApiParam(value = "" ,required=true) @NotNull @Valid User body
+    public Response testBodyWithQueryParams(@ApiParam(value = "", required = true) @QueryParam("query") @NotNull  String query
+,@ApiParam(value = "", required = true) @NotNull @Valid  User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithQueryParams(query, body, securityContext);
@@ -157,7 +157,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "To test \"client\" model", notes = "To test \"client\" model", response = Client.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response testClientModel(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
+    public Response testClientModel(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClientModel(body, securityContext);
@@ -204,10 +204,10 @@ public class FakeApi  {
         @io.swagger.annotations.ApiResponse(code = 404, message = "Not found", response = Void.class) })
     public Response testEnumParameters(@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $", defaultValue="new ArrayList<>()")@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray
 ,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString
-,@ApiParam(value = "Query parameter enum test (string array)")@QueryParam("enum_query_string_array") List<String> enumQueryStringArray
-,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg")@QueryParam("enum_query_string") String enumQueryString
-,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2")@QueryParam("enum_query_integer") Integer enumQueryInteger
-,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2")@QueryParam("enum_query_double") Double enumQueryDouble
+,@ApiParam(value = "Query parameter enum test (string array)") @QueryParam("enum_query_string_array") @Valid  List<String> enumQueryStringArray
+,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue = "-efg") @DefaultValue("-efg") @QueryParam("enum_query_string")  String enumQueryString
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2") @QueryParam("enum_query_integer")  Integer enumQueryInteger
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @QueryParam("enum_query_double")  Double enumQueryDouble
 ,@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $", defaultValue="$")  @DefaultValue("$") @FormParam("enum_form_string_array")  List<String> enumFormStringArray
 ,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString
 ,@Context SecurityContext securityContext)
@@ -221,12 +221,12 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "Fake endpoint to test group parameters (optional)", notes = "Fake endpoint to test group parameters (optional)", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 400, message = "Someting wrong", response = Void.class) })
-    public Response testGroupParameters(@ApiParam(value = "Required String in group parameters",required=true)@QueryParam("required_string_group") Integer requiredStringGroup
+    public Response testGroupParameters(@ApiParam(value = "Required String in group parameters", required = true) @QueryParam("required_string_group") @NotNull  Integer requiredStringGroup
 ,@ApiParam(value = "Required Boolean in group parameters" ,required=true)@HeaderParam("required_boolean_group") Boolean requiredBooleanGroup
-,@ApiParam(value = "Required Integer in group parameters",required=true)@QueryParam("required_int64_group") Long requiredInt64Group
-,@ApiParam(value = "String in group parameters")@QueryParam("string_group") Integer stringGroup
+,@ApiParam(value = "Required Integer in group parameters", required = true) @QueryParam("required_int64_group") @NotNull  Long requiredInt64Group
+,@ApiParam(value = "String in group parameters") @QueryParam("string_group")  Integer stringGroup
 ,@ApiParam(value = "Boolean in group parameters" )@HeaderParam("boolean_group") Boolean booleanGroup
-,@ApiParam(value = "Integer in group parameters")@QueryParam("int64_group") Long int64Group
+,@ApiParam(value = "Integer in group parameters") @QueryParam("int64_group")  Long int64Group
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, securityContext);
@@ -238,7 +238,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "test inline additionalProperties", notes = "", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true) @NotNull @Valid Map<String, String> param
+    public Response testInlineAdditionalProperties(@ApiParam(value = "request body", required = true) @NotNull @Valid  Map<String, String> param
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testInlineAdditionalProperties(param, securityContext);
@@ -263,11 +263,11 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testQueryParameterCollectionFormat(@ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe
-,@ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil
-,@ApiParam(value = "",required=true)@QueryParam("http") List<String> http
-,@ApiParam(value = "",required=true)@QueryParam("url") List<String> url
-,@ApiParam(value = "",required=true)@QueryParam("context") List<String> context
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "", required = true) @QueryParam("pipe") @NotNull @Valid  List<String> pipe
+,@ApiParam(value = "", required = true) @QueryParam("ioutil") @NotNull @Valid  List<String> ioutil
+,@ApiParam(value = "", required = true) @QueryParam("http") @NotNull @Valid  List<String> http
+,@ApiParam(value = "", required = true) @QueryParam("url") @NotNull @Valid  List<String> url
+,@ApiParam(value = "", required = true) @QueryParam("context") @NotNull @Valid  List<String> context
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, securityContext);
@@ -284,7 +284,7 @@ public class FakeApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
-    public Response uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId
+    public Response uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId
 ,
             @FormDataParam("requiredFile") InputStream requiredFileInputStream,
             @FormDataParam("requiredFile") FormDataContentDisposition requiredFileDetail

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -64,7 +64,7 @@ public class FakeClassnameTestApi  {
     }, tags={ "fake_classname_tags 123#$%^", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response testClassname(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
+    public Response testClassname(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClassname(body, securityContext);

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/PetApi.java
@@ -71,7 +71,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
-    public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
+    public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.addPet(body, securityContext);
@@ -90,7 +90,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid pet value", response = Void.class) })
-    public Response deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathParam("petId") Long petId
+    public Response deletePet(@ApiParam(value = "Pet id to delete", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "" )@HeaderParam("api_key") String apiKey
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
@@ -110,7 +110,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
-    public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter",required=true)@QueryParam("status") List<String> status
+    public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter", required = true) @QueryParam("status") @NotNull @Valid  List<String> status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByStatus(status, securityContext);
@@ -129,7 +129,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
-    public Response findPetsByTags(@ApiParam(value = "Tags to filter by",required=true)@QueryParam("tags") List<String> tags
+    public Response findPetsByTags(@ApiParam(value = "Tags to filter by", required = true) @QueryParam("tags") @NotNull @Valid  List<String> tags
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByTags(tags, securityContext);
@@ -147,7 +147,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
-    public Response getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId
+    public Response getPetById(@ApiParam(value = "ID of pet to return", required = true) @PathParam("petId") @NotNull  Long petId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getPetById(petId, securityContext);
@@ -170,7 +170,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 405, message = "Validation exception", response = Void.class) })
-    public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
+    public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updatePet(body, securityContext);
@@ -187,7 +187,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
-    public Response updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathParam("petId") Long petId
+    public Response updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "Updated name of the pet")  @FormParam("name")  String name
 ,@ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status
 ,@Context SecurityContext securityContext)
@@ -206,7 +206,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
-    public Response uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId
+    public Response uploadFile(@ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,
             @FormDataParam("file") InputStream fileInputStream,

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/StoreApi.java
@@ -65,7 +65,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
-    public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId
+    public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required = true) @PathParam("order_id") @NotNull  String orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteOrder(orderId, securityContext);
@@ -94,7 +94,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
-    public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("order_id") Long orderId
+    public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched", required = true) @PathParam("order_id") @NotNull  @Min(1L) @Max(5L) Long orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getOrderById(orderId, securityContext);
@@ -108,7 +108,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Order.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
-    public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true) @NotNull @Valid Order body
+    public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet", required = true) @NotNull @Valid  Order body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.placeOrder(body, securityContext);

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/UserApi.java
@@ -63,7 +63,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUser(@ApiParam(value = "Created user object" ,required=true) @NotNull @Valid User body
+    public Response createUser(@ApiParam(value = "Created user object", required = true) @NotNull @Valid  User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUser(body, securityContext);
@@ -75,7 +75,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
+    public Response createUsersWithArrayInput(@ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithArrayInput(body, securityContext);
@@ -87,7 +87,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
+    public Response createUsersWithListInput(@ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithListInput(body, securityContext);
@@ -101,7 +101,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username
+    public Response deleteUser(@ApiParam(value = "The name that needs to be deleted", required = true) @PathParam("username") @NotNull  String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteUser(username, securityContext);
@@ -117,7 +117,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathParam("username") String username
+    public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required = true) @PathParam("username") @NotNull  String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getUserByName(username, securityContext);
@@ -131,8 +131,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = String.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
-    public Response loginUser(@ApiParam(value = "The user name for login",required=true)@QueryParam("username") String username
-,@ApiParam(value = "The password for login in clear text",required=true)@QueryParam("password") String password
+    public Response loginUser(@ApiParam(value = "The user name for login", required = true) @QueryParam("username") @NotNull  String username
+,@ApiParam(value = "The password for login in clear text", required = true) @QueryParam("password") @NotNull  String password
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.loginUser(username, password, securityContext);
@@ -157,8 +157,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathParam("username") String username
-,@ApiParam(value = "Updated user object" ,required=true) @NotNull @Valid User body
+    public Response updateUser(@ApiParam(value = "name that need to be deleted", required = true) @PathParam("username") @NotNull  String username
+,@ApiParam(value = "Updated user object", required = true) @NotNull @Valid  User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updateUser(username, body, securityContext);

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -62,7 +62,7 @@ public class AnotherFakeApi  {
     @io.swagger.annotations.ApiOperation(value = "To test special tags", notes = "To test special tags and operation ID starting with number", response = Client.class, tags={ "$another-fake?", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response call123testSpecialTags(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client client
+    public Response call123testSpecialTags(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client client
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.call123testSpecialTags(client, securityContext);

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
@@ -82,7 +82,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer boolean types", response = Boolean.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
-    public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body" ) Boolean body
+    public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body")  Boolean body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterBooleanSerialize(body, securityContext);
@@ -94,7 +94,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of object with outer number type", response = OuterComposite.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
-    public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body" ) @Valid OuterComposite outerComposite
+    public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body") @Valid  OuterComposite outerComposite
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterCompositeSerialize(outerComposite, securityContext);
@@ -106,7 +106,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer number types", response = BigDecimal.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
-    public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body" ) BigDecimal body
+    public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body")  BigDecimal body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterNumberSerialize(body, securityContext);
@@ -118,7 +118,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer string types", response = String.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output string", response = String.class) })
-    public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body" ) String body
+    public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body")  String body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterStringSerialize(body, securityContext);
@@ -130,7 +130,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "For this test, the body for this request much reference a schema named `File`.", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testBodyWithFileSchema(@ApiParam(value = "" ,required=true) @NotNull @Valid FileSchemaTestClass fileSchemaTestClass
+    public Response testBodyWithFileSchema(@ApiParam(value = "", required = true) @NotNull @Valid  FileSchemaTestClass fileSchemaTestClass
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithFileSchema(fileSchemaTestClass, securityContext);
@@ -142,8 +142,8 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testBodyWithQueryParams(@ApiParam(value = "",required=true)@QueryParam("query") String query
-,@ApiParam(value = "" ,required=true) @NotNull @Valid User user
+    public Response testBodyWithQueryParams(@ApiParam(value = "", required = true) @QueryParam("query") @NotNull  String query
+,@ApiParam(value = "", required = true) @NotNull @Valid  User user
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithQueryParams(query, user, securityContext);
@@ -155,7 +155,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "To test \"client\" model", notes = "To test \"client\" model", response = Client.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response testClientModel(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client client
+    public Response testClientModel(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client client
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClientModel(client, securityContext);
@@ -202,10 +202,10 @@ public class FakeApi  {
         @io.swagger.annotations.ApiResponse(code = 404, message = "Not found", response = Void.class) })
     public Response testEnumParameters(@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $", defaultValue="new ArrayList<String>()")@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray
 ,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString
-,@ApiParam(value = "Query parameter enum test (string array)")@QueryParam("enum_query_string_array") List<String> enumQueryStringArray
-,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg")@QueryParam("enum_query_string") String enumQueryString
-,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2")@QueryParam("enum_query_integer") Integer enumQueryInteger
-,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2")@QueryParam("enum_query_double") Double enumQueryDouble
+,@ApiParam(value = "Query parameter enum test (string array)") @QueryParam("enum_query_string_array") @Valid  List<String> enumQueryStringArray
+,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue = "-efg") @DefaultValue("-efg") @QueryParam("enum_query_string")  String enumQueryString
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2") @QueryParam("enum_query_integer")  Integer enumQueryInteger
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @QueryParam("enum_query_double")  Double enumQueryDouble
 ,@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $", defaultValue="$")  @DefaultValue("$") @FormParam("enum_form_string_array")  List<String> enumFormStringArray
 ,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString
 ,@Context SecurityContext securityContext)
@@ -221,12 +221,12 @@ public class FakeApi  {
     }, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 400, message = "Someting wrong", response = Void.class) })
-    public Response testGroupParameters(@ApiParam(value = "Required String in group parameters",required=true)@QueryParam("required_string_group") Integer requiredStringGroup
+    public Response testGroupParameters(@ApiParam(value = "Required String in group parameters", required = true) @QueryParam("required_string_group") @NotNull  Integer requiredStringGroup
 ,@ApiParam(value = "Required Boolean in group parameters" ,required=true)@HeaderParam("required_boolean_group") Boolean requiredBooleanGroup
-,@ApiParam(value = "Required Integer in group parameters",required=true)@QueryParam("required_int64_group") Long requiredInt64Group
-,@ApiParam(value = "String in group parameters")@QueryParam("string_group") Integer stringGroup
+,@ApiParam(value = "Required Integer in group parameters", required = true) @QueryParam("required_int64_group") @NotNull  Long requiredInt64Group
+,@ApiParam(value = "String in group parameters") @QueryParam("string_group")  Integer stringGroup
 ,@ApiParam(value = "Boolean in group parameters" )@HeaderParam("boolean_group") Boolean booleanGroup
-,@ApiParam(value = "Integer in group parameters")@QueryParam("int64_group") Long int64Group
+,@ApiParam(value = "Integer in group parameters") @QueryParam("int64_group")  Long int64Group
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, securityContext);
@@ -238,7 +238,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "test inline additionalProperties", notes = "", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true) @NotNull @Valid Map<String, String> requestBody
+    public Response testInlineAdditionalProperties(@ApiParam(value = "request body", required = true) @NotNull @Valid  Map<String, String> requestBody
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testInlineAdditionalProperties(requestBody, securityContext);
@@ -263,11 +263,11 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testQueryParameterCollectionFormat(@ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe
-,@ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil
-,@ApiParam(value = "",required=true)@QueryParam("http") List<String> http
-,@ApiParam(value = "",required=true)@QueryParam("url") List<String> url
-,@ApiParam(value = "",required=true)@QueryParam("context") List<String> context
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "", required = true) @QueryParam("pipe") @NotNull @Valid  List<String> pipe
+,@ApiParam(value = "", required = true) @QueryParam("ioutil") @NotNull @Valid  List<String> ioutil
+,@ApiParam(value = "", required = true) @QueryParam("http") @NotNull @Valid  List<String> http
+,@ApiParam(value = "", required = true) @QueryParam("url") @NotNull @Valid  List<String> url
+,@ApiParam(value = "", required = true) @QueryParam("context") @NotNull @Valid  List<String> context
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, securityContext);
@@ -284,7 +284,7 @@ public class FakeApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
-    public Response uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId
+    public Response uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId
 ,
             @FormDataParam("requiredFile") InputStream requiredFileInputStream,
             @FormDataParam("requiredFile") FormDataContentDisposition requiredFileDetail

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -64,7 +64,7 @@ public class FakeClassnameTestApi  {
     }, tags={ "fake_classname_tags 123#$%^", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response testClassname(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client client
+    public Response testClassname(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client client
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClassname(client, securityContext);

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/PetApi.java
@@ -69,7 +69,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
-    public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet pet
+    public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet pet
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.addPet(pet, securityContext);
@@ -86,7 +86,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid pet value", response = Void.class) })
-    public Response deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathParam("petId") Long petId
+    public Response deletePet(@ApiParam(value = "Pet id to delete", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "" )@HeaderParam("api_key") String apiKey
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
@@ -106,7 +106,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
-    public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter",required=true)@QueryParam("status") List<String> status
+    public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter", required = true) @QueryParam("status") @NotNull @Valid  List<String> status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByStatus(status, securityContext);
@@ -125,7 +125,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
-    public Response findPetsByTags(@ApiParam(value = "Tags to filter by",required=true)@QueryParam("tags") List<String> tags
+    public Response findPetsByTags(@ApiParam(value = "Tags to filter by", required = true) @QueryParam("tags") @NotNull @Valid  List<String> tags
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByTags(tags, securityContext);
@@ -143,7 +143,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
-    public Response getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId
+    public Response getPetById(@ApiParam(value = "ID of pet to return", required = true) @PathParam("petId") @NotNull  Long petId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getPetById(petId, securityContext);
@@ -164,7 +164,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 405, message = "Validation exception", response = Void.class) })
-    public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet pet
+    public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet pet
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updatePet(pet, securityContext);
@@ -181,7 +181,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
-    public Response updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathParam("petId") Long petId
+    public Response updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "Updated name of the pet")  @FormParam("name")  String name
 ,@ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status
 ,@Context SecurityContext securityContext)
@@ -200,7 +200,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
-    public Response uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId
+    public Response uploadFile(@ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,
             @FormDataParam("file") InputStream fileInputStream,

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/StoreApi.java
@@ -65,7 +65,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
-    public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId
+    public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required = true) @PathParam("order_id") @NotNull  String orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteOrder(orderId, securityContext);
@@ -94,7 +94,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
-    public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("order_id") Long orderId
+    public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched", required = true) @PathParam("order_id") @NotNull  @Min(1L) @Max(5L) Long orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getOrderById(orderId, securityContext);
@@ -108,7 +108,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Order.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
-    public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true) @NotNull @Valid Order order
+    public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet", required = true) @NotNull @Valid  Order order
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.placeOrder(order, securityContext);

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/UserApi.java
@@ -63,7 +63,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUser(@ApiParam(value = "Created user object" ,required=true) @NotNull @Valid User user
+    public Response createUser(@ApiParam(value = "Created user object", required = true) @NotNull @Valid  User user
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUser(user, securityContext);
@@ -75,7 +75,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> user
+    public Response createUsersWithArrayInput(@ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> user
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithArrayInput(user, securityContext);
@@ -87,7 +87,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> user
+    public Response createUsersWithListInput(@ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> user
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithListInput(user, securityContext);
@@ -101,7 +101,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username
+    public Response deleteUser(@ApiParam(value = "The name that needs to be deleted", required = true) @PathParam("username") @NotNull  String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteUser(username, securityContext);
@@ -117,7 +117,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathParam("username") String username
+    public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required = true) @PathParam("username") @NotNull  String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getUserByName(username, securityContext);
@@ -131,8 +131,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = String.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
-    public Response loginUser(@ApiParam(value = "The user name for login",required=true)@QueryParam("username") String username
-,@ApiParam(value = "The password for login in clear text",required=true)@QueryParam("password") String password
+    public Response loginUser(@ApiParam(value = "The user name for login", required = true) @QueryParam("username") @NotNull  String username
+,@ApiParam(value = "The password for login in clear text", required = true) @QueryParam("password") @NotNull  String password
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.loginUser(username, password, securityContext);
@@ -157,8 +157,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathParam("username") String username
-,@ApiParam(value = "Updated user object" ,required=true) @NotNull @Valid User user
+    public Response updateUser(@ApiParam(value = "name that need to be deleted", required = true) @PathParam("username") @NotNull  String username
+,@ApiParam(value = "Updated user object", required = true) @NotNull @Valid  User user
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updateUser(username, user, securityContext);

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -41,7 +41,7 @@ public class AnotherFakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
     public Response call123testSpecialTags(
-        @ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body,
+        @ApiParam(value = "client model", required = true) @NotNull @Valid  Client body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.call123testSpecialTags(body,securityContext);

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/FakeApi.java
@@ -49,7 +49,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createXmlItem(
-        @ApiParam(value = "XmlItem Body" ,required=true) @NotNull @Valid XmlItem xmlItem,
+        @ApiParam(value = "XmlItem Body", required = true) @NotNull @Valid  XmlItem xmlItem,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createXmlItem(xmlItem,securityContext);
@@ -62,7 +62,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
     public Response fakeOuterBooleanSerialize(
-        @ApiParam(value = "Input boolean as post body" ) Boolean body,
+        @ApiParam(value = "Input boolean as post body")  Boolean body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterBooleanSerialize(body,securityContext);
@@ -75,7 +75,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
     public Response fakeOuterCompositeSerialize(
-        @ApiParam(value = "Input composite as post body" ) @Valid OuterComposite body,
+        @ApiParam(value = "Input composite as post body") @Valid  OuterComposite body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterCompositeSerialize(body,securityContext);
@@ -88,7 +88,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
     public Response fakeOuterNumberSerialize(
-        @ApiParam(value = "Input number as post body" ) BigDecimal body,
+        @ApiParam(value = "Input number as post body")  BigDecimal body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterNumberSerialize(body,securityContext);
@@ -101,7 +101,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output string", response = String.class) })
     public Response fakeOuterStringSerialize(
-        @ApiParam(value = "Input string as post body" ) String body,
+        @ApiParam(value = "Input string as post body")  String body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterStringSerialize(body,securityContext);
@@ -114,7 +114,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
     public Response testBodyWithFileSchema(
-        @ApiParam(value = "" ,required=true) @NotNull @Valid FileSchemaTestClass body,
+        @ApiParam(value = "", required = true) @NotNull @Valid  FileSchemaTestClass body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithFileSchema(body,securityContext);
@@ -127,8 +127,8 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
     public Response testBodyWithQueryParams(
-        @ApiParam(value = "",required=true)@QueryParam("query") String query,
-        @ApiParam(value = "" ,required=true) @NotNull @Valid User body,
+        @ApiParam(value = "", required = true) @QueryParam("query") @NotNull  String query,
+        @ApiParam(value = "", required = true) @NotNull @Valid  User body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithQueryParams(query,body,securityContext);
@@ -141,7 +141,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
     public Response testClientModel(
-        @ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body,
+        @ApiParam(value = "client model", required = true) @NotNull @Valid  Client body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClientModel(body,securityContext);
@@ -187,10 +187,10 @@ public class FakeApi  {
     public Response testEnumParameters(
         @ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $", defaultValue="new ArrayList<String>()")@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray,
         @ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString,
-        @ApiParam(value = "Query parameter enum test (string array)")@QueryParam("enum_query_string_array") List<String> enumQueryStringArray,
-        @ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg")@QueryParam("enum_query_string") String enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2")@QueryParam("enum_query_integer") Integer enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2")@QueryParam("enum_query_double") Double enumQueryDouble,
+        @ApiParam(value = "Query parameter enum test (string array)") @QueryParam("enum_query_string_array") @Valid  List<String> enumQueryStringArray,
+        @ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue = "-efg") @DefaultValue("-efg") @QueryParam("enum_query_string")  String enumQueryString,
+        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2") @QueryParam("enum_query_integer")  Integer enumQueryInteger,
+        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @QueryParam("enum_query_double")  Double enumQueryDouble,
         @ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $", defaultValue="$")  @DefaultValue("$") @FormParam("enum_form_string_array")  List<String> enumFormStringArray,
         @ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString,
         @Context SecurityContext securityContext)
@@ -205,12 +205,12 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 400, message = "Someting wrong", response = Void.class) })
     public Response testGroupParameters(
-        @ApiParam(value = "Required String in group parameters",required=true)@QueryParam("required_string_group") Integer requiredStringGroup,
+        @ApiParam(value = "Required String in group parameters", required = true) @QueryParam("required_string_group") @NotNull  Integer requiredStringGroup,
         @ApiParam(value = "Required Boolean in group parameters" ,required=true)@HeaderParam("required_boolean_group") Boolean requiredBooleanGroup,
-        @ApiParam(value = "Required Integer in group parameters",required=true)@QueryParam("required_int64_group") Long requiredInt64Group,
-        @ApiParam(value = "String in group parameters")@QueryParam("string_group") Integer stringGroup,
+        @ApiParam(value = "Required Integer in group parameters", required = true) @QueryParam("required_int64_group") @NotNull  Long requiredInt64Group,
+        @ApiParam(value = "String in group parameters") @QueryParam("string_group")  Integer stringGroup,
         @ApiParam(value = "Boolean in group parameters" )@HeaderParam("boolean_group") Boolean booleanGroup,
-        @ApiParam(value = "Integer in group parameters")@QueryParam("int64_group") Long int64Group,
+        @ApiParam(value = "Integer in group parameters") @QueryParam("int64_group")  Long int64Group,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testGroupParameters(requiredStringGroup,requiredBooleanGroup,requiredInt64Group,stringGroup,booleanGroup,int64Group,securityContext);
@@ -223,7 +223,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response testInlineAdditionalProperties(
-        @ApiParam(value = "request body" ,required=true) @NotNull @Valid Map<String, String> param,
+        @ApiParam(value = "request body", required = true) @NotNull @Valid  Map<String, String> param,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testInlineAdditionalProperties(param,securityContext);
@@ -250,11 +250,11 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
     public Response testQueryParameterCollectionFormat(
-        @ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe,
-        @ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil,
-        @ApiParam(value = "",required=true)@QueryParam("http") List<String> http,
-        @ApiParam(value = "",required=true)@QueryParam("url") List<String> url,
-        @ApiParam(value = "",required=true)@QueryParam("context") List<String> context,
+        @ApiParam(value = "", required = true) @QueryParam("pipe") @NotNull @Valid  List<String> pipe,
+        @ApiParam(value = "", required = true) @QueryParam("ioutil") @NotNull @Valid  List<String> ioutil,
+        @ApiParam(value = "", required = true) @QueryParam("http") @NotNull @Valid  List<String> http,
+        @ApiParam(value = "", required = true) @QueryParam("url") @NotNull @Valid  List<String> url,
+        @ApiParam(value = "", required = true) @QueryParam("context") @NotNull @Valid  List<String> context,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testQueryParameterCollectionFormat(pipe,ioutil,http,url,context,securityContext);

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -43,7 +43,7 @@ public class FakeClassnameTags123Api  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
     public Response testClassname(
-        @ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body,
+        @ApiParam(value = "client model", required = true) @NotNull @Valid  Client body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClassname(body,securityContext);

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/PetApi.java
@@ -49,7 +49,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response addPet(
-        @ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body,
+        @ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.addPet(body,securityContext);
@@ -68,7 +68,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid pet value", response = Void.class) })
     public Response deletePet(
-        @ApiParam(value = "Pet id to delete",required=true) @PathParam("petId") Long petId,
+        @ApiParam(value = "Pet id to delete", required = true) @PathParam("petId") @NotNull  Long petId,
         @ApiParam(value = "" )@HeaderParam("api_key") String apiKey,
         @Context SecurityContext securityContext)
     throws NotFoundException {
@@ -88,7 +88,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
     public Response findPetsByStatus(
-        @ApiParam(value = "Status values that need to be considered for filter",required=true)@QueryParam("status") List<String> status,
+        @ApiParam(value = "Status values that need to be considered for filter", required = true) @QueryParam("status") @NotNull @Valid  List<String> status,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByStatus(status,securityContext);
@@ -107,7 +107,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
     public Response findPetsByTags(
-        @ApiParam(value = "Tags to filter by",required=true)@QueryParam("tags") List<String> tags,
+        @ApiParam(value = "Tags to filter by", required = true) @QueryParam("tags") @NotNull @Valid  List<String> tags,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByTags(tags,securityContext);
@@ -124,7 +124,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
     public Response getPetById(
-        @ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId,
+        @ApiParam(value = "ID of pet to return", required = true) @PathParam("petId") @NotNull  Long petId,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getPetById(petId,securityContext);
@@ -145,7 +145,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 405, message = "Validation exception", response = Void.class) })
     public Response updatePet(
-        @ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body,
+        @ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updatePet(body,securityContext);
@@ -163,7 +163,7 @@ public class PetApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response updatePetWithForm(
-        @ApiParam(value = "ID of pet that needs to be updated",required=true) @PathParam("petId") Long petId,
+        @ApiParam(value = "ID of pet that needs to be updated", required = true) @PathParam("petId") @NotNull  Long petId,
         @ApiParam(value = "Updated name of the pet")  @FormParam("name")  String name,
         @ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status,
         @Context SecurityContext securityContext)
@@ -183,7 +183,7 @@ public class PetApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     public Response uploadFile(
-        @ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId,
+        @ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId,
         @FormDataParam("additionalMetadata")  String additionalMetadata,
         @FormDataParam("file") InputStream inputStream,
         @FormDataParam("file") FormDataContentDisposition fileDetail,
@@ -204,7 +204,7 @@ public class PetApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     public Response uploadFileWithRequiredFile(
-        @ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId,
+        @ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId,
         @FormDataParam("requiredFile") InputStream inputStream,
         @FormDataParam("requiredFile") FormDataContentDisposition fileDetail,
         @FormDataParam("additionalMetadata")  String additionalMetadata,

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/StoreApi.java
@@ -43,7 +43,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     public Response deleteOrder(
-        @ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId,
+        @ApiParam(value = "ID of the order that needs to be deleted", required = true) @PathParam("order_id") @NotNull  String orderId,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteOrder(orderId,securityContext);
@@ -72,7 +72,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     public Response getOrderById(
-        @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("order_id") Long orderId,
+        @ApiParam(value = "ID of pet that needs to be fetched", required = true) @PathParam("order_id") @NotNull  @Min(1L) @Max(5L) Long orderId,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getOrderById(orderId,securityContext);
@@ -86,7 +86,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Order.class),
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
     public Response placeOrder(
-        @ApiParam(value = "order placed for purchasing the pet" ,required=true) @NotNull @Valid Order body,
+        @ApiParam(value = "order placed for purchasing the pet", required = true) @NotNull @Valid  Order body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.placeOrder(body,securityContext);

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/api/UserApi.java
@@ -42,7 +42,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUser(
-        @ApiParam(value = "Created user object" ,required=true) @NotNull @Valid User body,
+        @ApiParam(value = "Created user object", required = true) @NotNull @Valid  User body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUser(body,securityContext);
@@ -55,7 +55,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUsersWithArrayInput(
-        @ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body,
+        @ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithArrayInput(body,securityContext);
@@ -68,7 +68,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUsersWithListInput(
-        @ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body,
+        @ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithListInput(body,securityContext);
@@ -82,7 +82,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response deleteUser(
-        @ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username,
+        @ApiParam(value = "The name that needs to be deleted", required = true) @PathParam("username") @NotNull  String username,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteUser(username,securityContext);
@@ -97,7 +97,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response getUserByName(
-        @ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathParam("username") String username,
+        @ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required = true) @PathParam("username") @NotNull  String username,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getUserByName(username,securityContext);
@@ -111,8 +111,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = String.class),
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
     public Response loginUser(
-        @ApiParam(value = "The user name for login",required=true)@QueryParam("username") String username,
-        @ApiParam(value = "The password for login in clear text",required=true)@QueryParam("password") String password,
+        @ApiParam(value = "The user name for login", required = true) @QueryParam("username") @NotNull  String username,
+        @ApiParam(value = "The password for login in clear text", required = true) @QueryParam("password") @NotNull  String password,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.loginUser(username,password,securityContext);
@@ -138,8 +138,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response updateUser(
-        @ApiParam(value = "name that need to be deleted",required=true) @PathParam("username") String username,
-        @ApiParam(value = "Updated user object" ,required=true) @NotNull @Valid User body,
+        @ApiParam(value = "name that need to be deleted", required = true) @PathParam("username") @NotNull  String username,
+        @ApiParam(value = "Updated user object", required = true) @NotNull @Valid  User body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updateUser(username,body,securityContext);

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -41,7 +41,7 @@ public class AnotherFakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
     public Response call123testSpecialTags(
-        @ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body,
+        @ApiParam(value = "client model", required = true) @NotNull @Valid  Client body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.call123testSpecialTags(body,securityContext);

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/FakeApi.java
@@ -50,7 +50,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createXmlItem(
-        @ApiParam(value = "XmlItem Body" ,required=true) @NotNull @Valid XmlItem xmlItem,
+        @ApiParam(value = "XmlItem Body", required = true) @NotNull @Valid  XmlItem xmlItem,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createXmlItem(xmlItem,securityContext);
@@ -63,7 +63,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
     public Response fakeOuterBooleanSerialize(
-        @ApiParam(value = "Input boolean as post body" ) Boolean body,
+        @ApiParam(value = "Input boolean as post body")  Boolean body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterBooleanSerialize(body,securityContext);
@@ -76,7 +76,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
     public Response fakeOuterCompositeSerialize(
-        @ApiParam(value = "Input composite as post body" ) @Valid OuterComposite body,
+        @ApiParam(value = "Input composite as post body") @Valid  OuterComposite body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterCompositeSerialize(body,securityContext);
@@ -89,7 +89,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
     public Response fakeOuterNumberSerialize(
-        @ApiParam(value = "Input number as post body" ) BigDecimal body,
+        @ApiParam(value = "Input number as post body")  BigDecimal body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterNumberSerialize(body,securityContext);
@@ -102,7 +102,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output string", response = String.class) })
     public Response fakeOuterStringSerialize(
-        @ApiParam(value = "Input string as post body" ) String body,
+        @ApiParam(value = "Input string as post body")  String body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterStringSerialize(body,securityContext);
@@ -115,7 +115,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
     public Response testBodyWithFileSchema(
-        @ApiParam(value = "" ,required=true) @NotNull @Valid FileSchemaTestClass body,
+        @ApiParam(value = "", required = true) @NotNull @Valid  FileSchemaTestClass body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithFileSchema(body,securityContext);
@@ -128,8 +128,8 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
     public Response testBodyWithQueryParams(
-        @ApiParam(value = "",required=true)@QueryParam("query") String query,
-        @ApiParam(value = "" ,required=true) @NotNull @Valid User body,
+        @ApiParam(value = "", required = true) @QueryParam("query") @NotNull  String query,
+        @ApiParam(value = "", required = true) @NotNull @Valid  User body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithQueryParams(query,body,securityContext);
@@ -142,7 +142,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
     public Response testClientModel(
-        @ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body,
+        @ApiParam(value = "client model", required = true) @NotNull @Valid  Client body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClientModel(body,securityContext);
@@ -188,10 +188,10 @@ public class FakeApi  {
     public Response testEnumParameters(
         @ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $", defaultValue="new ArrayList<String>()")@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray,
         @ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString,
-        @ApiParam(value = "Query parameter enum test (string array)")@QueryParam("enum_query_string_array") List<String> enumQueryStringArray,
-        @ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg")@QueryParam("enum_query_string") String enumQueryString,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2")@QueryParam("enum_query_integer") Integer enumQueryInteger,
-        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2")@QueryParam("enum_query_double") Double enumQueryDouble,
+        @ApiParam(value = "Query parameter enum test (string array)") @QueryParam("enum_query_string_array") @Valid  List<String> enumQueryStringArray,
+        @ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue = "-efg") @DefaultValue("-efg") @QueryParam("enum_query_string")  String enumQueryString,
+        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2") @QueryParam("enum_query_integer")  Integer enumQueryInteger,
+        @ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @QueryParam("enum_query_double")  Double enumQueryDouble,
         @ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $", defaultValue="$")  @DefaultValue("$") @FormParam("enum_form_string_array")  List<String> enumFormStringArray,
         @ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString,
         @Context SecurityContext securityContext)
@@ -206,12 +206,12 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 400, message = "Someting wrong", response = Void.class) })
     public Response testGroupParameters(
-        @ApiParam(value = "Required String in group parameters",required=true)@QueryParam("required_string_group") Integer requiredStringGroup,
+        @ApiParam(value = "Required String in group parameters", required = true) @QueryParam("required_string_group") @NotNull  Integer requiredStringGroup,
         @ApiParam(value = "Required Boolean in group parameters" ,required=true)@HeaderParam("required_boolean_group") Boolean requiredBooleanGroup,
-        @ApiParam(value = "Required Integer in group parameters",required=true)@QueryParam("required_int64_group") Long requiredInt64Group,
-        @ApiParam(value = "String in group parameters")@QueryParam("string_group") Integer stringGroup,
+        @ApiParam(value = "Required Integer in group parameters", required = true) @QueryParam("required_int64_group") @NotNull  Long requiredInt64Group,
+        @ApiParam(value = "String in group parameters") @QueryParam("string_group")  Integer stringGroup,
         @ApiParam(value = "Boolean in group parameters" )@HeaderParam("boolean_group") Boolean booleanGroup,
-        @ApiParam(value = "Integer in group parameters")@QueryParam("int64_group") Long int64Group,
+        @ApiParam(value = "Integer in group parameters") @QueryParam("int64_group")  Long int64Group,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testGroupParameters(requiredStringGroup,requiredBooleanGroup,requiredInt64Group,stringGroup,booleanGroup,int64Group,securityContext);
@@ -224,7 +224,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response testInlineAdditionalProperties(
-        @ApiParam(value = "request body" ,required=true) @NotNull @Valid Map<String, String> param,
+        @ApiParam(value = "request body", required = true) @NotNull @Valid  Map<String, String> param,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testInlineAdditionalProperties(param,securityContext);
@@ -251,11 +251,11 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
     public Response testQueryParameterCollectionFormat(
-        @ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe,
-        @ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil,
-        @ApiParam(value = "",required=true)@QueryParam("http") List<String> http,
-        @ApiParam(value = "",required=true)@QueryParam("url") List<String> url,
-        @ApiParam(value = "",required=true)@QueryParam("context") List<String> context,
+        @ApiParam(value = "", required = true) @QueryParam("pipe") @NotNull @Valid  List<String> pipe,
+        @ApiParam(value = "", required = true) @QueryParam("ioutil") @NotNull @Valid  List<String> ioutil,
+        @ApiParam(value = "", required = true) @QueryParam("http") @NotNull @Valid  List<String> http,
+        @ApiParam(value = "", required = true) @QueryParam("url") @NotNull @Valid  List<String> url,
+        @ApiParam(value = "", required = true) @QueryParam("context") @NotNull @Valid  List<String> context,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testQueryParameterCollectionFormat(pipe,ioutil,http,url,context,securityContext);
@@ -273,7 +273,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     public Response uploadFileWithRequiredFile(
-        @ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId,
+        @ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId,
         @FormDataParam("requiredFile") InputStream inputStream,
         @FormDataParam("requiredFile") FormDataContentDisposition fileDetail,
         @FormDataParam("additionalMetadata")  String additionalMetadata,

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -43,7 +43,7 @@ public class FakeClassnameTestApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
     public Response testClassname(
-        @ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body,
+        @ApiParam(value = "client model", required = true) @NotNull @Valid  Client body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClassname(body,securityContext);

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/PetApi.java
@@ -49,7 +49,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response addPet(
-        @ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body,
+        @ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.addPet(body,securityContext);
@@ -68,7 +68,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid pet value", response = Void.class) })
     public Response deletePet(
-        @ApiParam(value = "Pet id to delete",required=true) @PathParam("petId") Long petId,
+        @ApiParam(value = "Pet id to delete", required = true) @PathParam("petId") @NotNull  Long petId,
         @ApiParam(value = "" )@HeaderParam("api_key") String apiKey,
         @Context SecurityContext securityContext)
     throws NotFoundException {
@@ -88,7 +88,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
     public Response findPetsByStatus(
-        @ApiParam(value = "Status values that need to be considered for filter",required=true)@QueryParam("status") List<String> status,
+        @ApiParam(value = "Status values that need to be considered for filter", required = true) @QueryParam("status") @NotNull @Valid  List<String> status,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByStatus(status,securityContext);
@@ -107,7 +107,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
     public Response findPetsByTags(
-        @ApiParam(value = "Tags to filter by",required=true)@QueryParam("tags") List<String> tags,
+        @ApiParam(value = "Tags to filter by", required = true) @QueryParam("tags") @NotNull @Valid  List<String> tags,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByTags(tags,securityContext);
@@ -124,7 +124,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
     public Response getPetById(
-        @ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId,
+        @ApiParam(value = "ID of pet to return", required = true) @PathParam("petId") @NotNull  Long petId,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getPetById(petId,securityContext);
@@ -145,7 +145,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 405, message = "Validation exception", response = Void.class) })
     public Response updatePet(
-        @ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body,
+        @ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updatePet(body,securityContext);
@@ -163,7 +163,7 @@ public class PetApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
     public Response updatePetWithForm(
-        @ApiParam(value = "ID of pet that needs to be updated",required=true) @PathParam("petId") Long petId,
+        @ApiParam(value = "ID of pet that needs to be updated", required = true) @PathParam("petId") @NotNull  Long petId,
         @ApiParam(value = "Updated name of the pet")  @FormParam("name")  String name,
         @ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status,
         @Context SecurityContext securityContext)
@@ -183,7 +183,7 @@ public class PetApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
     public Response uploadFile(
-        @ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId,
+        @ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId,
         @FormDataParam("additionalMetadata")  String additionalMetadata,
         @FormDataParam("file") InputStream inputStream,
         @FormDataParam("file") FormDataContentDisposition fileDetail,

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/StoreApi.java
@@ -43,7 +43,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     public Response deleteOrder(
-        @ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId,
+        @ApiParam(value = "ID of the order that needs to be deleted", required = true) @PathParam("order_id") @NotNull  String orderId,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteOrder(orderId,securityContext);
@@ -72,7 +72,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
     public Response getOrderById(
-        @ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("order_id") Long orderId,
+        @ApiParam(value = "ID of pet that needs to be fetched", required = true) @PathParam("order_id") @NotNull  @Min(1L) @Max(5L) Long orderId,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getOrderById(orderId,securityContext);
@@ -86,7 +86,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Order.class),
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
     public Response placeOrder(
-        @ApiParam(value = "order placed for purchasing the pet" ,required=true) @NotNull @Valid Order body,
+        @ApiParam(value = "order placed for purchasing the pet", required = true) @NotNull @Valid  Order body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.placeOrder(body,securityContext);

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/api/UserApi.java
@@ -42,7 +42,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUser(
-        @ApiParam(value = "Created user object" ,required=true) @NotNull @Valid User body,
+        @ApiParam(value = "Created user object", required = true) @NotNull @Valid  User body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUser(body,securityContext);
@@ -55,7 +55,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUsersWithArrayInput(
-        @ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body,
+        @ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithArrayInput(body,securityContext);
@@ -68,7 +68,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
     public Response createUsersWithListInput(
-        @ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body,
+        @ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithListInput(body,securityContext);
@@ -82,7 +82,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response deleteUser(
-        @ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username,
+        @ApiParam(value = "The name that needs to be deleted", required = true) @PathParam("username") @NotNull  String username,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteUser(username,securityContext);
@@ -97,7 +97,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response getUserByName(
-        @ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathParam("username") String username,
+        @ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required = true) @PathParam("username") @NotNull  String username,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getUserByName(username,securityContext);
@@ -111,8 +111,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = String.class),
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
     public Response loginUser(
-        @ApiParam(value = "The user name for login",required=true)@QueryParam("username") String username,
-        @ApiParam(value = "The password for login in clear text",required=true)@QueryParam("password") String password,
+        @ApiParam(value = "The user name for login", required = true) @QueryParam("username") @NotNull  String username,
+        @ApiParam(value = "The password for login in clear text", required = true) @QueryParam("password") @NotNull  String password,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.loginUser(username,password,securityContext);
@@ -138,8 +138,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
     public Response updateUser(
-        @ApiParam(value = "name that need to be deleted",required=true) @PathParam("username") String username,
-        @ApiParam(value = "Updated user object" ,required=true) @NotNull @Valid User body,
+        @ApiParam(value = "name that need to be deleted", required = true) @PathParam("username") @NotNull  String username,
+        @ApiParam(value = "Updated user object", required = true) @NotNull @Valid  User body,
         @Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updateUser(username,body,securityContext);

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -62,7 +62,7 @@ public class AnotherFakeApi  {
     @io.swagger.annotations.ApiOperation(value = "To test special tags", notes = "To test special tags and operation ID starting with number", response = Client.class, tags={ "$another-fake?", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response call123testSpecialTags(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
+    public Response call123testSpecialTags(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.call123testSpecialTags(body, securityContext);

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
@@ -70,7 +70,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "creates an XmlItem", notes = "this route creates an XmlItem", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createXmlItem(@ApiParam(value = "XmlItem Body" ,required=true) @NotNull @Valid XmlItem xmlItem
+    public Response createXmlItem(@ApiParam(value = "XmlItem Body", required = true) @NotNull @Valid  XmlItem xmlItem
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createXmlItem(xmlItem, securityContext);
@@ -82,7 +82,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer boolean types", response = Boolean.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
-    public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body" ) Boolean body
+    public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body")  Boolean body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterBooleanSerialize(body, securityContext);
@@ -94,7 +94,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of object with outer number type", response = OuterComposite.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
-    public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body" ) @Valid OuterComposite body
+    public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body") @Valid  OuterComposite body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterCompositeSerialize(body, securityContext);
@@ -106,7 +106,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer number types", response = BigDecimal.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
-    public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body" ) BigDecimal body
+    public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body")  BigDecimal body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterNumberSerialize(body, securityContext);
@@ -118,7 +118,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer string types", response = String.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output string", response = String.class) })
-    public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body" ) String body
+    public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body")  String body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterStringSerialize(body, securityContext);
@@ -130,7 +130,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "For this test, the body for this request much reference a schema named `File`.", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testBodyWithFileSchema(@ApiParam(value = "" ,required=true) @NotNull @Valid FileSchemaTestClass body
+    public Response testBodyWithFileSchema(@ApiParam(value = "", required = true) @NotNull @Valid  FileSchemaTestClass body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithFileSchema(body, securityContext);
@@ -142,8 +142,8 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testBodyWithQueryParams(@ApiParam(value = "",required=true)@QueryParam("query") String query
-,@ApiParam(value = "" ,required=true) @NotNull @Valid User body
+    public Response testBodyWithQueryParams(@ApiParam(value = "", required = true) @QueryParam("query") @NotNull  String query
+,@ApiParam(value = "", required = true) @NotNull @Valid  User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithQueryParams(query, body, securityContext);
@@ -155,7 +155,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "To test \"client\" model", notes = "To test \"client\" model", response = Client.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response testClientModel(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
+    public Response testClientModel(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClientModel(body, securityContext);
@@ -202,10 +202,10 @@ public class FakeApi  {
         @io.swagger.annotations.ApiResponse(code = 404, message = "Not found", response = Void.class) })
     public Response testEnumParameters(@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $", defaultValue="new ArrayList<String>()")@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray
 ,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString
-,@ApiParam(value = "Query parameter enum test (string array)")@QueryParam("enum_query_string_array") List<String> enumQueryStringArray
-,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg")@QueryParam("enum_query_string") String enumQueryString
-,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2")@QueryParam("enum_query_integer") Integer enumQueryInteger
-,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2")@QueryParam("enum_query_double") Double enumQueryDouble
+,@ApiParam(value = "Query parameter enum test (string array)") @QueryParam("enum_query_string_array") @Valid  List<String> enumQueryStringArray
+,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue = "-efg") @DefaultValue("-efg") @QueryParam("enum_query_string")  String enumQueryString
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2") @QueryParam("enum_query_integer")  Integer enumQueryInteger
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @QueryParam("enum_query_double")  Double enumQueryDouble
 ,@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $", defaultValue="$")  @DefaultValue("$") @FormParam("enum_form_string_array")  List<String> enumFormStringArray
 ,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString
 ,@Context SecurityContext securityContext)
@@ -219,12 +219,12 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "Fake endpoint to test group parameters (optional)", notes = "Fake endpoint to test group parameters (optional)", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 400, message = "Someting wrong", response = Void.class) })
-    public Response testGroupParameters(@ApiParam(value = "Required String in group parameters",required=true)@QueryParam("required_string_group") Integer requiredStringGroup
+    public Response testGroupParameters(@ApiParam(value = "Required String in group parameters", required = true) @QueryParam("required_string_group") @NotNull  Integer requiredStringGroup
 ,@ApiParam(value = "Required Boolean in group parameters" ,required=true)@HeaderParam("required_boolean_group") Boolean requiredBooleanGroup
-,@ApiParam(value = "Required Integer in group parameters",required=true)@QueryParam("required_int64_group") Long requiredInt64Group
-,@ApiParam(value = "String in group parameters")@QueryParam("string_group") Integer stringGroup
+,@ApiParam(value = "Required Integer in group parameters", required = true) @QueryParam("required_int64_group") @NotNull  Long requiredInt64Group
+,@ApiParam(value = "String in group parameters") @QueryParam("string_group")  Integer stringGroup
 ,@ApiParam(value = "Boolean in group parameters" )@HeaderParam("boolean_group") Boolean booleanGroup
-,@ApiParam(value = "Integer in group parameters")@QueryParam("int64_group") Long int64Group
+,@ApiParam(value = "Integer in group parameters") @QueryParam("int64_group")  Long int64Group
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, securityContext);
@@ -236,7 +236,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "test inline additionalProperties", notes = "", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true) @NotNull @Valid Map<String, String> param
+    public Response testInlineAdditionalProperties(@ApiParam(value = "request body", required = true) @NotNull @Valid  Map<String, String> param
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testInlineAdditionalProperties(param, securityContext);
@@ -261,11 +261,11 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testQueryParameterCollectionFormat(@ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe
-,@ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil
-,@ApiParam(value = "",required=true)@QueryParam("http") List<String> http
-,@ApiParam(value = "",required=true)@QueryParam("url") List<String> url
-,@ApiParam(value = "",required=true)@QueryParam("context") List<String> context
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "", required = true) @QueryParam("pipe") @NotNull @Valid  List<String> pipe
+,@ApiParam(value = "", required = true) @QueryParam("ioutil") @NotNull @Valid  List<String> ioutil
+,@ApiParam(value = "", required = true) @QueryParam("http") @NotNull @Valid  List<String> http
+,@ApiParam(value = "", required = true) @QueryParam("url") @NotNull @Valid  List<String> url
+,@ApiParam(value = "", required = true) @QueryParam("context") @NotNull @Valid  List<String> context
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, securityContext);

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -64,7 +64,7 @@ public class FakeClassnameTags123Api  {
     }, tags={ "fake_classname_tags 123#$%^", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response testClassname(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
+    public Response testClassname(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClassname(body, securityContext);

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/PetApi.java
@@ -71,7 +71,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
-    public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
+    public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.addPet(body, securityContext);
@@ -90,7 +90,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid pet value", response = Void.class) })
-    public Response deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathParam("petId") Long petId
+    public Response deletePet(@ApiParam(value = "Pet id to delete", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "" )@HeaderParam("api_key") String apiKey
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
@@ -110,7 +110,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
-    public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter",required=true)@QueryParam("status") List<String> status
+    public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter", required = true) @QueryParam("status") @NotNull @Valid  List<String> status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByStatus(status, securityContext);
@@ -129,7 +129,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
-    public Response findPetsByTags(@ApiParam(value = "Tags to filter by",required=true)@QueryParam("tags") List<String> tags
+    public Response findPetsByTags(@ApiParam(value = "Tags to filter by", required = true) @QueryParam("tags") @NotNull @Valid  List<String> tags
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByTags(tags, securityContext);
@@ -147,7 +147,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
-    public Response getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId
+    public Response getPetById(@ApiParam(value = "ID of pet to return", required = true) @PathParam("petId") @NotNull  Long petId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getPetById(petId, securityContext);
@@ -170,7 +170,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 405, message = "Validation exception", response = Void.class) })
-    public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
+    public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updatePet(body, securityContext);
@@ -187,7 +187,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
-    public Response updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathParam("petId") Long petId
+    public Response updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "Updated name of the pet")  @FormParam("name")  String name
 ,@ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status
 ,@Context SecurityContext securityContext)
@@ -206,7 +206,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
-    public Response uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId
+    public Response uploadFile(@ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,
             @FormDataParam("file") InputStream fileInputStream,
@@ -227,7 +227,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
-    public Response uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId
+    public Response uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId
 ,
             @FormDataParam("requiredFile") InputStream requiredFileInputStream,
             @FormDataParam("requiredFile") FormDataContentDisposition requiredFileDetail

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/StoreApi.java
@@ -65,7 +65,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
-    public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId
+    public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required = true) @PathParam("order_id") @NotNull  String orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteOrder(orderId, securityContext);
@@ -94,7 +94,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
-    public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("order_id") Long orderId
+    public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched", required = true) @PathParam("order_id") @NotNull  @Min(1L) @Max(5L) Long orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getOrderById(orderId, securityContext);
@@ -108,7 +108,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Order.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
-    public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true) @NotNull @Valid Order body
+    public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet", required = true) @NotNull @Valid  Order body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.placeOrder(body, securityContext);

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApi.java
@@ -63,7 +63,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUser(@ApiParam(value = "Created user object" ,required=true) @NotNull @Valid User body
+    public Response createUser(@ApiParam(value = "Created user object", required = true) @NotNull @Valid  User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUser(body, securityContext);
@@ -75,7 +75,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
+    public Response createUsersWithArrayInput(@ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithArrayInput(body, securityContext);
@@ -87,7 +87,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
+    public Response createUsersWithListInput(@ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithListInput(body, securityContext);
@@ -101,7 +101,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username
+    public Response deleteUser(@ApiParam(value = "The name that needs to be deleted", required = true) @PathParam("username") @NotNull  String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteUser(username, securityContext);
@@ -117,7 +117,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathParam("username") String username
+    public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required = true) @PathParam("username") @NotNull  String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getUserByName(username, securityContext);
@@ -131,8 +131,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = String.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
-    public Response loginUser(@ApiParam(value = "The user name for login",required=true)@QueryParam("username") String username
-,@ApiParam(value = "The password for login in clear text",required=true)@QueryParam("password") String password
+    public Response loginUser(@ApiParam(value = "The user name for login", required = true) @QueryParam("username") @NotNull  String username
+,@ApiParam(value = "The password for login in clear text", required = true) @QueryParam("password") @NotNull  String password
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.loginUser(username, password, securityContext);
@@ -157,8 +157,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathParam("username") String username
-,@ApiParam(value = "Updated user object" ,required=true) @NotNull @Valid User body
+    public Response updateUser(@ApiParam(value = "name that need to be deleted", required = true) @PathParam("username") @NotNull  String username
+,@ApiParam(value = "Updated user object", required = true) @NotNull @Valid  User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updateUser(username, body, securityContext);

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -62,7 +62,7 @@ public class AnotherFakeApi  {
     @io.swagger.annotations.ApiOperation(value = "To test special tags", notes = "To test special tags and operation ID starting with number", response = Client.class, tags={ "$another-fake?", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response call123testSpecialTags(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
+    public Response call123testSpecialTags(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.call123testSpecialTags(body, securityContext);

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApi.java
@@ -71,7 +71,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "creates an XmlItem", notes = "this route creates an XmlItem", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createXmlItem(@ApiParam(value = "XmlItem Body" ,required=true) @NotNull @Valid XmlItem xmlItem
+    public Response createXmlItem(@ApiParam(value = "XmlItem Body", required = true) @NotNull @Valid  XmlItem xmlItem
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createXmlItem(xmlItem, securityContext);
@@ -83,7 +83,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer boolean types", response = Boolean.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output boolean", response = Boolean.class) })
-    public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body" ) Boolean body
+    public Response fakeOuterBooleanSerialize(@ApiParam(value = "Input boolean as post body")  Boolean body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterBooleanSerialize(body, securityContext);
@@ -95,7 +95,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of object with outer number type", response = OuterComposite.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output composite", response = OuterComposite.class) })
-    public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body" ) @Valid OuterComposite body
+    public Response fakeOuterCompositeSerialize(@ApiParam(value = "Input composite as post body") @Valid  OuterComposite body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterCompositeSerialize(body, securityContext);
@@ -107,7 +107,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer number types", response = BigDecimal.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output number", response = BigDecimal.class) })
-    public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body" ) BigDecimal body
+    public Response fakeOuterNumberSerialize(@ApiParam(value = "Input number as post body")  BigDecimal body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterNumberSerialize(body, securityContext);
@@ -119,7 +119,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "Test serialization of outer string types", response = String.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Output string", response = String.class) })
-    public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body" ) String body
+    public Response fakeOuterStringSerialize(@ApiParam(value = "Input string as post body")  String body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.fakeOuterStringSerialize(body, securityContext);
@@ -131,7 +131,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "For this test, the body for this request much reference a schema named `File`.", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testBodyWithFileSchema(@ApiParam(value = "" ,required=true) @NotNull @Valid FileSchemaTestClass body
+    public Response testBodyWithFileSchema(@ApiParam(value = "", required = true) @NotNull @Valid  FileSchemaTestClass body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithFileSchema(body, securityContext);
@@ -143,8 +143,8 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testBodyWithQueryParams(@ApiParam(value = "",required=true)@QueryParam("query") String query
-,@ApiParam(value = "" ,required=true) @NotNull @Valid User body
+    public Response testBodyWithQueryParams(@ApiParam(value = "", required = true) @QueryParam("query") @NotNull  String query
+,@ApiParam(value = "", required = true) @NotNull @Valid  User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testBodyWithQueryParams(query, body, securityContext);
@@ -156,7 +156,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "To test \"client\" model", notes = "To test \"client\" model", response = Client.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response testClientModel(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
+    public Response testClientModel(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClientModel(body, securityContext);
@@ -203,10 +203,10 @@ public class FakeApi  {
         @io.swagger.annotations.ApiResponse(code = 404, message = "Not found", response = Void.class) })
     public Response testEnumParameters(@ApiParam(value = "Header parameter enum test (string array)" , allowableValues=">, $", defaultValue="new ArrayList<String>()")@HeaderParam("enum_header_string_array") List<String> enumHeaderStringArray
 ,@ApiParam(value = "Header parameter enum test (string)" , allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")@HeaderParam("enum_header_string") String enumHeaderString
-,@ApiParam(value = "Query parameter enum test (string array)")@QueryParam("enum_query_string_array") List<String> enumQueryStringArray
-,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg") @DefaultValue("-efg")@QueryParam("enum_query_string") String enumQueryString
-,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2")@QueryParam("enum_query_integer") Integer enumQueryInteger
-,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2")@QueryParam("enum_query_double") Double enumQueryDouble
+,@ApiParam(value = "Query parameter enum test (string array)") @QueryParam("enum_query_string_array") @Valid  List<String> enumQueryStringArray
+,@ApiParam(value = "Query parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue = "-efg") @DefaultValue("-efg") @QueryParam("enum_query_string")  String enumQueryString
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1, -2") @QueryParam("enum_query_integer")  Integer enumQueryInteger
+,@ApiParam(value = "Query parameter enum test (double)", allowableValues="1.1, -1.2") @QueryParam("enum_query_double")  Double enumQueryDouble
 ,@ApiParam(value = "Form parameter enum test (string array)", allowableValues=">, $", defaultValue="$")  @DefaultValue("$") @FormParam("enum_form_string_array")  List<String> enumFormStringArray
 ,@ApiParam(value = "Form parameter enum test (string)", allowableValues="_abc, -efg, (xyz)", defaultValue="-efg")  @DefaultValue("-efg") @FormParam("enum_form_string")  String enumFormString
 ,@Context SecurityContext securityContext)
@@ -220,12 +220,12 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "Fake endpoint to test group parameters (optional)", notes = "Fake endpoint to test group parameters (optional)", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 400, message = "Someting wrong", response = Void.class) })
-    public Response testGroupParameters(@ApiParam(value = "Required String in group parameters",required=true)@QueryParam("required_string_group") Integer requiredStringGroup
+    public Response testGroupParameters(@ApiParam(value = "Required String in group parameters", required = true) @QueryParam("required_string_group") @NotNull  Integer requiredStringGroup
 ,@ApiParam(value = "Required Boolean in group parameters" ,required=true)@HeaderParam("required_boolean_group") Boolean requiredBooleanGroup
-,@ApiParam(value = "Required Integer in group parameters",required=true)@QueryParam("required_int64_group") Long requiredInt64Group
-,@ApiParam(value = "String in group parameters")@QueryParam("string_group") Integer stringGroup
+,@ApiParam(value = "Required Integer in group parameters", required = true) @QueryParam("required_int64_group") @NotNull  Long requiredInt64Group
+,@ApiParam(value = "String in group parameters") @QueryParam("string_group")  Integer stringGroup
 ,@ApiParam(value = "Boolean in group parameters" )@HeaderParam("boolean_group") Boolean booleanGroup
-,@ApiParam(value = "Integer in group parameters")@QueryParam("int64_group") Long int64Group
+,@ApiParam(value = "Integer in group parameters") @QueryParam("int64_group")  Long int64Group
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testGroupParameters(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group, securityContext);
@@ -237,7 +237,7 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "test inline additionalProperties", notes = "", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response testInlineAdditionalProperties(@ApiParam(value = "request body" ,required=true) @NotNull @Valid Map<String, String> param
+    public Response testInlineAdditionalProperties(@ApiParam(value = "request body", required = true) @NotNull @Valid  Map<String, String> param
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testInlineAdditionalProperties(param, securityContext);
@@ -262,11 +262,11 @@ public class FakeApi  {
     @io.swagger.annotations.ApiOperation(value = "", notes = "To test the collection format in query parameters", response = Void.class, tags={ "fake", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "Success", response = Void.class) })
-    public Response testQueryParameterCollectionFormat(@ApiParam(value = "",required=true)@QueryParam("pipe") List<String> pipe
-,@ApiParam(value = "",required=true)@QueryParam("ioutil") List<String> ioutil
-,@ApiParam(value = "",required=true)@QueryParam("http") List<String> http
-,@ApiParam(value = "",required=true)@QueryParam("url") List<String> url
-,@ApiParam(value = "",required=true)@QueryParam("context") List<String> context
+    public Response testQueryParameterCollectionFormat(@ApiParam(value = "", required = true) @QueryParam("pipe") @NotNull @Valid  List<String> pipe
+,@ApiParam(value = "", required = true) @QueryParam("ioutil") @NotNull @Valid  List<String> ioutil
+,@ApiParam(value = "", required = true) @QueryParam("http") @NotNull @Valid  List<String> http
+,@ApiParam(value = "", required = true) @QueryParam("url") @NotNull @Valid  List<String> url
+,@ApiParam(value = "", required = true) @QueryParam("context") @NotNull @Valid  List<String> context
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testQueryParameterCollectionFormat(pipe, ioutil, http, url, context, securityContext);
@@ -283,7 +283,7 @@ public class FakeApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
-    public Response uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId
+    public Response uploadFileWithRequiredFile(@ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId
 ,
             @FormDataParam("requiredFile") InputStream requiredFileInputStream,
             @FormDataParam("requiredFile") FormDataContentDisposition requiredFileDetail

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -64,7 +64,7 @@ public class FakeClassnameTestApi  {
     }, tags={ "fake_classname_tags 123#$%^", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Client.class) })
-    public Response testClassname(@ApiParam(value = "client model" ,required=true) @NotNull @Valid Client body
+    public Response testClassname(@ApiParam(value = "client model", required = true) @NotNull @Valid  Client body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.testClassname(body, securityContext);

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/PetApi.java
@@ -71,7 +71,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
-    public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
+    public Response addPet(@ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.addPet(body, securityContext);
@@ -90,7 +90,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid pet value", response = Void.class) })
-    public Response deletePet(@ApiParam(value = "Pet id to delete",required=true) @PathParam("petId") Long petId
+    public Response deletePet(@ApiParam(value = "Pet id to delete", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "" )@HeaderParam("api_key") String apiKey
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
@@ -110,7 +110,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid status value", response = Void.class) })
-    public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter",required=true)@QueryParam("status") List<String> status
+    public Response findPetsByStatus(@ApiParam(value = "Status values that need to be considered for filter", required = true) @QueryParam("status") @NotNull @Valid  List<String> status
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByStatus(status, securityContext);
@@ -129,7 +129,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Pet.class, responseContainer = "List"),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid tag value", response = Void.class) })
-    public Response findPetsByTags(@ApiParam(value = "Tags to filter by",required=true)@QueryParam("tags") List<String> tags
+    public Response findPetsByTags(@ApiParam(value = "Tags to filter by", required = true) @QueryParam("tags") @NotNull @Valid  List<String> tags
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.findPetsByTags(tags, securityContext);
@@ -147,7 +147,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class) })
-    public Response getPetById(@ApiParam(value = "ID of pet to return",required=true) @PathParam("petId") Long petId
+    public Response getPetById(@ApiParam(value = "ID of pet to return", required = true) @PathParam("petId") @NotNull  Long petId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getPetById(petId, securityContext);
@@ -170,7 +170,7 @@ public class PetApi  {
         @io.swagger.annotations.ApiResponse(code = 404, message = "Pet not found", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 405, message = "Validation exception", response = Void.class) })
-    public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store" ,required=true) @NotNull @Valid Pet body
+    public Response updatePet(@ApiParam(value = "Pet object that needs to be added to the store", required = true) @NotNull @Valid  Pet body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updatePet(body, securityContext);
@@ -187,7 +187,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 405, message = "Invalid input", response = Void.class) })
-    public Response updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated",required=true) @PathParam("petId") Long petId
+    public Response updatePetWithForm(@ApiParam(value = "ID of pet that needs to be updated", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "Updated name of the pet")  @FormParam("name")  String name
 ,@ApiParam(value = "Updated status of the pet")  @FormParam("status")  String status
 ,@Context SecurityContext securityContext)
@@ -206,7 +206,7 @@ public class PetApi  {
     }, tags={ "pet", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = ModelApiResponse.class) })
-    public Response uploadFile(@ApiParam(value = "ID of pet to update",required=true) @PathParam("petId") Long petId
+    public Response uploadFile(@ApiParam(value = "ID of pet to update", required = true) @PathParam("petId") @NotNull  Long petId
 ,@ApiParam(value = "Additional data to pass to server")@FormDataParam("additionalMetadata")  String additionalMetadata
 ,
             @FormDataParam("file") InputStream fileInputStream,

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/StoreApi.java
@@ -65,7 +65,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
-    public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted",required=true) @PathParam("order_id") String orderId
+    public Response deleteOrder(@ApiParam(value = "ID of the order that needs to be deleted", required = true) @PathParam("order_id") @NotNull  String orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteOrder(orderId, securityContext);
@@ -94,7 +94,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid ID supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "Order not found", response = Void.class) })
-    public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched",required=true) @PathParam("order_id") Long orderId
+    public Response getOrderById(@ApiParam(value = "ID of pet that needs to be fetched", required = true) @PathParam("order_id") @NotNull  @Min(1L) @Max(5L) Long orderId
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getOrderById(orderId, securityContext);
@@ -108,7 +108,7 @@ public class StoreApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Order.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid Order", response = Void.class) })
-    public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet" ,required=true) @NotNull @Valid Order body
+    public Response placeOrder(@ApiParam(value = "order placed for purchasing the pet", required = true) @NotNull @Valid  Order body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.placeOrder(body, securityContext);

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/UserApi.java
@@ -63,7 +63,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUser(@ApiParam(value = "Created user object" ,required=true) @NotNull @Valid User body
+    public Response createUser(@ApiParam(value = "Created user object", required = true) @NotNull @Valid  User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUser(body, securityContext);
@@ -75,7 +75,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUsersWithArrayInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
+    public Response createUsersWithArrayInput(@ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithArrayInput(body, securityContext);
@@ -87,7 +87,7 @@ public class UserApi  {
     @io.swagger.annotations.ApiOperation(value = "Creates list of users with given input array", notes = "", response = Void.class, tags={ "user", })
     @io.swagger.annotations.ApiResponses(value = { 
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = Void.class) })
-    public Response createUsersWithListInput(@ApiParam(value = "List of user object" ,required=true) @NotNull @Valid List<User> body
+    public Response createUsersWithListInput(@ApiParam(value = "List of user object", required = true) @NotNull @Valid  List<User> body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.createUsersWithListInput(body, securityContext);
@@ -101,7 +101,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response deleteUser(@ApiParam(value = "The name that needs to be deleted",required=true) @PathParam("username") String username
+    public Response deleteUser(@ApiParam(value = "The name that needs to be deleted", required = true) @PathParam("username") @NotNull  String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.deleteUser(username, securityContext);
@@ -117,7 +117,7 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.",required=true) @PathParam("username") String username
+    public Response getUserByName(@ApiParam(value = "The name that needs to be fetched. Use user1 for testing.", required = true) @PathParam("username") @NotNull  String username
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.getUserByName(username, securityContext);
@@ -131,8 +131,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 200, message = "successful operation", response = String.class),
         
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid username/password supplied", response = Void.class) })
-    public Response loginUser(@ApiParam(value = "The user name for login",required=true)@QueryParam("username") String username
-,@ApiParam(value = "The password for login in clear text",required=true)@QueryParam("password") String password
+    public Response loginUser(@ApiParam(value = "The user name for login", required = true) @QueryParam("username") @NotNull  String username
+,@ApiParam(value = "The password for login in clear text", required = true) @QueryParam("password") @NotNull  String password
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.loginUser(username, password, securityContext);
@@ -157,8 +157,8 @@ public class UserApi  {
         @io.swagger.annotations.ApiResponse(code = 400, message = "Invalid user supplied", response = Void.class),
         
         @io.swagger.annotations.ApiResponse(code = 404, message = "User not found", response = Void.class) })
-    public Response updateUser(@ApiParam(value = "name that need to be deleted",required=true) @PathParam("username") String username
-,@ApiParam(value = "Updated user object" ,required=true) @NotNull @Valid User body
+    public Response updateUser(@ApiParam(value = "name that need to be deleted", required = true) @PathParam("username") @NotNull  String username
+,@ApiParam(value = "Updated user object", required = true) @NotNull @Valid  User body
 ,@Context SecurityContext securityContext)
     throws NotFoundException {
         return delegate.updateUser(username, body, securityContext);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix for #3861 
I improved the formatting of *Params.mustache files (only for 'pure' JAXRS templates). The added line breaks are commented and therefore will be omitted in the generators output. Thereafter, I added the missing validation templates.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)