### PR TITLE
Add Gantner (https://www.gantner.com) to the list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ Here are some companies/projects (alphabetical order) using OpenAPI Generator in
 - [Element AI](https://www.elementai.com/)
 - [FormAPI](https://formapi.io/)
 - [Fuse](https://www.fuse.no/)
+- [Gantner](https://www.gantner.com)
 - [GenFlow](https://github.com/RepreZen/GenFlow)
 - [GMO Pepabo](https://pepabo.com/en/)
 - [GoDaddy](https://godaddy.com)


### PR DESCRIPTION
As discussed via e-mail with @wing328 this PR adds the company I work for, Gantner, to the list of users of OpenAPI Generator. I'm raising this against `master` but I'm not sure so please correct if necessary.