### PR TITLE
add gradle repository for using gralde dependency in plugin

### DIFF
--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -20,6 +20,20 @@
         <gradleVersion>4.10.2</gradleVersion>
     </properties>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>Gradle Releases</id>
+            <name>Gradle Releases repository</name>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <dependencies>
         <dependency>
             <groupId>org.openapitools</groupId>


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
`org.gradle:gradle-tooling-api` is on Gradle Releases repository (cf. https://mvnrepository.com/artifact/org.gradle/gradle-tooling-api/4.10.2)

So, we need to add this repository to `pluginManagement`.

Without this setting, following error will occur in some environment.
```
[INFO] --- gradle-maven-plugin:1.0.8:invoke (default) @ openapi-generator-gradle-plugin-mvn-wrapper ---
[WARNING] The POM for org.gradle:gradle-tooling-api:jar:4.10.2 is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] openapi-generator-project .......................... SUCCESS [  3.859 s]
[INFO] openapi-generator-core ............................. SUCCESS [  3.680 s]
[INFO] openapi-generator (core library) ................... SUCCESS [ 50.943 s]
[INFO] openapi-generator (executable) ..................... SUCCESS [ 17.679 s]
[INFO] openapi-generator (maven-plugin) ................... SUCCESS [  6.745 s]
[INFO] openapi-generator-gradle-plugin (maven wrapper) .... FAILURE [  0.061 s]
[INFO] openapi-generator-online ........................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:23 min
[INFO] Finished at: 2019-09-10T05:05:53+00:00
[INFO] Final Memory: 69M/1395M
[INFO] ------------------------------------------------------------------------
```

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

