### PR TITLE
typescript-fetch: fix missing comma in multiple imports

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -13,7 +13,7 @@ import {
 {{#discriminator}}
 import {
 {{#discriminator.mappedModels}}
-     {{modelName}}FromJSONTyped
+     {{modelName}}FromJSONTyped{{^-last}},{{/-last}}
 {{/discriminator.mappedModels}}
 } from './';
 


### PR DESCRIPTION
When generating the import list for a super class, the comma separating the objects was missing:
The code generated in `SuperClass.ts` was
```ts
import {
     SubClassAFromJSONTyped <-- missing comma
     SubClassBFromJSONTyped
} from './';
```
It was missing the comma between the imported entries.

I tested by building the latest version off of master and generating the client for my app, then applied the fix and validated that the new version correctly passed the typescript compilation.