### PR TITLE
Fix javadoc error

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocSampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocSampleGeneratorTest.java
@@ -16,7 +16,10 @@ import org.testng.annotations.Test;
 
 public class AsciidocSampleGeneratorTest {
 
-    /** ensure api-docs.json includes sample and spec files into markup. */
+    /** 
+     * ensure api-docs.json includes sample and spec files into markup.
+     * @throws Exception generic exception
+     */
     @Test
     public void testSampleAsciidocMarkupGenerationFromJsonWithSpecsAndSamples() throws Exception {
 


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This small PR fixes a javadoc bloc to fix following warning:

> Javadoc: Missing tag for declared exception: Exception

