### PR TITLE
Feature/api name suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ NAME
 SYNOPSIS
         openapi-generator-cli generate
                 [(-a <authorization> | --auth <authorization>)]
+                [--api-name-suffix <api name suffix>]
                 [--api-package <api package>] [--artifact-id <artifact id>]
                 [--artifact-version <artifact version>]
                 [(-c <configuration file> | --config <configuration file>)]

--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -65,7 +65,7 @@ public class Generate implements Runnable {
     private String templateDir;
 
     @Option(name = {"-e", "--engine"}, title = "templating engine",
-        description = "templating engine: \"mustache\" (default) or \"handlebars\" (beta)")
+            description = "templating engine: \"mustache\" (default) or \"handlebars\" (beta)")
     private String templatingEngine;
 
     @Option(
@@ -108,6 +108,10 @@ public class Generate implements Runnable {
     @Option(name = {"--model-package"}, title = "model package",
             description = CodegenConstants.MODEL_PACKAGE_DESC)
     private String modelPackage;
+
+    @Option(name = {"--api-name-suffix"}, title = "api name suffix",
+            description = CodegenConstants.API_NAME_SUFFIX_DESC)
+    private String apiNameSuffix;
 
     @Option(name = {"--model-name-prefix"}, title = "model name prefix",
             description = CodegenConstants.MODEL_NAME_PREFIX_DESC)
@@ -317,6 +321,10 @@ public class Generate implements Runnable {
 
         if (isNotEmpty(modelPackage)) {
             configurator.setModelPackage(modelPackage);
+        }
+
+        if (isNotEmpty(apiNameSuffix)) {
+            configurator.setApiNameSuffix(apiNameSuffix);
         }
 
         if (isNotEmpty(modelNamePrefix)) {

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
@@ -40,6 +40,7 @@ public final class GeneratorSettings implements Serializable {
     private String modelPackage;
     private String invokerPackage;
     private String packageName;
+    private String apiNameSuffix;
     private String modelNamePrefix;
     private String modelNameSuffix;
     private String groupId;
@@ -104,6 +105,21 @@ public final class GeneratorSettings implements Serializable {
      */
     public String getPackageName() {
         return packageName;
+    }
+
+    /**
+     * Gets a api name suffix for generated models. This name will be appended to a api name.
+     * <p>
+     * This option is often used to circumvent compilation issues where models match keywords.
+     * <p>
+     * Example:
+     * <p>
+     * Suffix <code>Gen</code> applied to <code>Object</code> results in a generated class named <code>ObjectGen</code>.
+     *
+     * @return the model name suffix
+     */
+    public String getApiNameSuffix() {
+        return apiNameSuffix;
     }
 
     /**
@@ -325,6 +341,7 @@ public final class GeneratorSettings implements Serializable {
         modelPackage = builder.modelPackage;
         invokerPackage = builder.invokerPackage;
         packageName = builder.packageName;
+        apiNameSuffix = builder.apiNameSuffix;
         modelNamePrefix = builder.modelNamePrefix;
         modelNameSuffix = builder.modelNameSuffix;
         groupId = builder.groupId;
@@ -365,6 +382,9 @@ public final class GeneratorSettings implements Serializable {
         }
         if (isNotEmpty(artifactVersion)) {
             additional.put("artifactVersion", artifactVersion);
+        }
+        if (isNotEmpty(apiNameSuffix)) {
+            additional.put("apiNameSuffix", apiNameSuffix);
         }
         if (isNotEmpty(modelNamePrefix)) {
             additional.put("modelNamePrefix", modelNamePrefix);
@@ -433,6 +453,7 @@ public final class GeneratorSettings implements Serializable {
         builder.modelPackage = copy.getModelPackage();
         builder.invokerPackage = copy.getInvokerPackage();
         builder.packageName = copy.getPackageName();
+        builder.apiNameSuffix = copy.getApiNameSuffix();
         builder.modelNamePrefix = copy.getModelNamePrefix();
         builder.modelNameSuffix = copy.getModelNameSuffix();
         builder.groupId = copy.getGroupId();
@@ -479,6 +500,7 @@ public final class GeneratorSettings implements Serializable {
         private String modelPackage;
         private String invokerPackage;
         private String packageName;
+        private String apiNameSuffix;
         private String modelNamePrefix;
         private String modelNameSuffix;
         private String groupId;
@@ -568,6 +590,17 @@ public final class GeneratorSettings implements Serializable {
          */
         public Builder withPackageName(String packageName) {
             this.packageName = packageName;
+            return this;
+        }
+
+        /**
+         * Sets the {@code apiNameSuffix} and returns a reference to this Builder so that the methods can be chained together.
+         *
+         * @param apiNameSuffix the {@code apiNameSuffix} to set
+         * @return a reference to this Builder
+         */
+        public Builder withApiNameSuffix(String apiNameSuffix) {
+            this.apiNameSuffix = apiNameSuffix;
             return this;
         }
 
@@ -880,6 +913,7 @@ public final class GeneratorSettings implements Serializable {
                 ", modelPackage='" + modelPackage + '\'' +
                 ", invokerPackage='" + invokerPackage + '\'' +
                 ", packageName='" + packageName + '\'' +
+                ", apiNameSuffix='" + apiNameSuffix + '\'' +
                 ", modelNamePrefix='" + modelNamePrefix + '\'' +
                 ", modelNameSuffix='" + modelNameSuffix + '\'' +
                 ", groupId='" + groupId + '\'' +
@@ -910,6 +944,7 @@ public final class GeneratorSettings implements Serializable {
                 Objects.equals(getModelPackage(), that.getModelPackage()) &&
                 Objects.equals(getInvokerPackage(), that.getInvokerPackage()) &&
                 Objects.equals(getPackageName(), that.getPackageName()) &&
+                Objects.equals(getApiNameSuffix(), that.getApiNameSuffix()) &&
                 Objects.equals(getModelNamePrefix(), that.getModelNamePrefix()) &&
                 Objects.equals(getModelNameSuffix(), that.getModelNameSuffix()) &&
                 Objects.equals(getGroupId(), that.getGroupId()) &&
@@ -937,6 +972,7 @@ public final class GeneratorSettings implements Serializable {
                 getModelPackage(),
                 getInvokerPackage(),
                 getPackageName(),
+                getApiNameSuffix(),
                 getModelNamePrefix(),
                 getModelNameSuffix(),
                 getGroupId(),

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -206,6 +206,9 @@ public class CodegenConstants {
     // Codegen constants should define a description and provide proper input validation for the value of serializationLibrary
     public static final String SERIALIZATION_LIBRARY = "serializationLibrary";
 
+    public static final String API_NAME_SUFFIX = "apiNameSuffix";
+    public static final String API_NAME_SUFFIX_DESC = "Suffix that will be appended to all api names.";
+
     public static final String MODEL_NAME_PREFIX = "modelNamePrefix";
     public static final String MODEL_NAME_PREFIX_DESC = "Prefix that will be prepended to all model names.";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -85,6 +85,7 @@ public class DefaultCodegen implements CodegenConfig {
     protected Map<String, String> importMapping = new HashMap<String, String>();
     protected String modelPackage = "", apiPackage = "", fileSuffix;
     protected String modelNamePrefix = "", modelNameSuffix = "";
+    protected String apiNameSuffix = "Api";
     protected String testPackage = "";
     protected Map<String, String> apiTemplateFiles = new HashMap<String, String>();
     protected Map<String, String> modelTemplateFiles = new HashMap<String, String>();
@@ -178,6 +179,10 @@ public class DefaultCodegen implements CodegenConfig {
         if (additionalProperties.containsKey(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS)) {
             this.setAllowUnicodeIdentifiers(Boolean.valueOf(additionalProperties
                     .get(CodegenConstants.ALLOW_UNICODE_IDENTIFIERS).toString()));
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.API_NAME_SUFFIX)) {
+            this.setApiNameSuffix((String) additionalProperties.get(CodegenConstants.API_NAME_SUFFIX));
         }
 
         if (additionalProperties.containsKey(CodegenConstants.MODEL_NAME_PREFIX)) {
@@ -777,6 +782,14 @@ public class DefaultCodegen implements CodegenConfig {
 
     public void setModelNameSuffix(String modelNameSuffix) {
         this.modelNameSuffix = modelNameSuffix;
+    }
+
+    public String getApiNameSuffix() {
+        return apiNameSuffix;
+    }
+
+    public void setApiNameSuffix(String apiNameSuffix) {
+        this.apiNameSuffix = apiNameSuffix;
     }
 
     public void setApiPackage(String apiPackage) {
@@ -1693,17 +1706,17 @@ public class DefaultCodegen implements CodegenConfig {
     }
 
     /**
-     * Output the API (class) name (capitalized) ending with "Api"
+     * Output the API (class) name (capitalized) ending with the specified or default suffix
      * Return DefaultApi if name is empty
      *
      * @param name the name of the Api
-     * @return capitalized Api name ending with "Api"
+     * @return capitalized Api name
      */
     public String toApiName(String name) {
         if (name.length() == 0) {
             return "DefaultApi";
         }
-        return camelize(name) + "Api";
+        return camelize(name + "_" + apiNameSuffix);
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/CodegenConfigurator.java
@@ -287,6 +287,11 @@ public class CodegenConfigurator {
         return this;
     }
 
+    public CodegenConfigurator setApiNameSuffix(String suffix) {
+        generatorSettingsBuilder.withApiNameSuffix(suffix);
+        return this;
+    }
+
     public CodegenConfigurator setModelNamePrefix(String prefix) {
         generatorSettingsBuilder.withModelNamePrefix(prefix);
         return this;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
@@ -150,7 +150,7 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public String toApiName(String type) {
-        return sanitizeName(modelNamePrefix + Character.toUpperCase(type.charAt(0)) + type.substring(1) + "Api");
+        return sanitizeName(modelNamePrefix + super.toApiName(type));
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaJAXRSServerCodegen.java
@@ -244,11 +244,10 @@ public abstract class AbstractJavaJAXRSServerCodegen extends AbstractJavaCodegen
     @Override
     public String toApiName(final String name) {
         String computed = name;
-        if (computed.length() == 0) {
-            return "DefaultApi";
+        if (computed.length() > 0) {
+            computed = sanitizeName(computed);
         }
-        computed = sanitizeName(computed);
-        return camelize(computed) + "Api";
+         return super.toApiName(computed);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -531,7 +531,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         name = name.replaceAll("-", "_");
 
         // e.g. PhoneNumberApi.py => phone_number_api.py
-        return underscore(name) + "_api";
+        return underscore(name+ "_" + apiNameSuffix);
     }
 
     @Override
@@ -541,11 +541,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
 
     @Override
     public String toApiName(String name) {
-        if (name.length() == 0) {
-            return "DefaultApi";
-        }
-        // e.g. phone_number_api => PhoneNumberApi
-        return camelize(name) + "Api";
+        return super.toApiName(name);
     }
 
     @Override
@@ -553,7 +549,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         if (name.length() == 0) {
             return "default_api";
         }
-        return underscore(name) + "_api";
+        return underscore(name+ "_" + apiNameSuffix);
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -387,7 +387,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
         name = name.replaceAll("-", "_"); // FIXME: a parameter should not be assigned. Also declare the methods parameters as 'final'.
 
         // e.g. PhoneNumberApi.rb => phone_number_api.rb
-        return underscore(name) + "_api";
+        return underscore(name + "_" + apiNameSuffix);
     }
 
     @Override
@@ -407,11 +407,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
 
     @Override
     public String toApiName(String name) {
-        if (name.length() == 0) {
-            return "DefaultApi";
-        }
-        // e.g. phone_number_api => PhoneNumberApi
-        return camelize(name) + "Api";
+        return super.toApiName(name);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -43,6 +43,7 @@ import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -966,6 +967,21 @@ public class DefaultCodegenTest {
         assertTrue(lambdas.get("indented_8") instanceof IndentedLambda, "Expecting IndentedLambda class");
         assertTrue(lambdas.get("indented_12") instanceof IndentedLambda, "Expecting IndentedLambda class");
         assertTrue(lambdas.get("indented_16") instanceof IndentedLambda, "Expecting IndentedLambda class");
+    }
+
+    @Test
+    public void convertApiNameWithEmptySuffix() {
+        DefaultCodegen codegen = new DefaultCodegen();
+        assertEquals(codegen.toApiName("Fake"), "FakeApi");
+        assertEquals(codegen.toApiName(""), "DefaultApi");
+    }
+
+    @Test
+    public void convertApiNameWithSuffix() {
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setApiNameSuffix("Test");
+        assertEquals(codegen.toApiName("Fake"), "FakeTest");
+        assertEquals(codegen.toApiName(""), "DefaultApi");
     }
 
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/CodegenConfiguratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/CodegenConfiguratorTest.java
@@ -77,6 +77,7 @@ public class CodegenConfiguratorTest {
                 .setGitHost("test.com")
                 .setGroupId("group")
                 .setHttpUserAgent("agent")
+                .setApiNameSuffix("api-suffix")
                 .setModelNamePrefix("model-prefix")
                 .setModelNameSuffix("model-suffix")
                 .setModelPackage("model-package")
@@ -100,6 +101,7 @@ public class CodegenConfiguratorTest {
         want(props, CodegenConstants.PREPEND_FORM_OR_BODY_PARAMETERS, false);
         want(props, CodegenConstants.ENSURE_UNIQUE_PARAMS, true);
         want(props, CodegenConstants.ALLOW_UNICODE_IDENTIFIERS, true);
+        want(props, CodegenConstants.API_NAME_SUFFIX, "api-suffix");
         want(props, CodegenConstants.MODEL_NAME_PREFIX, "model-prefix");
         want(props, CodegenConstants.MODEL_NAME_SUFFIX, "model-suffix");
         want(props, CodegenConstants.REMOVE_OPERATION_ID_PREFIX, false);


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

The problem:
API generation for C#, Java and Ruby creates a class based on the tag and then adds "Api" after it. 
Ideally though we have a class like  "Study" or "Study{{Suffix}}" not "StudyApi".

I introduced a apiNameSuffix parameter in order to add suffixes to the generated api class/file/document names. Added the option "--api-name-suffix" to allow the user specify api name suffix via openapi-generator command line, the value of apiNameSuffix is "Api" if the option "--api-name-suffix" is not provided or empty. 

Sample of command line:
java -jar openapi-generator-cli.jar generate g java --api-name-suffix=client -i petstore.yaml -o out/petstore

This PR works for Java, Ruby, C# and Python 

@jcarres-mdsol
@bkashyapmd
@jfeltesse-mdsol
@prajon84
@ykitamura-mdsol
@cabbott
