### PR TITLE
[java][client] Don't include nullable attributes twice in serialized JSON

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -676,15 +676,17 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                     var.getVendorExtensions().put("isJacksonOptionalNullable", isOptionalNullable);
                 }
                 if (addImports) {
-                    cm.imports.add("JsonNullable");
-                    Map<String, String> itemJsonNullable = new HashMap<String, String>();
-                    itemJsonNullable.put("import", "org.openapitools.jackson.nullable.JsonNullable");
-                    imports.add(itemJsonNullable);
-
-                    cm.imports.add("NoSuchElementException");
-                    Map<String, String> itemExc = new HashMap<String, String>();
-                    itemExc.put("import", "java.util.NoSuchElementException");
-                    imports.add(itemExc);
+                    Map<String, String> imports2Classnames = new HashMap<String, String>() {{
+                        put("JsonNullable", "org.openapitools.jackson.nullable.JsonNullable");
+                        put("NoSuchElementException", "java.util.NoSuchElementException");
+                        put("JsonIgnore", "com.fasterxml.jackson.annotation.JsonIgnore");
+                    }};
+                    for (Map.Entry<String, String> entry : imports2Classnames.entrySet()) {
+                        cm.imports.add(entry.getKey());
+                        Map<String, String> importsItem = new HashMap<String, String>();
+                        importsItem.put("import", entry.getValue());
+                        imports.add(importsItem);
+                    }
                 }
             }
         }

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -180,6 +180,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}
+{{#vendorExtensions.isJacksonOptionalNullable}}  @JsonIgnore{{! unannotated, Jackson would pick this up automatically and add it *in addition* to the _JsonNullable getter field }}{{/vendorExtensions.isJacksonOptionalNullable}}
 {{^vendorExtensions.isJacksonOptionalNullable}}{{#jackson}}{{> jackson_annotations}}{{/jackson}}{{/vendorExtensions.isJacksonOptionalNullable}}
   public {{{datatypeWithEnum}}} {{getter}}() {
     {{#vendorExtensions.isJacksonOptionalNullable}}
@@ -202,14 +203,15 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   }
   {{/vendorExtensions.isJacksonOptionalNullable}}
 
-  {{^isReadOnly}}
   {{#vendorExtensions.isJacksonOptionalNullable}}
   @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
-  public void {{setter}}_JsonNullable(JsonNullable<{{{datatypeWithEnum}}}> {{name}}) {
+  {{#isReadOnly}}private{{/isReadOnly}}{{^isReadOnly}}public{{/isReadOnly}} void {{setter}}_JsonNullable(JsonNullable<{{{datatypeWithEnum}}}> {{name}}) {
+    {{! For getters/setters that have name differing from attribute name, we must include setter (albeit private) for jackson to be able to set the attribute}}
     this.{{name}} = {{name}};
   }
   {{/vendorExtensions.isJacksonOptionalNullable}}
 
+  {{^isReadOnly}}
   public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.isJacksonOptionalNullable}}
     this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -180,7 +180,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
 {{#vendorExtensions.extraAnnotation}}
   {{{vendorExtensions.extraAnnotation}}}
 {{/vendorExtensions.extraAnnotation}}
-{{#vendorExtensions.isJacksonOptionalNullable}}  @JsonIgnore{{! unannotated, Jackson would pick this up automatically and add it *in addition* to the _JsonNullable getter field }}{{/vendorExtensions.isJacksonOptionalNullable}}
+{{#vendorExtensions.isJacksonOptionalNullable}}
+  {{!unannotated, Jackson would pick this up automatically and add it *in addition* to the _JsonNullable getter field}}
+  @JsonIgnore
+{{/vendorExtensions.isJacksonOptionalNullable}}
 {{^vendorExtensions.isJacksonOptionalNullable}}{{#jackson}}{{> jackson_annotations}}{{/jackson}}{{/vendorExtensions.isJacksonOptionalNullable}}
   public {{{datatypeWithEnum}}} {{getter}}() {
     {{#vendorExtensions.isJacksonOptionalNullable}}
@@ -201,9 +204,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   public JsonNullable<{{{datatypeWithEnum}}}> {{getter}}_JsonNullable() {
     return {{name}};
   }
-  {{/vendorExtensions.isJacksonOptionalNullable}}
-
-  {{#vendorExtensions.isJacksonOptionalNullable}}
+  {{/vendorExtensions.isJacksonOptionalNullable}}{{#vendorExtensions.isJacksonOptionalNullable}}
   @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
   {{#isReadOnly}}private{{/isReadOnly}}{{^isReadOnly}}public{{/isReadOnly}} void {{setter}}_JsonNullable(JsonNullable<{{{datatypeWithEnum}}}> {{name}}) {
     {{! For getters/setters that have name differing from attribute name, we must include setter (albeit private) for jackson to be able to set the attribute}}

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean isComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean isMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean isBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean isBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean isNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean isComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean isMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean isBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean isBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean isNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -56,7 +56,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -56,7 +56,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -106,7 +106,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -138,7 +137,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -174,7 +172,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -206,7 +203,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -242,7 +238,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -274,7 +269,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -310,7 +304,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -344,7 +337,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -368,7 +360,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -396,7 +387,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -420,7 +410,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -56,7 +56,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -56,7 +56,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -56,7 +56,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Animal.java
@@ -65,7 +65,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -89,7 +88,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -65,7 +65,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -65,7 +65,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -73,7 +73,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -107,7 +106,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -139,7 +137,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -74,7 +74,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -98,7 +97,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -126,7 +124,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -150,7 +147,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -178,7 +174,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -202,7 +197,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Cat.java
@@ -56,7 +56,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -54,7 +54,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Category.java
@@ -58,7 +58,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -81,7 +80,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -55,7 +55,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Client.java
@@ -54,7 +54,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Dog.java
@@ -56,7 +56,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -54,7 +54,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -130,7 +130,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -162,7 +161,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -215,7 +215,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -238,7 +237,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -266,7 +264,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -292,7 +289,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -316,7 +312,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -60,7 +60,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -92,7 +91,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -113,7 +113,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -141,7 +140,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -165,7 +163,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -192,7 +189,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -222,7 +218,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -250,7 +245,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -276,7 +270,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -299,7 +292,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -327,7 +319,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -350,7 +341,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -378,7 +368,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -402,7 +391,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -429,7 +417,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -453,7 +440,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MapTest.java
@@ -112,7 +112,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -144,7 +143,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -180,7 +178,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -212,7 +209,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -68,7 +68,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -92,7 +91,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -126,7 +124,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -59,7 +59,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -83,7 +82,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -62,7 +62,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -88,7 +87,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -112,7 +110,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -55,7 +55,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Name.java
@@ -66,7 +66,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -106,7 +105,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -55,7 +55,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Order.java
@@ -112,7 +112,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -136,7 +135,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -164,7 +162,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -188,7 +185,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -216,7 +212,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,7 +235,6 @@ public class Order {
   public Boolean isComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -63,7 +63,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -89,7 +88,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -113,7 +111,6 @@ public class OuterComposite {
   public Boolean isMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Pet.java
@@ -115,7 +115,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -141,7 +140,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -164,7 +162,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -194,7 +191,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -230,7 +226,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -254,7 +249,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -74,7 +74,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -54,7 +54,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/Tag.java
@@ -58,7 +58,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -72,7 +72,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -95,7 +94,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -122,7 +120,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -145,7 +142,6 @@ public class TypeHolderDefault {
   public Boolean isBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -175,7 +171,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -76,7 +76,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,7 +98,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -126,7 +124,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -151,7 +148,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -174,7 +170,6 @@ public class TypeHolderExample {
   public Boolean isBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -204,7 +199,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/User.java
@@ -82,7 +82,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -106,7 +105,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -134,7 +132,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -158,7 +155,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -186,7 +182,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -210,7 +205,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -238,7 +232,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -262,7 +255,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -169,7 +169,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -193,7 +192,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -221,7 +219,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -245,7 +242,6 @@ public class XmlItem {
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -281,7 +277,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -305,7 +300,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -333,7 +327,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -359,7 +352,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -383,7 +375,6 @@ public class XmlItem {
   public Boolean isNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -419,7 +410,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -453,7 +443,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -477,7 +466,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -505,7 +493,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -531,7 +518,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -555,7 +541,6 @@ public class XmlItem {
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -591,7 +576,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -625,7 +609,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -649,7 +632,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -677,7 +659,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -703,7 +684,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -727,7 +707,6 @@ public class XmlItem {
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -763,7 +742,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -797,7 +775,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -821,7 +798,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -849,7 +825,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -875,7 +850,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -899,7 +873,6 @@ public class XmlItem {
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -935,7 +908,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -967,7 +939,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,7 +60,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -108,7 +108,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -138,7 +137,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -172,7 +170,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -202,7 +199,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -236,7 +232,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -266,7 +261,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -300,7 +294,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -332,7 +325,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -354,7 +346,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -380,7 +371,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -402,7 +392,6 @@ public class AdditionalPropertiesClass implements Parcelable {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,7 +60,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Animal.java
@@ -61,7 +61,6 @@ public class Animal implements Parcelable {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -83,7 +82,6 @@ public class Animal implements Parcelable {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -67,7 +67,6 @@ public class ArrayOfArrayOfNumberOnly implements Parcelable {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -67,7 +67,6 @@ public class ArrayOfNumberOnly implements Parcelable {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -75,7 +75,6 @@ public class ArrayTest implements Parcelable {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -107,7 +106,6 @@ public class ArrayTest implements Parcelable {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -137,7 +135,6 @@ public class ArrayTest implements Parcelable {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -76,7 +76,6 @@ public class Capitalization implements Parcelable {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -98,7 +97,6 @@ public class Capitalization implements Parcelable {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -124,7 +122,6 @@ public class Capitalization implements Parcelable {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -146,7 +143,6 @@ public class Capitalization implements Parcelable {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -172,7 +168,6 @@ public class Capitalization implements Parcelable {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -194,7 +189,6 @@ public class Capitalization implements Parcelable {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Cat.java
@@ -59,7 +59,6 @@ public class Cat extends Animal implements Parcelable {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -56,7 +56,6 @@ public class CatAllOf implements Parcelable {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Category.java
@@ -60,7 +60,6 @@ public class Category implements Parcelable {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -81,7 +80,6 @@ public class Category implements Parcelable {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -57,7 +57,6 @@ public class ClassModel implements Parcelable {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Client.java
@@ -56,7 +56,6 @@ public class Client implements Parcelable {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Dog.java
@@ -59,7 +59,6 @@ public class Dog extends Animal implements Parcelable {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -56,7 +56,6 @@ public class DogAllOf implements Parcelable {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -156,7 +156,6 @@ public class EnumArrays implements Parcelable {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -186,7 +185,6 @@ public class EnumArrays implements Parcelable {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -265,7 +265,6 @@ public class EnumTest implements Parcelable {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -286,7 +285,6 @@ public class EnumTest implements Parcelable {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -312,7 +310,6 @@ public class EnumTest implements Parcelable {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -336,7 +333,6 @@ public class EnumTest implements Parcelable {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -358,7 +354,6 @@ public class EnumTest implements Parcelable {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -62,7 +62,6 @@ public class FileSchemaTestClass implements Parcelable {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -92,7 +91,6 @@ public class FileSchemaTestClass implements Parcelable {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -115,7 +115,6 @@ public class FormatTest implements Parcelable {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -141,7 +140,6 @@ public class FormatTest implements Parcelable {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -163,7 +161,6 @@ public class FormatTest implements Parcelable {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -188,7 +185,6 @@ public class FormatTest implements Parcelable {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -216,7 +212,6 @@ public class FormatTest implements Parcelable {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -242,7 +237,6 @@ public class FormatTest implements Parcelable {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -266,7 +260,6 @@ public class FormatTest implements Parcelable {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -287,7 +280,6 @@ public class FormatTest implements Parcelable {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -313,7 +305,6 @@ public class FormatTest implements Parcelable {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -334,7 +325,6 @@ public class FormatTest implements Parcelable {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -360,7 +350,6 @@ public class FormatTest implements Parcelable {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -382,7 +371,6 @@ public class FormatTest implements Parcelable {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -407,7 +395,6 @@ public class FormatTest implements Parcelable {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -429,7 +416,6 @@ public class FormatTest implements Parcelable {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MapTest.java
@@ -126,7 +126,6 @@ public class MapTest implements Parcelable {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -156,7 +155,6 @@ public class MapTest implements Parcelable {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -190,7 +188,6 @@ public class MapTest implements Parcelable {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -220,7 +217,6 @@ public class MapTest implements Parcelable {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -70,7 +70,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass implements Parcelable {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -92,7 +91,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass implements Parcelable {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -124,7 +122,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass implements Parcelable {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -61,7 +61,6 @@ public class Model200Response implements Parcelable {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -83,7 +82,6 @@ public class Model200Response implements Parcelable {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -64,7 +64,6 @@ public class ModelApiResponse implements Parcelable {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -88,7 +87,6 @@ public class ModelApiResponse implements Parcelable {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -110,7 +108,6 @@ public class ModelApiResponse implements Parcelable {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -57,7 +57,6 @@ public class ModelReturn implements Parcelable {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Name.java
@@ -68,7 +68,6 @@ public class Name implements Parcelable {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -104,7 +103,6 @@ public class Name implements Parcelable {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -57,7 +57,6 @@ public class NumberOnly implements Parcelable {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Order.java
@@ -126,7 +126,6 @@ public class Order implements Parcelable {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -148,7 +147,6 @@ public class Order implements Parcelable {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -174,7 +172,6 @@ public class Order implements Parcelable {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -196,7 +193,6 @@ public class Order implements Parcelable {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -222,7 +218,6 @@ public class Order implements Parcelable {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -244,7 +239,6 @@ public class Order implements Parcelable {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -65,7 +65,6 @@ public class OuterComposite implements Parcelable {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -89,7 +88,6 @@ public class OuterComposite implements Parcelable {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -111,7 +109,6 @@ public class OuterComposite implements Parcelable {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Pet.java
@@ -129,7 +129,6 @@ public class Pet implements Parcelable {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -153,7 +152,6 @@ public class Pet implements Parcelable {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -174,7 +172,6 @@ public class Pet implements Parcelable {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -202,7 +199,6 @@ public class Pet implements Parcelable {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -236,7 +232,6 @@ public class Pet implements Parcelable {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -258,7 +253,6 @@ public class Pet implements Parcelable {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -74,7 +74,6 @@ public class ReadOnlyFirst implements Parcelable {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -56,7 +56,6 @@ public class SpecialModelName implements Parcelable {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/Tag.java
@@ -60,7 +60,6 @@ public class Tag implements Parcelable {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Tag implements Parcelable {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -74,7 +74,6 @@ public class TypeHolderDefault implements Parcelable {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -95,7 +94,6 @@ public class TypeHolderDefault implements Parcelable {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -120,7 +118,6 @@ public class TypeHolderDefault implements Parcelable {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -141,7 +138,6 @@ public class TypeHolderDefault implements Parcelable {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -169,7 +165,6 @@ public class TypeHolderDefault implements Parcelable {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -78,7 +78,6 @@ public class TypeHolderExample implements Parcelable {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -99,7 +98,6 @@ public class TypeHolderExample implements Parcelable {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -124,7 +122,6 @@ public class TypeHolderExample implements Parcelable {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -147,7 +144,6 @@ public class TypeHolderExample implements Parcelable {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -168,7 +164,6 @@ public class TypeHolderExample implements Parcelable {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -196,7 +191,6 @@ public class TypeHolderExample implements Parcelable {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/User.java
@@ -84,7 +84,6 @@ public class User implements Parcelable {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -106,7 +105,6 @@ public class User implements Parcelable {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -132,7 +130,6 @@ public class User implements Parcelable {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -154,7 +151,6 @@ public class User implements Parcelable {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -180,7 +176,6 @@ public class User implements Parcelable {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -202,7 +197,6 @@ public class User implements Parcelable {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -228,7 +222,6 @@ public class User implements Parcelable {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -250,7 +243,6 @@ public class User implements Parcelable {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -171,7 +171,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -193,7 +192,6 @@ public class XmlItem implements Parcelable {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -219,7 +217,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -241,7 +238,6 @@ public class XmlItem implements Parcelable {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -275,7 +271,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -297,7 +292,6 @@ public class XmlItem implements Parcelable {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -323,7 +317,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -347,7 +340,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -369,7 +361,6 @@ public class XmlItem implements Parcelable {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -403,7 +394,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -435,7 +425,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -457,7 +446,6 @@ public class XmlItem implements Parcelable {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -483,7 +471,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -507,7 +494,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -529,7 +515,6 @@ public class XmlItem implements Parcelable {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -563,7 +548,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -595,7 +579,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -617,7 +600,6 @@ public class XmlItem implements Parcelable {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -643,7 +625,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -667,7 +648,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -689,7 +669,6 @@ public class XmlItem implements Parcelable {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -723,7 +702,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -755,7 +733,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -777,7 +754,6 @@ public class XmlItem implements Parcelable {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -803,7 +779,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -827,7 +802,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -849,7 +823,6 @@ public class XmlItem implements Parcelable {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -883,7 +856,6 @@ public class XmlItem implements Parcelable {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -913,7 +885,6 @@ public class XmlItem implements Parcelable {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -104,7 +104,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -134,7 +133,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -168,7 +166,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -198,7 +195,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -232,7 +228,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -262,7 +257,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -296,7 +290,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -328,7 +321,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -350,7 +342,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -376,7 +367,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -398,7 +388,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Animal.java
@@ -59,7 +59,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -81,7 +80,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -71,7 +71,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -103,7 +102,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -133,7 +131,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -72,7 +72,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -94,7 +93,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -120,7 +118,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -142,7 +139,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -168,7 +164,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -190,7 +185,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Cat.java
@@ -54,7 +54,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -52,7 +52,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Category.java
@@ -56,7 +56,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -77,7 +76,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -53,7 +53,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Client.java
@@ -52,7 +52,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Dog.java
@@ -54,7 +54,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -52,7 +52,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -152,7 +152,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -182,7 +181,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -261,7 +261,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -282,7 +281,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -308,7 +306,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -332,7 +329,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -354,7 +350,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -58,7 +58,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -88,7 +87,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -111,7 +111,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -137,7 +136,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -159,7 +157,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -184,7 +181,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -212,7 +208,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -238,7 +233,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -262,7 +256,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -283,7 +276,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -309,7 +301,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -330,7 +321,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -356,7 +346,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -378,7 +367,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -403,7 +391,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -425,7 +412,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MapTest.java
@@ -122,7 +122,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -152,7 +151,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -186,7 +184,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -216,7 +213,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -66,7 +66,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -88,7 +87,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -120,7 +118,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -57,7 +57,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,7 +78,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -60,7 +60,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -84,7 +83,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -106,7 +104,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -53,7 +53,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Name.java
@@ -64,7 +64,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -100,7 +99,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -53,7 +53,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Order.java
@@ -122,7 +122,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -144,7 +143,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -170,7 +168,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -192,7 +189,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -218,7 +214,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,7 +235,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -61,7 +61,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -85,7 +84,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -107,7 +105,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Pet.java
@@ -125,7 +125,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -149,7 +148,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -170,7 +168,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -198,7 +195,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -232,7 +228,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -254,7 +249,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -70,7 +70,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -52,7 +52,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Tag.java
@@ -56,7 +56,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -78,7 +77,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -70,7 +70,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,7 +90,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -116,7 +114,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -137,7 +134,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -165,7 +161,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -74,7 +74,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -95,7 +94,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -120,7 +118,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -143,7 +140,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -164,7 +160,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -192,7 +187,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/User.java
@@ -80,7 +80,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -102,7 +101,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -128,7 +126,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -150,7 +147,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -176,7 +172,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -198,7 +193,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -224,7 +218,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -246,7 +239,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -167,7 +167,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -189,7 +188,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -215,7 +213,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -237,7 +234,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -271,7 +267,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -293,7 +288,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -319,7 +313,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -343,7 +336,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -365,7 +357,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -399,7 +390,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -431,7 +421,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -453,7 +442,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -479,7 +467,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -503,7 +490,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -525,7 +511,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -559,7 +544,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -591,7 +575,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -613,7 +596,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -639,7 +621,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -663,7 +644,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -685,7 +665,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -719,7 +698,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -751,7 +729,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -773,7 +750,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -799,7 +775,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -823,7 +798,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -845,7 +819,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -879,7 +852,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -909,7 +881,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -104,7 +104,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -134,7 +133,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -168,7 +166,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -198,7 +195,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -232,7 +228,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -262,7 +257,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -296,7 +290,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -328,7 +321,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -350,7 +342,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -376,7 +367,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -398,7 +388,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Animal.java
@@ -59,7 +59,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -81,7 +80,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -71,7 +71,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -103,7 +102,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -133,7 +131,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -72,7 +72,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -94,7 +93,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -120,7 +118,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -142,7 +139,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -168,7 +164,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -190,7 +185,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Cat.java
@@ -54,7 +54,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -52,7 +52,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Category.java
@@ -56,7 +56,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -77,7 +76,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -53,7 +53,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Client.java
@@ -52,7 +52,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Dog.java
@@ -54,7 +54,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -52,7 +52,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -152,7 +152,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -182,7 +181,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -261,7 +261,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -282,7 +281,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -308,7 +306,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -332,7 +329,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -354,7 +350,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -58,7 +58,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -88,7 +87,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -111,7 +111,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -137,7 +136,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -159,7 +157,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -184,7 +181,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -212,7 +208,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -238,7 +233,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -262,7 +256,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -283,7 +276,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -309,7 +301,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -330,7 +321,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -356,7 +346,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -378,7 +367,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -403,7 +391,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -425,7 +412,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MapTest.java
@@ -122,7 +122,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -152,7 +151,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -186,7 +184,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -216,7 +213,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -66,7 +66,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -88,7 +87,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -120,7 +118,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -57,7 +57,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,7 +78,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -60,7 +60,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -84,7 +83,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -106,7 +104,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -53,7 +53,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Name.java
@@ -64,7 +64,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -100,7 +99,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -53,7 +53,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Order.java
@@ -122,7 +122,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -144,7 +143,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -170,7 +168,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -192,7 +189,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -218,7 +214,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,7 +235,6 @@ public class Order {
   public Boolean isComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -61,7 +61,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -85,7 +84,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -107,7 +105,6 @@ public class OuterComposite {
   public Boolean isMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Pet.java
@@ -125,7 +125,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -149,7 +148,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -170,7 +168,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -198,7 +195,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -232,7 +228,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -254,7 +249,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -70,7 +70,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -52,7 +52,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/Tag.java
@@ -56,7 +56,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -78,7 +77,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -70,7 +70,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,7 +90,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -116,7 +114,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -137,7 +134,6 @@ public class TypeHolderDefault {
   public Boolean isBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -165,7 +161,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -74,7 +74,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -95,7 +94,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -120,7 +118,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -143,7 +140,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -164,7 +160,6 @@ public class TypeHolderExample {
   public Boolean isBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -192,7 +187,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/User.java
@@ -80,7 +80,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -102,7 +101,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -128,7 +126,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -150,7 +147,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -176,7 +172,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -198,7 +193,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -224,7 +218,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -246,7 +239,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -167,7 +167,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -189,7 +188,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -215,7 +213,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -237,7 +234,6 @@ public class XmlItem {
   public Boolean isAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -271,7 +267,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -293,7 +288,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -319,7 +313,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -343,7 +336,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -365,7 +357,6 @@ public class XmlItem {
   public Boolean isNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -399,7 +390,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -431,7 +421,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -453,7 +442,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -479,7 +467,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -503,7 +490,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -525,7 +511,6 @@ public class XmlItem {
   public Boolean isPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -559,7 +544,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -591,7 +575,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -613,7 +596,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -639,7 +621,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -663,7 +644,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -685,7 +665,6 @@ public class XmlItem {
   public Boolean isNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -719,7 +698,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -751,7 +729,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -773,7 +750,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -799,7 +775,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -823,7 +798,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -845,7 +819,6 @@ public class XmlItem {
   public Boolean isPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -879,7 +852,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -909,7 +881,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -64,7 +64,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -65,7 +65,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -64,7 +64,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -147,7 +147,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -179,7 +178,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -215,7 +213,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -247,7 +244,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -283,7 +279,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -315,7 +310,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -351,7 +345,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -385,7 +378,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -410,7 +402,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -439,7 +430,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -464,7 +454,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -64,7 +64,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -65,7 +65,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -64,7 +64,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -64,7 +64,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
@@ -74,7 +74,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -99,7 +98,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -75,7 +75,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -75,7 +75,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -91,7 +91,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -125,7 +124,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -157,7 +155,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -87,7 +87,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -112,7 +111,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -141,7 +139,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -166,7 +163,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -195,7 +191,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -220,7 +215,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
@@ -64,7 +64,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -62,7 +62,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
@@ -67,7 +67,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -91,7 +90,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -63,7 +63,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
@@ -62,7 +62,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
@@ -64,7 +64,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -62,7 +62,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -142,7 +142,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -174,7 +173,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -227,7 +227,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -251,7 +250,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -280,7 +278,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -307,7 +304,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -332,7 +328,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -72,7 +72,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -104,7 +103,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -134,7 +134,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -163,7 +162,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -188,7 +186,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -216,7 +213,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -247,7 +243,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -276,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -303,7 +297,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -327,7 +320,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -356,7 +348,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -380,7 +371,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -409,7 +399,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -434,7 +423,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -462,7 +450,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -487,7 +474,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
@@ -134,7 +134,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -166,7 +165,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -202,7 +200,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -234,7 +231,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -81,7 +81,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -106,7 +105,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -140,7 +138,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -68,7 +68,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -93,7 +92,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -72,7 +72,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -99,7 +98,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -124,7 +122,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -63,7 +63,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
@@ -77,7 +77,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -119,7 +118,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -63,7 +63,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
@@ -125,7 +125,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -150,7 +149,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -179,7 +177,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -204,7 +201,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -233,7 +229,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -258,7 +253,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -73,7 +73,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -100,7 +99,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -125,7 +123,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
@@ -136,7 +136,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -163,7 +162,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -187,7 +185,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -219,7 +216,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -257,7 +253,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -282,7 +277,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -84,7 +84,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -62,7 +62,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
@@ -67,7 +67,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -92,7 +91,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -87,7 +87,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -111,7 +110,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -139,7 +137,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -163,7 +160,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -193,7 +189,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -92,7 +92,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -116,7 +115,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -144,7 +142,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -170,7 +167,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -194,7 +190,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -224,7 +219,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
@@ -97,7 +97,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -122,7 +121,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -151,7 +149,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -176,7 +173,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -205,7 +201,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -230,7 +225,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -259,7 +253,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -284,7 +277,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -237,7 +237,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -262,7 +261,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -291,7 +289,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -316,7 +313,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -354,7 +350,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -379,7 +374,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -408,7 +402,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -435,7 +428,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -460,7 +452,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -494,7 +485,6 @@ public class XmlItem {
   public List<Integer> getNameArray() {
     return nameArray;
   }
-
 
 
   public void setNameArray(List<Integer> nameArray) {
@@ -532,7 +522,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -557,7 +546,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -586,7 +574,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -613,7 +600,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -638,7 +624,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -672,7 +657,6 @@ public class XmlItem {
   public List<Integer> getPrefixArray() {
     return prefixArray;
   }
-
 
 
   public void setPrefixArray(List<Integer> prefixArray) {
@@ -710,7 +694,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -735,7 +718,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -764,7 +746,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -791,7 +772,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -816,7 +796,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -850,7 +829,6 @@ public class XmlItem {
   public List<Integer> getNamespaceArray() {
     return namespaceArray;
   }
-
 
 
   public void setNamespaceArray(List<Integer> namespaceArray) {
@@ -888,7 +866,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -913,7 +890,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -942,7 +918,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -969,7 +944,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -994,7 +968,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -1030,7 +1003,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -1064,7 +1036,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -104,7 +104,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -134,7 +133,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -168,7 +166,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -198,7 +195,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -232,7 +228,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -262,7 +257,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -296,7 +290,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -328,7 +321,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -350,7 +342,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -376,7 +367,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -398,7 +388,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Animal.java
@@ -59,7 +59,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -81,7 +80,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -71,7 +71,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -103,7 +102,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -133,7 +131,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -72,7 +72,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -94,7 +93,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -120,7 +118,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -142,7 +139,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -168,7 +164,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -190,7 +185,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Cat.java
@@ -54,7 +54,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -52,7 +52,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Category.java
@@ -56,7 +56,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -77,7 +76,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -53,7 +53,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Client.java
@@ -52,7 +52,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Dog.java
@@ -54,7 +54,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -52,7 +52,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -152,7 +152,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -182,7 +181,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -261,7 +261,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -282,7 +281,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -308,7 +306,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -332,7 +329,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -354,7 +350,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -58,7 +58,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -88,7 +87,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -111,7 +111,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -137,7 +136,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -159,7 +157,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -184,7 +181,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -212,7 +208,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -238,7 +233,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -262,7 +256,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -283,7 +276,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -309,7 +301,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -330,7 +321,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -356,7 +346,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(DateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -378,7 +367,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -403,7 +391,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -425,7 +412,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MapTest.java
@@ -122,7 +122,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -152,7 +151,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -186,7 +184,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -216,7 +213,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -66,7 +66,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -88,7 +87,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public DateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(DateTime dateTime) {
@@ -120,7 +118,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -57,7 +57,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,7 +78,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -60,7 +60,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -84,7 +83,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -106,7 +104,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -53,7 +53,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Name.java
@@ -64,7 +64,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -100,7 +99,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -53,7 +53,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Order.java
@@ -122,7 +122,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -144,7 +143,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -170,7 +168,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -192,7 +189,6 @@ public class Order {
   public DateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(DateTime shipDate) {
@@ -218,7 +214,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,7 +235,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -61,7 +61,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -85,7 +84,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -107,7 +105,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Pet.java
@@ -125,7 +125,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -149,7 +148,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -170,7 +168,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -198,7 +195,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -232,7 +228,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -254,7 +249,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -70,7 +70,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -52,7 +52,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/Tag.java
@@ -56,7 +56,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -78,7 +77,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -70,7 +70,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,7 +90,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -116,7 +114,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -137,7 +134,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -165,7 +161,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -74,7 +74,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -95,7 +94,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -120,7 +118,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -143,7 +140,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -164,7 +160,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -192,7 +187,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/User.java
@@ -80,7 +80,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -102,7 +101,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -128,7 +126,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -150,7 +147,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -176,7 +172,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -198,7 +193,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -224,7 +218,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -246,7 +239,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -167,7 +167,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -189,7 +188,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -215,7 +213,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -237,7 +234,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -271,7 +267,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -293,7 +288,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -319,7 +313,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -343,7 +336,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -365,7 +357,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -399,7 +390,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -431,7 +421,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -453,7 +442,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -479,7 +467,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -503,7 +490,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -525,7 +511,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -559,7 +544,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -591,7 +575,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -613,7 +596,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -639,7 +621,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -663,7 +644,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -685,7 +665,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -719,7 +698,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -751,7 +729,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -773,7 +750,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -799,7 +775,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -823,7 +798,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -845,7 +819,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -879,7 +852,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -909,7 +881,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,7 +60,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,7 +109,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,7 +141,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -178,7 +176,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -210,7 +207,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -247,7 +243,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -280,7 +275,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -317,7 +311,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -352,7 +345,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -377,7 +369,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -406,7 +397,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -431,7 +421,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,7 +60,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Animal.java
@@ -69,7 +69,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -93,7 +92,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -69,7 +69,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -69,7 +69,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,7 +76,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -111,7 +110,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -144,7 +142,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,7 +77,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -101,7 +100,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -129,7 +127,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -153,7 +150,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -181,7 +177,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -205,7 +200,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Cat.java
@@ -59,7 +59,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,7 +57,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Category.java
@@ -61,7 +61,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,7 +84,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,7 +58,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Client.java
@@ -57,7 +57,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Dog.java
@@ -59,7 +59,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,7 +57,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,7 +133,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -165,7 +164,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,7 +218,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,7 +241,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -270,7 +268,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -294,7 +291,6 @@ public class EnumTest {
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
-
 
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
@@ -321,7 +317,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -64,7 +64,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -97,7 +96,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,7 +116,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -144,7 +143,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,7 +166,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -199,7 +196,6 @@ public class FormatTest {
   }
 
 
-
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -225,7 +221,6 @@ public class FormatTest {
   public Float getFloat() {
     return _float;
   }
-
 
 
   public void setFloat(Float _float) {
@@ -255,7 +250,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -281,7 +275,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -305,7 +298,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -334,7 +326,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -359,7 +350,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -388,7 +378,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -413,7 +402,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -441,7 +429,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -466,7 +453,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MapTest.java
@@ -116,7 +116,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,7 +147,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -184,7 +182,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -216,7 +213,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -72,7 +72,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -97,7 +96,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -132,7 +130,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,7 +62,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -86,7 +85,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,7 +65,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -91,7 +90,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -115,7 +113,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,7 +58,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Name.java
@@ -70,7 +70,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,7 +109,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -59,7 +59,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Order.java
@@ -115,7 +115,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -141,7 +140,6 @@ public class Order {
   }
 
 
-
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,7 +163,6 @@ public class Order {
   public Integer getQuantity() {
     return quantity;
   }
-
 
 
   public void setQuantity(Integer quantity) {
@@ -194,7 +191,6 @@ public class Order {
   }
 
 
-
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -220,7 +216,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -244,7 +239,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -67,7 +67,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -93,7 +92,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -117,7 +115,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Pet.java
@@ -118,7 +118,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,7 +144,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,7 +167,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -200,7 +197,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -237,7 +233,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -261,7 +256,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,7 +77,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,7 +57,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,7 +61,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,7 +84,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -76,7 +76,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -101,7 +100,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -129,7 +127,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -153,7 +150,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -184,7 +180,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -80,7 +80,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -105,7 +104,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -133,7 +131,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -159,7 +156,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -183,7 +179,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -214,7 +209,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/User.java
@@ -85,7 +85,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -109,7 +108,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -137,7 +135,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -161,7 +158,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -189,7 +185,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -213,7 +208,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -241,7 +235,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -265,7 +258,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,7 +172,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,7 +196,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -225,7 +223,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -249,7 +246,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -285,7 +281,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -309,7 +304,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -338,7 +332,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -364,7 +357,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -388,7 +380,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -424,7 +415,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -458,7 +448,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -482,7 +471,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -511,7 +499,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -537,7 +524,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -561,7 +547,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -597,7 +582,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -631,7 +615,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -655,7 +638,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -684,7 +666,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -710,7 +691,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -734,7 +714,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -770,7 +749,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -804,7 +782,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -828,7 +805,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -857,7 +833,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -883,7 +858,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -907,7 +881,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -943,7 +916,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -975,7 +947,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,7 +60,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,7 +109,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,7 +141,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -178,7 +176,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -210,7 +207,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -247,7 +243,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -280,7 +275,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -317,7 +311,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -352,7 +345,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -377,7 +369,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -406,7 +397,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -431,7 +421,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,7 +60,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Animal.java
@@ -69,7 +69,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -93,7 +92,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -69,7 +69,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -69,7 +69,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,7 +76,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -111,7 +110,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -144,7 +142,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,7 +77,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -101,7 +100,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -129,7 +127,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -153,7 +150,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -181,7 +177,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -205,7 +200,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Cat.java
@@ -59,7 +59,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,7 +57,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Category.java
@@ -61,7 +61,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,7 +84,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,7 +58,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Client.java
@@ -57,7 +57,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Dog.java
@@ -59,7 +59,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,7 +57,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,7 +133,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -165,7 +164,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,7 +218,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,7 +241,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -270,7 +268,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -294,7 +291,6 @@ public class EnumTest {
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
-
 
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
@@ -321,7 +317,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -64,7 +64,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -97,7 +96,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,7 +116,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -144,7 +143,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,7 +166,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -199,7 +196,6 @@ public class FormatTest {
   }
 
 
-
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -225,7 +221,6 @@ public class FormatTest {
   public Float getFloat() {
     return _float;
   }
-
 
 
   public void setFloat(Float _float) {
@@ -255,7 +250,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -281,7 +275,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -305,7 +298,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -334,7 +326,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -359,7 +350,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -388,7 +378,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -413,7 +402,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -441,7 +429,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -466,7 +453,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MapTest.java
@@ -116,7 +116,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,7 +147,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -184,7 +182,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -216,7 +213,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -72,7 +72,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -97,7 +96,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -132,7 +130,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,7 +62,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -86,7 +85,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,7 +65,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -91,7 +90,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -115,7 +113,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,7 +58,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Name.java
@@ -70,7 +70,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,7 +109,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -59,7 +59,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Order.java
@@ -115,7 +115,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -141,7 +140,6 @@ public class Order {
   }
 
 
-
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,7 +163,6 @@ public class Order {
   public Integer getQuantity() {
     return quantity;
   }
-
 
 
   public void setQuantity(Integer quantity) {
@@ -194,7 +191,6 @@ public class Order {
   }
 
 
-
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -220,7 +216,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -244,7 +239,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -67,7 +67,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -93,7 +92,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -117,7 +115,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Pet.java
@@ -118,7 +118,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,7 +144,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,7 +167,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -200,7 +197,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -237,7 +233,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -261,7 +256,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,7 +77,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,7 +57,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,7 +61,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,7 +84,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -76,7 +76,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -101,7 +100,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -129,7 +127,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -153,7 +150,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -184,7 +180,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -80,7 +80,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -105,7 +104,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -133,7 +131,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -159,7 +156,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -183,7 +179,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -214,7 +209,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/User.java
@@ -85,7 +85,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -109,7 +108,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -137,7 +135,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -161,7 +158,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -189,7 +185,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -213,7 +208,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -241,7 +235,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -265,7 +258,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,7 +172,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,7 +196,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -225,7 +223,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -249,7 +246,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -285,7 +281,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -309,7 +304,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -338,7 +332,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -364,7 +357,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -388,7 +380,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -424,7 +415,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -458,7 +448,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -482,7 +471,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -511,7 +499,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -537,7 +524,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -561,7 +547,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -597,7 +582,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -631,7 +615,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -655,7 +638,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -684,7 +666,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -710,7 +691,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -734,7 +714,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -770,7 +749,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -804,7 +782,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -828,7 +805,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -857,7 +833,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -883,7 +858,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -907,7 +881,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -943,7 +916,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -975,7 +947,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -60,7 +60,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -109,7 +109,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -142,7 +141,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -178,7 +176,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -210,7 +207,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -247,7 +243,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -280,7 +275,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -317,7 +311,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -352,7 +345,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -377,7 +369,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -406,7 +397,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -431,7 +421,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -60,7 +60,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -59,7 +59,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Animal.java
@@ -69,7 +69,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -93,7 +92,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -69,7 +69,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -69,7 +69,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -76,7 +76,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -111,7 +110,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -144,7 +142,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -77,7 +77,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -101,7 +100,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -129,7 +127,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -153,7 +150,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -181,7 +177,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -205,7 +200,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Cat.java
@@ -59,7 +59,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -57,7 +57,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Category.java
@@ -61,7 +61,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,7 +84,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -58,7 +58,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Client.java
@@ -57,7 +57,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Dog.java
@@ -59,7 +59,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -57,7 +57,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -133,7 +133,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -165,7 +164,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -218,7 +218,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -242,7 +241,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -270,7 +268,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -294,7 +291,6 @@ public class EnumTest {
   public EnumNumberEnum getEnumNumber() {
     return enumNumber;
   }
-
 
 
   public void setEnumNumber(EnumNumberEnum enumNumber) {
@@ -321,7 +317,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -64,7 +64,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -97,7 +96,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -116,7 +116,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -144,7 +143,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -168,7 +166,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -199,7 +196,6 @@ public class FormatTest {
   }
 
 
-
   public void setNumber(BigDecimal number) {
     this.number = number;
   }
@@ -225,7 +221,6 @@ public class FormatTest {
   public Float getFloat() {
     return _float;
   }
-
 
 
   public void setFloat(Float _float) {
@@ -255,7 +250,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -281,7 +275,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -305,7 +298,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -334,7 +326,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -359,7 +350,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -388,7 +378,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -413,7 +402,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -441,7 +429,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -466,7 +453,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MapTest.java
@@ -116,7 +116,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -148,7 +147,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -184,7 +182,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -216,7 +213,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -72,7 +72,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -97,7 +96,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -132,7 +130,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -62,7 +62,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -86,7 +85,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -65,7 +65,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -91,7 +90,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -115,7 +113,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -58,7 +58,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Name.java
@@ -70,7 +70,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -110,7 +109,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -59,7 +59,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Order.java
@@ -115,7 +115,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -141,7 +140,6 @@ public class Order {
   }
 
 
-
   public void setPetId(Long petId) {
     this.petId = petId;
   }
@@ -165,7 +163,6 @@ public class Order {
   public Integer getQuantity() {
     return quantity;
   }
-
 
 
   public void setQuantity(Integer quantity) {
@@ -194,7 +191,6 @@ public class Order {
   }
 
 
-
   public void setShipDate(OffsetDateTime shipDate) {
     this.shipDate = shipDate;
   }
@@ -220,7 +216,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -244,7 +239,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -67,7 +67,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -93,7 +92,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -117,7 +115,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Pet.java
@@ -118,7 +118,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -145,7 +144,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -169,7 +167,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -200,7 +197,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -237,7 +233,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -261,7 +256,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -77,7 +77,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -57,7 +57,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/Tag.java
@@ -61,7 +61,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -85,7 +84,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -76,7 +76,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -101,7 +100,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -129,7 +127,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -153,7 +150,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -184,7 +180,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -80,7 +80,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -105,7 +104,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -133,7 +131,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -159,7 +156,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -183,7 +179,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -214,7 +209,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/User.java
@@ -85,7 +85,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -109,7 +108,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -137,7 +135,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -161,7 +158,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -189,7 +185,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -213,7 +208,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -241,7 +235,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -265,7 +258,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -172,7 +172,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -197,7 +196,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -225,7 +223,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -249,7 +246,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -285,7 +281,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -309,7 +304,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -338,7 +332,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -364,7 +357,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -388,7 +380,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -424,7 +415,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -458,7 +448,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -482,7 +471,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -511,7 +499,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -537,7 +524,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -561,7 +547,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -597,7 +582,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -631,7 +615,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -655,7 +638,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -684,7 +666,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -710,7 +691,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -734,7 +714,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -770,7 +749,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -804,7 +782,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -828,7 +805,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -857,7 +833,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -883,7 +858,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -907,7 +881,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -943,7 +916,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -975,7 +947,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -104,7 +104,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -134,7 +133,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -168,7 +166,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -198,7 +195,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -232,7 +228,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -262,7 +257,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -296,7 +290,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -328,7 +321,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -350,7 +342,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -376,7 +367,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -398,7 +388,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Animal.java
@@ -59,7 +59,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -81,7 +80,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -71,7 +71,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -103,7 +102,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -133,7 +131,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -72,7 +72,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -94,7 +93,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -120,7 +118,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -142,7 +139,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -168,7 +164,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -190,7 +185,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Cat.java
@@ -54,7 +54,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -52,7 +52,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Category.java
@@ -56,7 +56,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -77,7 +76,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -53,7 +53,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Client.java
@@ -52,7 +52,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Dog.java
@@ -54,7 +54,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -52,7 +52,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -152,7 +152,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -182,7 +181,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -261,7 +261,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -282,7 +281,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -308,7 +306,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -332,7 +329,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -354,7 +350,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -58,7 +58,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -88,7 +87,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -111,7 +111,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -137,7 +136,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -159,7 +157,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -184,7 +181,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -212,7 +208,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -238,7 +233,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -262,7 +256,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -283,7 +276,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -309,7 +301,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -330,7 +321,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -356,7 +346,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -378,7 +367,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -403,7 +391,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -425,7 +412,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -122,7 +122,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -152,7 +151,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -186,7 +184,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -216,7 +213,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -66,7 +66,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -88,7 +87,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -120,7 +118,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -57,7 +57,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,7 +78,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -60,7 +60,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -84,7 +83,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -106,7 +104,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -53,7 +53,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Name.java
@@ -64,7 +64,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -100,7 +99,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -53,7 +53,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Order.java
@@ -122,7 +122,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -144,7 +143,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -170,7 +168,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -192,7 +189,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -218,7 +214,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,7 +235,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -61,7 +61,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -85,7 +84,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -107,7 +105,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Pet.java
@@ -125,7 +125,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -149,7 +148,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -170,7 +168,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -198,7 +195,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -232,7 +228,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -254,7 +249,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -70,7 +70,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -52,7 +52,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/Tag.java
@@ -56,7 +56,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -78,7 +77,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -70,7 +70,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,7 +90,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -116,7 +114,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -137,7 +134,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -165,7 +161,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -74,7 +74,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -95,7 +94,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -120,7 +118,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -143,7 +140,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -164,7 +160,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -192,7 +187,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/User.java
@@ -80,7 +80,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -102,7 +101,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -128,7 +126,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -150,7 +147,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -176,7 +172,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -198,7 +193,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -224,7 +218,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -246,7 +239,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -167,7 +167,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -189,7 +188,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -215,7 +213,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -237,7 +234,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -271,7 +267,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -293,7 +288,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -319,7 +313,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -343,7 +336,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -365,7 +357,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -399,7 +390,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -431,7 +421,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -453,7 +442,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -479,7 +467,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -503,7 +490,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -525,7 +511,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -559,7 +544,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -591,7 +575,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -613,7 +596,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -639,7 +621,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -663,7 +644,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -685,7 +665,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -719,7 +698,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -751,7 +729,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -773,7 +750,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -799,7 +775,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -823,7 +798,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -845,7 +819,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -879,7 +852,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -909,7 +881,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -104,7 +104,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -134,7 +133,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -168,7 +166,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -198,7 +195,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -232,7 +228,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -262,7 +257,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -296,7 +290,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -328,7 +321,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -350,7 +342,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -376,7 +367,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -398,7 +388,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Animal.java
@@ -59,7 +59,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -81,7 +80,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -71,7 +71,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -103,7 +102,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -133,7 +131,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -72,7 +72,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -94,7 +93,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -120,7 +118,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -142,7 +139,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -168,7 +164,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -190,7 +185,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Cat.java
@@ -54,7 +54,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -52,7 +52,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Category.java
@@ -56,7 +56,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -77,7 +76,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -53,7 +53,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Client.java
@@ -52,7 +52,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Dog.java
@@ -54,7 +54,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -52,7 +52,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -152,7 +152,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -182,7 +181,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -261,7 +261,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -282,7 +281,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -308,7 +306,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -332,7 +329,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -354,7 +350,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -58,7 +58,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -88,7 +87,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -111,7 +111,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -137,7 +136,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -159,7 +157,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -184,7 +181,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -212,7 +208,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -238,7 +233,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -262,7 +256,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -283,7 +276,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -309,7 +301,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -330,7 +321,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -356,7 +346,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -378,7 +367,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -403,7 +391,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -425,7 +412,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -122,7 +122,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -152,7 +151,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -186,7 +184,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -216,7 +213,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -66,7 +66,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -88,7 +87,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -120,7 +118,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -57,7 +57,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,7 +78,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -60,7 +60,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -84,7 +83,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -106,7 +104,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -53,7 +53,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Name.java
@@ -64,7 +64,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -100,7 +99,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -53,7 +53,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Order.java
@@ -122,7 +122,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -144,7 +143,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -170,7 +168,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -192,7 +189,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -218,7 +214,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,7 +235,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -61,7 +61,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -85,7 +84,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -107,7 +105,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Pet.java
@@ -125,7 +125,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -149,7 +148,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -170,7 +168,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -198,7 +195,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -232,7 +228,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -254,7 +249,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -70,7 +70,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -52,7 +52,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/Tag.java
@@ -56,7 +56,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -78,7 +77,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -70,7 +70,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,7 +90,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -116,7 +114,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -137,7 +134,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -165,7 +161,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -74,7 +74,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -95,7 +94,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -120,7 +118,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -143,7 +140,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -164,7 +160,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -192,7 +187,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/User.java
@@ -80,7 +80,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -102,7 +101,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -128,7 +126,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -150,7 +147,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -176,7 +172,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -198,7 +193,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -224,7 +218,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -246,7 +239,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -167,7 +167,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -189,7 +188,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -215,7 +213,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -237,7 +234,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -271,7 +267,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -293,7 +288,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -319,7 +313,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -343,7 +336,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -365,7 +357,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -399,7 +390,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -431,7 +421,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -453,7 +442,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -479,7 +467,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -503,7 +490,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -525,7 +511,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -559,7 +544,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -591,7 +575,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -613,7 +596,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -639,7 +621,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -663,7 +644,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -685,7 +665,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -719,7 +698,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -751,7 +729,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -773,7 +750,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -799,7 +775,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -823,7 +798,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -845,7 +819,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -879,7 +852,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -909,7 +881,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -104,7 +104,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -134,7 +133,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -168,7 +166,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -198,7 +195,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -232,7 +228,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -262,7 +257,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -296,7 +290,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -328,7 +321,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -350,7 +342,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -376,7 +367,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -398,7 +388,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -55,7 +55,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -54,7 +54,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Animal.java
@@ -59,7 +59,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -81,7 +80,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -63,7 +63,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -71,7 +71,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -103,7 +102,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -133,7 +131,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -72,7 +72,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -94,7 +93,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -120,7 +118,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -142,7 +139,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -168,7 +164,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -190,7 +185,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Cat.java
@@ -54,7 +54,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -52,7 +52,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Category.java
@@ -56,7 +56,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -77,7 +76,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -53,7 +53,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Client.java
@@ -52,7 +52,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Dog.java
@@ -54,7 +54,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -52,7 +52,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -152,7 +152,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -182,7 +181,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -261,7 +261,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -282,7 +281,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -308,7 +306,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -332,7 +329,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -354,7 +350,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -58,7 +58,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -88,7 +87,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -111,7 +111,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -137,7 +136,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -159,7 +157,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -184,7 +181,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -212,7 +208,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -238,7 +233,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -262,7 +256,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -283,7 +276,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -309,7 +301,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -330,7 +321,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -356,7 +346,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -378,7 +367,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -403,7 +391,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -425,7 +412,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MapTest.java
@@ -122,7 +122,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -152,7 +151,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -186,7 +184,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -216,7 +213,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -66,7 +66,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -88,7 +87,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -120,7 +118,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -57,7 +57,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -79,7 +78,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -60,7 +60,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -84,7 +83,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -106,7 +104,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -53,7 +53,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Name.java
@@ -64,7 +64,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -100,7 +99,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -53,7 +53,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Order.java
@@ -122,7 +122,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -144,7 +143,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -170,7 +168,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -192,7 +189,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -218,7 +214,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -240,7 +235,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -61,7 +61,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -85,7 +84,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -107,7 +105,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Pet.java
@@ -125,7 +125,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -149,7 +148,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -170,7 +168,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -198,7 +195,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -232,7 +228,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -254,7 +249,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -70,7 +70,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -52,7 +52,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/Tag.java
@@ -56,7 +56,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -78,7 +77,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -70,7 +70,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -91,7 +90,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -116,7 +114,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -137,7 +134,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -165,7 +161,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -74,7 +74,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -95,7 +94,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -120,7 +118,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -143,7 +140,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -164,7 +160,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -192,7 +187,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/User.java
@@ -80,7 +80,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -102,7 +101,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -128,7 +126,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -150,7 +147,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -176,7 +172,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -198,7 +193,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -224,7 +218,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -246,7 +239,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -167,7 +167,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -189,7 +188,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -215,7 +213,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -237,7 +234,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -271,7 +267,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -293,7 +288,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -319,7 +313,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -343,7 +336,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -365,7 +357,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -399,7 +390,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -431,7 +421,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -453,7 +442,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -479,7 +467,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -503,7 +490,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -525,7 +511,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -559,7 +544,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -591,7 +575,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -613,7 +596,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -639,7 +621,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -663,7 +644,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -685,7 +665,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -719,7 +698,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -751,7 +729,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -773,7 +750,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -799,7 +775,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -823,7 +798,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -845,7 +819,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -879,7 +852,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -909,7 +881,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(AsyncFile binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -107,7 +107,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapString(Map<String, String> mapString) {
     this.mapString = mapString;
   }
@@ -139,7 +138,6 @@ public class AdditionalPropertiesClass {
   public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
-
 
 
   public void setMapNumber(Map<String, BigDecimal> mapNumber) {
@@ -175,7 +173,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapInteger(Map<String, Integer> mapInteger) {
     this.mapInteger = mapInteger;
   }
@@ -207,7 +204,6 @@ public class AdditionalPropertiesClass {
   public Map<String, Boolean> getMapBoolean() {
     return mapBoolean;
   }
-
 
 
   public void setMapBoolean(Map<String, Boolean> mapBoolean) {
@@ -243,7 +239,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     this.mapArrayInteger = mapArrayInteger;
   }
@@ -275,7 +270,6 @@ public class AdditionalPropertiesClass {
   public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
-
 
 
   public void setMapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
@@ -311,7 +305,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapString(Map<String, Map<String, String>> mapMapString) {
     this.mapMapString = mapMapString;
   }
@@ -345,7 +338,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setMapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     this.mapMapAnytype = mapMapAnytype;
   }
@@ -369,7 +361,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype1() {
     return anytype1;
   }
-
 
 
   public void setAnytype1(Object anytype1) {
@@ -397,7 +388,6 @@ public class AdditionalPropertiesClass {
   }
 
 
-
   public void setAnytype2(Object anytype2) {
     this.anytype2 = anytype2;
   }
@@ -421,7 +411,6 @@ public class AdditionalPropertiesClass {
   public Object getAnytype3() {
     return anytype3;
   }
-
 
 
   public void setAnytype3(Object anytype3) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -58,7 +58,6 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -57,7 +57,6 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   }
 
 
-
   public void setName(String name) {
     this.name = name;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Animal.java
@@ -66,7 +66,6 @@ public class Animal {
   }
 
 
-
   public void setClassName(String className) {
     this.className = className;
   }
@@ -90,7 +89,6 @@ public class Animal {
   public String getColor() {
     return color;
   }
-
 
 
   public void setColor(String color) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfArrayOfNumberOnly {
   }
 
 
-
   public void setArrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     this.arrayArrayNumber = arrayArrayNumber;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -66,7 +66,6 @@ public class ArrayOfNumberOnly {
   }
 
 
-
   public void setArrayNumber(List<BigDecimal> arrayNumber) {
     this.arrayNumber = arrayNumber;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -74,7 +74,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayOfString(List<String> arrayOfString) {
     this.arrayOfString = arrayOfString;
   }
@@ -108,7 +107,6 @@ public class ArrayTest {
   }
 
 
-
   public void setArrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
@@ -140,7 +138,6 @@ public class ArrayTest {
   public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
-
 
 
   public void setArrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -75,7 +75,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallCamel(String smallCamel) {
     this.smallCamel = smallCamel;
   }
@@ -99,7 +98,6 @@ public class Capitalization {
   public String getCapitalCamel() {
     return capitalCamel;
   }
-
 
 
   public void setCapitalCamel(String capitalCamel) {
@@ -127,7 +125,6 @@ public class Capitalization {
   }
 
 
-
   public void setSmallSnake(String smallSnake) {
     this.smallSnake = smallSnake;
   }
@@ -151,7 +148,6 @@ public class Capitalization {
   public String getCapitalSnake() {
     return capitalSnake;
   }
-
 
 
   public void setCapitalSnake(String capitalSnake) {
@@ -179,7 +175,6 @@ public class Capitalization {
   }
 
 
-
   public void setScAETHFlowPoints(String scAETHFlowPoints) {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
@@ -203,7 +198,6 @@ public class Capitalization {
   public String getATTNAME() {
     return ATT_NAME;
   }
-
 
 
   public void setATTNAME(String ATT_NAME) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Cat.java
@@ -57,7 +57,6 @@ public class Cat extends Animal {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -55,7 +55,6 @@ public class CatAllOf {
   }
 
 
-
   public void setDeclawed(Boolean declawed) {
     this.declawed = declawed;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Category.java
@@ -59,7 +59,6 @@ public class Category {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -82,7 +81,6 @@ public class Category {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -56,7 +56,6 @@ public class ClassModel {
   }
 
 
-
   public void setPropertyClass(String propertyClass) {
     this.propertyClass = propertyClass;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Client.java
@@ -55,7 +55,6 @@ public class Client {
   }
 
 
-
   public void setClient(String client) {
     this.client = client;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Dog.java
@@ -57,7 +57,6 @@ public class Dog extends Animal {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -55,7 +55,6 @@ public class DogAllOf {
   }
 
 
-
   public void setBreed(String breed) {
     this.breed = breed;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -131,7 +131,6 @@ public class EnumArrays {
   }
 
 
-
   public void setJustSymbol(JustSymbolEnum justSymbol) {
     this.justSymbol = justSymbol;
   }
@@ -163,7 +162,6 @@ public class EnumArrays {
   public List<ArrayEnumEnum> getArrayEnum() {
     return arrayEnum;
   }
-
 
 
   public void setArrayEnum(List<ArrayEnumEnum> arrayEnum) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -216,7 +216,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumString(EnumStringEnum enumString) {
     this.enumString = enumString;
   }
@@ -239,7 +238,6 @@ public class EnumTest {
   public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
-
 
 
   public void setEnumStringRequired(EnumStringRequiredEnum enumStringRequired) {
@@ -267,7 +265,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumInteger(EnumIntegerEnum enumInteger) {
     this.enumInteger = enumInteger;
   }
@@ -293,7 +290,6 @@ public class EnumTest {
   }
 
 
-
   public void setEnumNumber(EnumNumberEnum enumNumber) {
     this.enumNumber = enumNumber;
   }
@@ -317,7 +313,6 @@ public class EnumTest {
   public OuterEnum getOuterEnum() {
     return outerEnum;
   }
-
 
 
   public void setOuterEnum(OuterEnum outerEnum) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -61,7 +61,6 @@ public class FileSchemaTestClass {
   }
 
 
-
   public void setFile(java.io.File file) {
     this.file = file;
   }
@@ -93,7 +92,6 @@ public class FileSchemaTestClass {
   public List<java.io.File> getFiles() {
     return files;
   }
-
 
 
   public void setFiles(List<java.io.File> files) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -114,7 +114,6 @@ public class FormatTest {
   }
 
 
-
   public void setInteger(Integer integer) {
     this.integer = integer;
   }
@@ -142,7 +141,6 @@ public class FormatTest {
   }
 
 
-
   public void setInt32(Integer int32) {
     this.int32 = int32;
   }
@@ -166,7 +164,6 @@ public class FormatTest {
   public Long getInt64() {
     return int64;
   }
-
 
 
   public void setInt64(Long int64) {
@@ -193,7 +190,6 @@ public class FormatTest {
   public BigDecimal getNumber() {
     return number;
   }
-
 
 
   public void setNumber(BigDecimal number) {
@@ -223,7 +219,6 @@ public class FormatTest {
   }
 
 
-
   public void setFloat(Float _float) {
     this._float = _float;
   }
@@ -251,7 +246,6 @@ public class FormatTest {
   }
 
 
-
   public void setDouble(Double _double) {
     this._double = _double;
   }
@@ -277,7 +271,6 @@ public class FormatTest {
   }
 
 
-
   public void setString(String string) {
     this.string = string;
   }
@@ -300,7 +293,6 @@ public class FormatTest {
   public byte[] getByte() {
     return _byte;
   }
-
 
 
   public void setByte(byte[] _byte) {
@@ -328,7 +320,6 @@ public class FormatTest {
   }
 
 
-
   public void setBinary(File binary) {
     this.binary = binary;
   }
@@ -351,7 +342,6 @@ public class FormatTest {
   public LocalDate getDate() {
     return date;
   }
-
 
 
   public void setDate(LocalDate date) {
@@ -379,7 +369,6 @@ public class FormatTest {
   }
 
 
-
   public void setDateTime(OffsetDateTime dateTime) {
     this.dateTime = dateTime;
   }
@@ -403,7 +392,6 @@ public class FormatTest {
   public UUID getUuid() {
     return uuid;
   }
-
 
 
   public void setUuid(UUID uuid) {
@@ -430,7 +418,6 @@ public class FormatTest {
   }
 
 
-
   public void setPassword(String password) {
     this.password = password;
   }
@@ -454,7 +441,6 @@ public class FormatTest {
   public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
-
 
 
   public void setBigDecimal(BigDecimal bigDecimal) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MapTest.java
@@ -113,7 +113,6 @@ public class MapTest {
   }
 
 
-
   public void setMapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     this.mapMapOfString = mapMapOfString;
   }
@@ -145,7 +144,6 @@ public class MapTest {
   public Map<String, InnerEnum> getMapOfEnumString() {
     return mapOfEnumString;
   }
-
 
 
   public void setMapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
@@ -181,7 +179,6 @@ public class MapTest {
   }
 
 
-
   public void setDirectMap(Map<String, Boolean> directMap) {
     this.directMap = directMap;
   }
@@ -213,7 +210,6 @@ public class MapTest {
   public Map<String, Boolean> getIndirectMap() {
     return indirectMap;
   }
-
 
 
   public void setIndirectMap(Map<String, Boolean> indirectMap) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -69,7 +69,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
-
   public void setUuid(UUID uuid) {
     this.uuid = uuid;
   }
@@ -93,7 +92,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public OffsetDateTime getDateTime() {
     return dateTime;
   }
-
 
 
   public void setDateTime(OffsetDateTime dateTime) {
@@ -127,7 +125,6 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   public Map<String, Animal> getMap() {
     return map;
   }
-
 
 
   public void setMap(Map<String, Animal> map) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -60,7 +60,6 @@ public class Model200Response {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -84,7 +83,6 @@ public class Model200Response {
   public String getPropertyClass() {
     return propertyClass;
   }
-
 
 
   public void setPropertyClass(String propertyClass) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -63,7 +63,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setCode(Integer code) {
     this.code = code;
   }
@@ -89,7 +88,6 @@ public class ModelApiResponse {
   }
 
 
-
   public void setType(String type) {
     this.type = type;
   }
@@ -113,7 +111,6 @@ public class ModelApiResponse {
   public String getMessage() {
     return message;
   }
-
 
 
   public void setMessage(String message) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -56,7 +56,6 @@ public class ModelReturn {
   }
 
 
-
   public void setReturn(Integer _return) {
     this._return = _return;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Name.java
@@ -67,7 +67,6 @@ public class Name {
   }
 
 
-
   public void setName(Integer name) {
     this.name = name;
   }
@@ -107,7 +106,6 @@ public class Name {
   public String getProperty() {
     return property;
   }
-
 
 
   public void setProperty(String property) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -56,7 +56,6 @@ public class NumberOnly {
   }
 
 
-
   public void setJustNumber(BigDecimal justNumber) {
     this.justNumber = justNumber;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Order.java
@@ -113,7 +113,6 @@ public class Order {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -137,7 +136,6 @@ public class Order {
   public Long getPetId() {
     return petId;
   }
-
 
 
   public void setPetId(Long petId) {
@@ -165,7 +163,6 @@ public class Order {
   }
 
 
-
   public void setQuantity(Integer quantity) {
     this.quantity = quantity;
   }
@@ -189,7 +186,6 @@ public class Order {
   public OffsetDateTime getShipDate() {
     return shipDate;
   }
-
 
 
   public void setShipDate(OffsetDateTime shipDate) {
@@ -217,7 +213,6 @@ public class Order {
   }
 
 
-
   public void setStatus(StatusEnum status) {
     this.status = status;
   }
@@ -241,7 +236,6 @@ public class Order {
   public Boolean getComplete() {
     return complete;
   }
-
 
 
   public void setComplete(Boolean complete) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -64,7 +64,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyNumber(BigDecimal myNumber) {
     this.myNumber = myNumber;
   }
@@ -90,7 +89,6 @@ public class OuterComposite {
   }
 
 
-
   public void setMyString(String myString) {
     this.myString = myString;
   }
@@ -114,7 +112,6 @@ public class OuterComposite {
   public Boolean getMyBoolean() {
     return myBoolean;
   }
-
 
 
   public void setMyBoolean(Boolean myBoolean) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Pet.java
@@ -116,7 +116,6 @@ public class Pet {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -142,7 +141,6 @@ public class Pet {
   }
 
 
-
   public void setCategory(Category category) {
     this.category = category;
   }
@@ -165,7 +163,6 @@ public class Pet {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {
@@ -195,7 +192,6 @@ public class Pet {
   public List<String> getPhotoUrls() {
     return photoUrls;
   }
-
 
 
   public void setPhotoUrls(List<String> photoUrls) {
@@ -231,7 +227,6 @@ public class Pet {
   }
 
 
-
   public void setTags(List<Tag> tags) {
     this.tags = tags;
   }
@@ -255,7 +250,6 @@ public class Pet {
   public StatusEnum getStatus() {
     return status;
   }
-
 
 
   public void setStatus(StatusEnum status) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -75,7 +75,6 @@ public class ReadOnlyFirst {
   }
 
 
-
   public void setBaz(String baz) {
     this.baz = baz;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -55,7 +55,6 @@ public class SpecialModelName {
   }
 
 
-
   public void set$SpecialPropertyName(Long $specialPropertyName) {
     this.$specialPropertyName = $specialPropertyName;
   }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/Tag.java
@@ -59,7 +59,6 @@ public class Tag {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -83,7 +82,6 @@ public class Tag {
   public String getName() {
     return name;
   }
-
 
 
   public void setName(String name) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -73,7 +73,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -96,7 +95,6 @@ public class TypeHolderDefault {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -123,7 +121,6 @@ public class TypeHolderDefault {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -146,7 +143,6 @@ public class TypeHolderDefault {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -176,7 +172,6 @@ public class TypeHolderDefault {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -77,7 +77,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setStringItem(String stringItem) {
     this.stringItem = stringItem;
   }
@@ -100,7 +99,6 @@ public class TypeHolderExample {
   public BigDecimal getNumberItem() {
     return numberItem;
   }
-
 
 
   public void setNumberItem(BigDecimal numberItem) {
@@ -127,7 +125,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setFloatItem(Float floatItem) {
     this.floatItem = floatItem;
   }
@@ -152,7 +149,6 @@ public class TypeHolderExample {
   }
 
 
-
   public void setIntegerItem(Integer integerItem) {
     this.integerItem = integerItem;
   }
@@ -175,7 +171,6 @@ public class TypeHolderExample {
   public Boolean getBoolItem() {
     return boolItem;
   }
-
 
 
   public void setBoolItem(Boolean boolItem) {
@@ -205,7 +200,6 @@ public class TypeHolderExample {
   public List<Integer> getArrayItem() {
     return arrayItem;
   }
-
 
 
   public void setArrayItem(List<Integer> arrayItem) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/User.java
@@ -83,7 +83,6 @@ public class User {
   }
 
 
-
   public void setId(Long id) {
     this.id = id;
   }
@@ -107,7 +106,6 @@ public class User {
   public String getUsername() {
     return username;
   }
-
 
 
   public void setUsername(String username) {
@@ -135,7 +133,6 @@ public class User {
   }
 
 
-
   public void setFirstName(String firstName) {
     this.firstName = firstName;
   }
@@ -159,7 +156,6 @@ public class User {
   public String getLastName() {
     return lastName;
   }
-
 
 
   public void setLastName(String lastName) {
@@ -187,7 +183,6 @@ public class User {
   }
 
 
-
   public void setEmail(String email) {
     this.email = email;
   }
@@ -211,7 +206,6 @@ public class User {
   public String getPassword() {
     return password;
   }
-
 
 
   public void setPassword(String password) {
@@ -239,7 +233,6 @@ public class User {
   }
 
 
-
   public void setPhone(String phone) {
     this.phone = phone;
   }
@@ -263,7 +256,6 @@ public class User {
   public Integer getUserStatus() {
     return userStatus;
   }
-
 
 
   public void setUserStatus(Integer userStatus) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -170,7 +170,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeString(String attributeString) {
     this.attributeString = attributeString;
   }
@@ -194,7 +193,6 @@ public class XmlItem {
   public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
-
 
 
   public void setAttributeNumber(BigDecimal attributeNumber) {
@@ -222,7 +220,6 @@ public class XmlItem {
   }
 
 
-
   public void setAttributeInteger(Integer attributeInteger) {
     this.attributeInteger = attributeInteger;
   }
@@ -246,7 +243,6 @@ public class XmlItem {
   public Boolean getAttributeBoolean() {
     return attributeBoolean;
   }
-
 
 
   public void setAttributeBoolean(Boolean attributeBoolean) {
@@ -282,7 +278,6 @@ public class XmlItem {
   }
 
 
-
   public void setWrappedArray(List<Integer> wrappedArray) {
     this.wrappedArray = wrappedArray;
   }
@@ -306,7 +301,6 @@ public class XmlItem {
   public String getNameString() {
     return nameString;
   }
-
 
 
   public void setNameString(String nameString) {
@@ -334,7 +328,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameNumber(BigDecimal nameNumber) {
     this.nameNumber = nameNumber;
   }
@@ -360,7 +353,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameInteger(Integer nameInteger) {
     this.nameInteger = nameInteger;
   }
@@ -384,7 +376,6 @@ public class XmlItem {
   public Boolean getNameBoolean() {
     return nameBoolean;
   }
-
 
 
   public void setNameBoolean(Boolean nameBoolean) {
@@ -420,7 +411,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameArray(List<Integer> nameArray) {
     this.nameArray = nameArray;
   }
@@ -454,7 +444,6 @@ public class XmlItem {
   }
 
 
-
   public void setNameWrappedArray(List<Integer> nameWrappedArray) {
     this.nameWrappedArray = nameWrappedArray;
   }
@@ -478,7 +467,6 @@ public class XmlItem {
   public String getPrefixString() {
     return prefixString;
   }
-
 
 
   public void setPrefixString(String prefixString) {
@@ -506,7 +494,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNumber(BigDecimal prefixNumber) {
     this.prefixNumber = prefixNumber;
   }
@@ -532,7 +519,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixInteger(Integer prefixInteger) {
     this.prefixInteger = prefixInteger;
   }
@@ -556,7 +542,6 @@ public class XmlItem {
   public Boolean getPrefixBoolean() {
     return prefixBoolean;
   }
-
 
 
   public void setPrefixBoolean(Boolean prefixBoolean) {
@@ -592,7 +577,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixArray(List<Integer> prefixArray) {
     this.prefixArray = prefixArray;
   }
@@ -626,7 +610,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixWrappedArray(List<Integer> prefixWrappedArray) {
     this.prefixWrappedArray = prefixWrappedArray;
   }
@@ -650,7 +633,6 @@ public class XmlItem {
   public String getNamespaceString() {
     return namespaceString;
   }
-
 
 
   public void setNamespaceString(String namespaceString) {
@@ -678,7 +660,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceNumber(BigDecimal namespaceNumber) {
     this.namespaceNumber = namespaceNumber;
   }
@@ -704,7 +685,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceInteger(Integer namespaceInteger) {
     this.namespaceInteger = namespaceInteger;
   }
@@ -728,7 +708,6 @@ public class XmlItem {
   public Boolean getNamespaceBoolean() {
     return namespaceBoolean;
   }
-
 
 
   public void setNamespaceBoolean(Boolean namespaceBoolean) {
@@ -764,7 +743,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceArray(List<Integer> namespaceArray) {
     this.namespaceArray = namespaceArray;
   }
@@ -798,7 +776,6 @@ public class XmlItem {
   }
 
 
-
   public void setNamespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     this.namespaceWrappedArray = namespaceWrappedArray;
   }
@@ -822,7 +799,6 @@ public class XmlItem {
   public String getPrefixNsString() {
     return prefixNsString;
   }
-
 
 
   public void setPrefixNsString(String prefixNsString) {
@@ -850,7 +826,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsNumber(BigDecimal prefixNsNumber) {
     this.prefixNsNumber = prefixNsNumber;
   }
@@ -876,7 +851,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsInteger(Integer prefixNsInteger) {
     this.prefixNsInteger = prefixNsInteger;
   }
@@ -900,7 +874,6 @@ public class XmlItem {
   public Boolean getPrefixNsBoolean() {
     return prefixNsBoolean;
   }
-
 
 
   public void setPrefixNsBoolean(Boolean prefixNsBoolean) {
@@ -936,7 +909,6 @@ public class XmlItem {
   }
 
 
-
   public void setPrefixNsArray(List<Integer> prefixNsArray) {
     this.prefixNsArray = prefixNsArray;
   }
@@ -968,7 +940,6 @@ public class XmlItem {
   public List<Integer> getPrefixNsWrappedArray() {
     return prefixNsWrappedArray;
   }
-
 
 
   public void setPrefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)

### Description of the PR

The problem that this PR solves is that for `JsonNullable` fields of POJOs, the field would appear twice, once in snake case and once in camel case (e.g. both `some_field` and `someField` would appear in the JSON). The cause is:

* `JsonNullable` fields have two sets of getters and setters - "simple ones" (e.g. `getSomeField`) and `JsonNullable` ones (e.g. `getSomeField_JsonNullable`).
* For the `JsonNullable` fields, the `getSomeField_JsonNullable` getter is marked as the attribute and explicitly marked to be serialized as `some_field`.
* By default, the Jackson serialization library takes all getters of the object and serializes them. This means that Jackson would also see the non-`JsonNullable` getter and add it to the serialized object.
* This would only demonstrate on fields that have at least two words in their name. For example, `getEnd` would work fine, as there would be `getEnd` and `getEnd_JsonNullable`. The `getEnd_JsonNullable` getter would be marked to be serialized as `end`, which would make Jackson override `getEnd`. But for `getSomeField` and `getSomeField_JsonNullable`, Jackson would serialize `getSomeField` as `someField` and `getSomeField_JsonNullable` as `some_field`.
* Note that this fix also uncovered the need to add a private setter if the nullable field is read-only (Jackson can use that to properly set the value of the readOnly nullable attribute).

This patch fixes the above by explicitly marking the simple getters as ignored during serialization.

There's a slight problem now that this adds an extraneous newline in between the getters' annotations, so I'm trying to get rid of that.