### PR TITLE
Added Dart config parameters to fulfill pubspec requirements for publishing to pub

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartClientCodegen.java
@@ -39,16 +39,22 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
     public static final String PUB_NAME = "pubName";
     public static final String PUB_VERSION = "pubVersion";
     public static final String PUB_DESCRIPTION = "pubDescription";
+    public static final String PUB_AUTHOR = "pubAuthor";
+    public static final String PUB_AUTHOR_EMAIL = "pubAuthorEmail";
+    public static final String PUB_HOMEPAGE = "pubHomepage";
     public static final String USE_ENUM_EXTENSION = "useEnumExtension";
     public static final String SUPPORT_DART2 = "supportDart2";
     protected boolean browserClient = true;
     protected String pubName = "openapi";
     protected String pubVersion = "1.0.0";
     protected String pubDescription = "OpenAPI API client";
+    protected String pubAuthor = "Author";
+    protected String pubAuthorEmail = "author@homepage";
+    protected String pubHomepage = "homepage";
     protected boolean useEnumExtension = false;
     protected String sourceFolder = "";
-    protected String apiDocPath = "docs" + File.separator;
-    protected String modelDocPath = "docs" + File.separator;
+    protected String apiDocPath = "doc" + File.separator;
+    protected String modelDocPath = "doc" + File.separator;
     protected String apiTestPath = "test" + File.separator;
     protected String modelTestPath = "test" + File.separator;
 
@@ -122,6 +128,9 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         cliOptions.add(new CliOption(PUB_NAME, "Name in generated pubspec"));
         cliOptions.add(new CliOption(PUB_VERSION, "Version in generated pubspec"));
         cliOptions.add(new CliOption(PUB_DESCRIPTION, "Description in generated pubspec"));
+        cliOptions.add(new CliOption(PUB_AUTHOR, "Author name in generated pubspec"));
+        cliOptions.add(new CliOption(PUB_AUTHOR_EMAIL, "Email address of the author in generated pubspec"));
+        cliOptions.add(new CliOption(PUB_HOMEPAGE, "Homepage in generated pubspec"));
         cliOptions.add(new CliOption(USE_ENUM_EXTENSION, "Allow the 'x-enum-values' extension for enums"));
         cliOptions.add(new CliOption(CodegenConstants.SOURCE_FOLDER, "Source folder for generated code"));
         cliOptions.add(CliOption.newBoolean(SUPPORT_DART2, "Support Dart 2.x (Dart 1.x support has been deprecated)").defaultValue(Boolean.TRUE.toString()));
@@ -177,6 +186,27 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
         } else {
             //not set, use to be passed to template
             additionalProperties.put(PUB_DESCRIPTION, pubDescription);
+        }
+
+        if (additionalProperties.containsKey(PUB_AUTHOR)) {
+            this.setPubAuthor((String) additionalProperties.get(PUB_AUTHOR));
+        } else {
+            //not set, use to be passed to template
+            additionalProperties.put(PUB_AUTHOR, pubAuthor);
+        }
+
+        if (additionalProperties.containsKey(PUB_AUTHOR_EMAIL)) {
+            this.setPubAuthorEmail((String) additionalProperties.get(PUB_AUTHOR_EMAIL));
+        } else {
+            //not set, use to be passed to template
+            additionalProperties.put(PUB_AUTHOR_EMAIL, pubAuthorEmail);
+        }
+
+        if (additionalProperties.containsKey(PUB_HOMEPAGE)) {
+            this.setPubHomepage((String) additionalProperties.get(PUB_HOMEPAGE));
+        } else {
+            //not set, use to be passed to template
+            additionalProperties.put(PUB_HOMEPAGE, pubHomepage);
         }
 
         if (additionalProperties.containsKey(USE_ENUM_EXTENSION)) {
@@ -509,6 +539,18 @@ public class DartClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     public void setPubDescription(String pubDescription) {
         this.pubDescription = pubDescription;
+    }
+
+    public void setPubAuthor(String pubAuthor) {
+        this.pubAuthor = pubAuthor;
+    }
+
+    public void setPubAuthorEmail(String pubAuthorEmail) {
+        this.pubAuthorEmail = pubAuthorEmail;
+    }
+
+    public void setPubHomepage(String pubHomepage) {
+        this.pubHomepage = pubHomepage;
     }
 
     public void setUseEnumExtension(boolean useEnumExtension) {

--- a/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
@@ -1,6 +1,9 @@
 name: {{pubName}}
 version: {{pubVersion}}
 description: {{pubDescription}}
+authors:
+  - {{pubAuthor}} <{{pubAuthorEmail}}>
+homepage: {{pubHomepage}}
 environment:
   sdk: '>=2.0.0 <3.0.0'
 dependencies:

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartClientOptionsTest.java
@@ -52,6 +52,12 @@ public class DartClientOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setPubDescription(DartClientOptionsProvider.PUB_DESCRIPTION_VALUE);
             times = 1;
+            clientCodegen.setPubAuthor(DartClientOptionsProvider.PUB_AUTHOR_VALUE);
+            times = 1;
+            clientCodegen.setPubAuthorEmail(DartClientOptionsProvider.PUB_AUTHOR_EMAIL_VALUE);
+            times = 1;
+            clientCodegen.setPubHomepage(DartClientOptionsProvider.PUB_HOMEPAGE_VALUE);
+            times = 1;
             clientCodegen.setSourceFolder(DartClientOptionsProvider.SOURCE_FOLDER_VALUE);
             times = 1;
             clientCodegen.setUseEnumExtension(Boolean.valueOf(DartClientOptionsProvider.USE_ENUM_EXTENSION));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartClientOptionsProvider.java
@@ -30,6 +30,9 @@ public class DartClientOptionsProvider implements OptionsProvider {
     public static final String PUB_NAME_VALUE = "swagger";
     public static final String PUB_VERSION_VALUE = "1.0.0-SNAPSHOT";
     public static final String PUB_DESCRIPTION_VALUE = "Swagger API client dart";
+    public static final String PUB_AUTHOR_VALUE = "Author";
+    public static final String PUB_AUTHOR_EMAIL_VALUE = "author@homepage";
+    public static final String PUB_HOMEPAGE_VALUE = "Homepage";
     public static final String SOURCE_FOLDER_VALUE = "src";
     public static final String USE_ENUM_EXTENSION = "true";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
@@ -49,6 +52,9 @@ public class DartClientOptionsProvider implements OptionsProvider {
                 .put(DartClientCodegen.PUB_NAME, PUB_NAME_VALUE)
                 .put(DartClientCodegen.PUB_VERSION, PUB_VERSION_VALUE)
                 .put(DartClientCodegen.PUB_DESCRIPTION, PUB_DESCRIPTION_VALUE)
+                .put(DartClientCodegen.PUB_AUTHOR, PUB_AUTHOR_VALUE)
+                .put(DartClientCodegen.PUB_AUTHOR_EMAIL, PUB_AUTHOR_EMAIL_VALUE)
+                .put(DartClientCodegen.PUB_HOMEPAGE, PUB_HOMEPAGE_VALUE)
                 .put(CodegenConstants.SOURCE_FOLDER, SOURCE_FOLDER_VALUE)
                 .put(DartClientCodegen.USE_ENUM_EXTENSION, USE_ENUM_EXTENSION)
                 .put(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, ALLOW_UNICODE_IDENTIFIERS_VALUE)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@ircecho @swipesight @jaumard @nickmeinhold
### Description of the PR

Added three configuration values for Dart 2 to be able to publish the generated code to pub without changes:

pubAuthor - contains the name of the author
pubAuthorEmail - contains the email address of the author
pubHomepage - contain the homepage of the project

Changed the name of the output directory from docs to doc as this follows the dart [package layout](https://dart.dev/tools/pub/package-layout)