### PR TITLE
[java] Don't import oltu when not necessary

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -3,8 +3,11 @@ package {{invokerPackage}};
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+{{#hasOAuthMethods}}
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.AuthenticationRequestBuilder;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.TokenRequestBuilder;
+{{/hasOAuthMethods}}
+
 {{#threetenbp}}
 import org.threeten.bp.*;
 {{/threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/ApiClient.mustache
@@ -7,8 +7,11 @@ import java.lang.reflect.Type;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+{{#hasOAuthMethods}}
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.AuthenticationRequestBuilder;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.TokenRequestBuilder;
+{{/hasOAuthMethods}}
+
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormatter;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
@@ -7,8 +7,10 @@ import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+{{#hasOAuthMethods}}
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.AuthenticationRequestBuilder;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.TokenRequestBuilder;
+{{/hasOAuthMethods}}
 {{#joda}}
 import org.joda.time.format.DateTimeFormatter;
 {{/joda}}

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.AuthenticationRequestBuilder;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.TokenRequestBuilder;
+
 import org.threeten.bp.*;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/ApiClient.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.AuthenticationRequestBuilder;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.TokenRequestBuilder;
+
 import org.threeten.bp.*;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/ApiClient.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.AuthenticationRequestBuilder;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest.TokenRequestBuilder;
+
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormatter;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC: @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)

### Description of the PR

The Apache Oltu library is only needed when OAuth is used.

Currently a user is forced to add an Oltu dependency even though it is not used. This PR changes the template to only import Oltu when needed.