### PR TITLE
[scala] add [date-time] field to codegen unit test

### DIFF
--- a/modules/openapi-generator/src/test/resources/3_0/scala_reserved_words.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/scala_reserved_words.yaml
@@ -75,6 +75,9 @@ components:
           type: string
         foobar:
           type: boolean
+        created_at:
+          type: string
+          format: date-time
       required:
         - id
         - try
@@ -82,3 +85,4 @@ components:
         - finally
         - lazy
         - foobar
+        - created_at

--- a/modules/openapi-generator/src/test/resources/codegen/scala/SomeObj.scala.txt
+++ b/modules/openapi-generator/src/test/resources/codegen/scala/SomeObj.scala.txt
@@ -36,7 +36,8 @@ case class SomeObj (
   `lazy`: String,
   `private`: Option[String] = None,
   `type`: Option[String] = None,
-  foobar: Boolean
+  foobar: Boolean,
+  createdAt: DateTime
 ) extends ApiModel
 
 object SomeObjEnums {


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

