### PR TITLE
typescript-fetch: Add application/x-www-form-urlencoded content support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ samples/client/petstore/python-tornado/.venv/
 samples/client/petstore/typescript-angular2/npm/npm-debug.log
 samples/client/petstore/typescript-node/npm/npm-debug.log
 samples/client/petstore/typescript-angular/tsd-debug.log
+samples/client/petstore/typescript-fetch/tests/**/dist/
 
 # aspnetcore
 samples/server/petstore/aspnetcore/.vs/

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -167,10 +167,8 @@ export class {{classname}} extends runtime.BaseAPI {
         {{/isFile}}
         {{/formParams}}
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -150,29 +150,52 @@ export class {{classname}} extends runtime.BaseAPI {
         {{/isOAuth}}
         {{/authMethods}}
         {{#hasFormParams}}
-        const formData = new FormData();
-        {{/hasFormParams}}
+        const consumes: runtime.Consume[] = [
+            {{#consumes}}
+            { contentType: '{{{mediaType}}}' },
+            {{/consumes}}
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        {{#formParams}}
+        {{#isFile}}
+        // use FormData to transmit files using content-type "multipart/form-data"
+        useForm = canConsumeForm;
+        {{/isFile}}
+        {{/formParams}}
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         {{#formParams}}
         {{#isListContainer}}
         if (requestParameters.{{paramName}}) {
             {{#isCollectionFormatMulti}}
             requestParameters.{{paramName}}.forEach((element) => {
-                formData.append('{{baseName}}', element as any);
+                formParams.append('{{baseName}}', element as any);
             })
             {{/isCollectionFormatMulti}}
             {{^isCollectionFormatMulti}}
-            formData.append('{{baseName}}', requestParameters.{{paramName}}.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]));
+            formParams.append('{{baseName}}', requestParameters.{{paramName}}.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]));
             {{/isCollectionFormatMulti}}
         }
 
         {{/isListContainer}}
         {{^isListContainer}}
         if (requestParameters.{{paramName}} !== undefined) {
-            formData.append('{{baseName}}', requestParameters.{{paramName}} as any);
+            formParams.append('{{baseName}}', requestParameters.{{paramName}} as any);
         }
 
         {{/isListContainer}}
         {{/formParams}}
+        {{/hasFormParams}}
         const response = await this.request({
             path: `{{{path}}}`{{#pathParams}}.replace(`{${"{{baseName}}"}}`, encodeURIComponent(String(requestParameters.{{paramName}}))){{/pathParams}},
             method: '{{httpMethod}}',
@@ -194,7 +217,7 @@ export class {{classname}} extends runtime.BaseAPI {
             {{/bodyParam}}
             {{/hasBodyParam}}
             {{#hasFormParams}}
-            body: formData,
+            body: formParams,
             {{/hasFormParams}}
         });
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -184,7 +184,7 @@ export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
-export type HTTPBody = Json | FormData;
+export type HTTPBody = Json | FormData | URLSearchParams;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export interface FetchParams {
@@ -229,6 +229,19 @@ export function mapValues(data: any, fn: (item: any) => any) {
     (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
     {}
   );
+}
+
+export function canConsumeForm(consumes: Consume[]): boolean {
+    for (const consume of consumes) {
+        if ('multipart/form-data' === consume.contentType) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export interface Consume {
+    contentType: string
 }
 
 export interface RequestContext {

--- a/samples/client/petstore/typescript-fetch/builds/default/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/src/apis/PetApi.ts
@@ -335,13 +335,28 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'application/x-www-form-urlencoded' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.name !== undefined) {
-            formData.append('name', requestParameters.name as any);
+            formParams.append('name', requestParameters.name as any);
         }
 
         if (requestParameters.status !== undefined) {
-            formData.append('status', requestParameters.status as any);
+            formParams.append('status', requestParameters.status as any);
         }
 
         const response = await this.request({
@@ -349,7 +364,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -383,13 +398,30 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'multipart/form-data' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        // use FormData to transmit files using content-type "multipart/form-data"
+        useForm = canConsumeForm;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.additionalMetadata !== undefined) {
-            formData.append('additionalMetadata', requestParameters.additionalMetadata as any);
+            formParams.append('additionalMetadata', requestParameters.additionalMetadata as any);
         }
 
         if (requestParameters.file !== undefined) {
-            formData.append('file', requestParameters.file as any);
+            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -397,7 +429,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/default/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/src/apis/PetApi.ts
@@ -344,10 +344,8 @@ export class PetApi extends runtime.BaseAPI {
         let formParams: { append(param: string, value: any): any };
         let useForm = false;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 
@@ -409,10 +407,8 @@ export class PetApi extends runtime.BaseAPI {
         // use FormData to transmit files using content-type "multipart/form-data"
         useForm = canConsumeForm;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/src/runtime.ts
@@ -195,7 +195,7 @@ export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
-export type HTTPBody = Json | FormData;
+export type HTTPBody = Json | FormData | URLSearchParams;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export interface FetchParams {
@@ -240,6 +240,19 @@ export function mapValues(data: any, fn: (item: any) => any) {
     (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
     {}
   );
+}
+
+export function canConsumeForm(consumes: Consume[]): boolean {
+    for (const consume of consumes) {
+        if ('multipart/form-data' === consume.contentType) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export interface Consume {
+    contentType: string
 }
 
 export interface RequestContext {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
@@ -335,13 +335,28 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'application/x-www-form-urlencoded' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.name !== undefined) {
-            formData.append('name', requestParameters.name as any);
+            formParams.append('name', requestParameters.name as any);
         }
 
         if (requestParameters.status !== undefined) {
-            formData.append('status', requestParameters.status as any);
+            formParams.append('status', requestParameters.status as any);
         }
 
         const response = await this.request({
@@ -349,7 +364,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -383,13 +398,30 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'multipart/form-data' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        // use FormData to transmit files using content-type "multipart/form-data"
+        useForm = canConsumeForm;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.additionalMetadata !== undefined) {
-            formData.append('additionalMetadata', requestParameters.additionalMetadata as any);
+            formParams.append('additionalMetadata', requestParameters.additionalMetadata as any);
         }
 
         if (requestParameters.file !== undefined) {
-            formData.append('file', requestParameters.file as any);
+            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -397,7 +429,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
@@ -344,10 +344,8 @@ export class PetApi extends runtime.BaseAPI {
         let formParams: { append(param: string, value: any): any };
         let useForm = false;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 
@@ -409,10 +407,8 @@ export class PetApi extends runtime.BaseAPI {
         // use FormData to transmit files using content-type "multipart/form-data"
         useForm = canConsumeForm;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -195,7 +195,7 @@ export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
-export type HTTPBody = Json | FormData;
+export type HTTPBody = Json | FormData | URLSearchParams;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export interface FetchParams {
@@ -240,6 +240,19 @@ export function mapValues(data: any, fn: (item: any) => any) {
     (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
     {}
   );
+}
+
+export function canConsumeForm(consumes: Consume[]): boolean {
+    for (const consume of consumes) {
+        if ('multipart/form-data' === consume.contentType) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export interface Consume {
+    contentType: string
 }
 
 export interface RequestContext {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/apis/PetApi.ts
@@ -335,13 +335,28 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'application/x-www-form-urlencoded' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.name !== undefined) {
-            formData.append('name', requestParameters.name as any);
+            formParams.append('name', requestParameters.name as any);
         }
 
         if (requestParameters.status !== undefined) {
-            formData.append('status', requestParameters.status as any);
+            formParams.append('status', requestParameters.status as any);
         }
 
         const response = await this.request({
@@ -349,7 +364,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -383,13 +398,30 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'multipart/form-data' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        // use FormData to transmit files using content-type "multipart/form-data"
+        useForm = canConsumeForm;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.additionalMetadata !== undefined) {
-            formData.append('additionalMetadata', requestParameters.additionalMetadata as any);
+            formParams.append('additionalMetadata', requestParameters.additionalMetadata as any);
         }
 
         if (requestParameters.file !== undefined) {
-            formData.append('file', requestParameters.file as any);
+            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -397,7 +429,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/apis/PetApi.ts
@@ -344,10 +344,8 @@ export class PetApi extends runtime.BaseAPI {
         let formParams: { append(param: string, value: any): any };
         let useForm = false;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 
@@ -409,10 +407,8 @@ export class PetApi extends runtime.BaseAPI {
         // use FormData to transmit files using content-type "multipart/form-data"
         useForm = canConsumeForm;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/runtime.ts
@@ -195,7 +195,7 @@ export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
-export type HTTPBody = Json | FormData;
+export type HTTPBody = Json | FormData | URLSearchParams;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export interface FetchParams {
@@ -240,6 +240,19 @@ export function mapValues(data: any, fn: (item: any) => any) {
     (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
     {}
   );
+}
+
+export function canConsumeForm(consumes: Consume[]): boolean {
+    for (const consume of consumes) {
+        if ('multipart/form-data' === consume.contentType) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export interface Consume {
+    contentType: string
 }
 
 export interface RequestContext {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
@@ -335,13 +335,28 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'application/x-www-form-urlencoded' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.name !== undefined) {
-            formData.append('name', requestParameters.name as any);
+            formParams.append('name', requestParameters.name as any);
         }
 
         if (requestParameters.status !== undefined) {
-            formData.append('status', requestParameters.status as any);
+            formParams.append('status', requestParameters.status as any);
         }
 
         const response = await this.request({
@@ -349,7 +364,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -383,13 +398,30 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'multipart/form-data' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        // use FormData to transmit files using content-type "multipart/form-data"
+        useForm = canConsumeForm;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.additionalMetadata !== undefined) {
-            formData.append('additionalMetadata', requestParameters.additionalMetadata as any);
+            formParams.append('additionalMetadata', requestParameters.additionalMetadata as any);
         }
 
         if (requestParameters.file !== undefined) {
-            formData.append('file', requestParameters.file as any);
+            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -397,7 +429,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
@@ -344,10 +344,8 @@ export class PetApi extends runtime.BaseAPI {
         let formParams: { append(param: string, value: any): any };
         let useForm = false;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 
@@ -409,10 +407,8 @@ export class PetApi extends runtime.BaseAPI {
         // use FormData to transmit files using content-type "multipart/form-data"
         useForm = canConsumeForm;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -195,7 +195,7 @@ export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
-export type HTTPBody = Json | FormData;
+export type HTTPBody = Json | FormData | URLSearchParams;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export interface FetchParams {
@@ -240,6 +240,19 @@ export function mapValues(data: any, fn: (item: any) => any) {
     (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
     {}
   );
+}
+
+export function canConsumeForm(consumes: Consume[]): boolean {
+    for (const consume of consumes) {
+        if ('multipart/form-data' === consume.contentType) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export interface Consume {
+    contentType: string
 }
 
 export interface RequestContext {

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/PetApi.ts
@@ -335,13 +335,28 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'application/x-www-form-urlencoded' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.name !== undefined) {
-            formData.append('name', requestParameters.name as any);
+            formParams.append('name', requestParameters.name as any);
         }
 
         if (requestParameters.status !== undefined) {
-            formData.append('status', requestParameters.status as any);
+            formParams.append('status', requestParameters.status as any);
         }
 
         const response = await this.request({
@@ -349,7 +364,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -383,13 +398,30 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'multipart/form-data' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        // use FormData to transmit files using content-type "multipart/form-data"
+        useForm = canConsumeForm;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.additionalMetadata !== undefined) {
-            formData.append('additionalMetadata', requestParameters.additionalMetadata as any);
+            formParams.append('additionalMetadata', requestParameters.additionalMetadata as any);
         }
 
         if (requestParameters.file !== undefined) {
-            formData.append('file', requestParameters.file as any);
+            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -397,7 +429,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/PetApi.ts
@@ -344,10 +344,8 @@ export class PetApi extends runtime.BaseAPI {
         let formParams: { append(param: string, value: any): any };
         let useForm = false;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 
@@ -409,10 +407,8 @@ export class PetApi extends runtime.BaseAPI {
         // use FormData to transmit files using content-type "multipart/form-data"
         useForm = canConsumeForm;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -195,7 +195,7 @@ export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
-export type HTTPBody = Json | FormData;
+export type HTTPBody = Json | FormData | URLSearchParams;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export interface FetchParams {
@@ -240,6 +240,19 @@ export function mapValues(data: any, fn: (item: any) => any) {
     (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
     {}
   );
+}
+
+export function canConsumeForm(consumes: Consume[]): boolean {
+    for (const consume of consumes) {
+        if ('multipart/form-data' === consume.contentType) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export interface Consume {
+    contentType: string
 }
 
 export interface RequestContext {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/apis/PetApi.ts
@@ -335,13 +335,28 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'application/x-www-form-urlencoded' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.name !== undefined) {
-            formData.append('name', requestParameters.name as any);
+            formParams.append('name', requestParameters.name as any);
         }
 
         if (requestParameters.status !== undefined) {
-            formData.append('status', requestParameters.status as any);
+            formParams.append('status', requestParameters.status as any);
         }
 
         const response = await this.request({
@@ -349,7 +364,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -383,13 +398,30 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'multipart/form-data' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        // use FormData to transmit files using content-type "multipart/form-data"
+        useForm = canConsumeForm;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.additionalMetadata !== undefined) {
-            formData.append('additionalMetadata', requestParameters.additionalMetadata as any);
+            formParams.append('additionalMetadata', requestParameters.additionalMetadata as any);
         }
 
         if (requestParameters.file !== undefined) {
-            formData.append('file', requestParameters.file as any);
+            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -397,7 +429,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/apis/PetApi.ts
@@ -344,10 +344,8 @@ export class PetApi extends runtime.BaseAPI {
         let formParams: { append(param: string, value: any): any };
         let useForm = false;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 
@@ -409,10 +407,8 @@ export class PetApi extends runtime.BaseAPI {
         // use FormData to transmit files using content-type "multipart/form-data"
         useForm = canConsumeForm;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/runtime.ts
@@ -195,7 +195,7 @@ export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
-export type HTTPBody = Json | FormData;
+export type HTTPBody = Json | FormData | URLSearchParams;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export interface FetchParams {
@@ -240,6 +240,19 @@ export function mapValues(data: any, fn: (item: any) => any) {
     (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
     {}
   );
+}
+
+export function canConsumeForm(consumes: Consume[]): boolean {
+    for (const consume of consumes) {
+        if ('multipart/form-data' === consume.contentType) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export interface Consume {
+    contentType: string
 }
 
 export interface RequestContext {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
@@ -335,13 +335,28 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'application/x-www-form-urlencoded' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.name !== undefined) {
-            formData.append('name', requestParameters.name as any);
+            formParams.append('name', requestParameters.name as any);
         }
 
         if (requestParameters.status !== undefined) {
-            formData.append('status', requestParameters.status as any);
+            formParams.append('status', requestParameters.status as any);
         }
 
         const response = await this.request({
@@ -349,7 +364,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.VoidApiResponse(response);
@@ -383,13 +398,30 @@ export class PetApi extends runtime.BaseAPI {
             }
         }
 
-        const formData = new FormData();
+        const consumes: runtime.Consume[] = [
+            { contentType: 'multipart/form-data' },
+        ];
+        // @ts-ignore: canConsumeForm may be unused
+        const canConsumeForm = runtime.canConsumeForm(consumes);
+
+        let formParams: { append(param: string, value: any): any };
+        let useForm = false;
+        // use FormData to transmit files using content-type "multipart/form-data"
+        useForm = canConsumeForm;
+        if (useForm) {
+            headerParameters['Content-Type'] = 'multipart/form-data';
+            formParams = new FormData();
+        } else {
+            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
+            formParams = new URLSearchParams();
+        }
+
         if (requestParameters.additionalMetadata !== undefined) {
-            formData.append('additionalMetadata', requestParameters.additionalMetadata as any);
+            formParams.append('additionalMetadata', requestParameters.additionalMetadata as any);
         }
 
         if (requestParameters.file !== undefined) {
-            formData.append('file', requestParameters.file as any);
+            formParams.append('file', requestParameters.file as any);
         }
 
         const response = await this.request({
@@ -397,7 +429,7 @@ export class PetApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: formData,
+            body: formParams,
         });
 
         return new runtime.JSONApiResponse(response, (jsonValue) => ModelApiResponseFromJSON(jsonValue));

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
@@ -344,10 +344,8 @@ export class PetApi extends runtime.BaseAPI {
         let formParams: { append(param: string, value: any): any };
         let useForm = false;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 
@@ -409,10 +407,8 @@ export class PetApi extends runtime.BaseAPI {
         // use FormData to transmit files using content-type "multipart/form-data"
         useForm = canConsumeForm;
         if (useForm) {
-            headerParameters['Content-Type'] = 'multipart/form-data';
             formParams = new FormData();
         } else {
-            headerParameters['Content-Type'] = 'application/x-www-form-urlencoded';
             formParams = new URLSearchParams();
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -195,7 +195,7 @@ export type Json = any;
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 export type HTTPHeaders = { [key: string]: string };
 export type HTTPQuery = { [key: string]: string | number | null | boolean | Array<string | number | null | boolean> | HTTPQuery };
-export type HTTPBody = Json | FormData;
+export type HTTPBody = Json | FormData | URLSearchParams;
 export type ModelPropertyNaming = 'camelCase' | 'snake_case' | 'PascalCase' | 'original';
 
 export interface FetchParams {
@@ -240,6 +240,19 @@ export function mapValues(data: any, fn: (item: any) => any) {
     (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
     {}
   );
+}
+
+export function canConsumeForm(consumes: Consume[]): boolean {
+    for (const consume of consumes) {
+        if ('multipart/form-data' === consume.contentType) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export interface Consume {
+    contentType: string
 }
 
 export interface RequestContext {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Resolve an issue described in  https://github.com/OpenAPITools/openapi-generator/issues/3920 ([typescript-fetch] cannot handle with application/x-www-form-urlencoded content).

fixes  #3920 

### Technical Committee

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07)