### PR TITLE
Fix generateAliasAsModels in the default generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.api.TemplatingEngineAdapter;
 import org.openapitools.codegen.ignore.CodegenIgnoreProcessor;
+import org.openapitools.codegen.languages.PythonClientExperimentalCodegen;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.serializer.SerializerUtils;
@@ -492,7 +493,9 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 Map<String, Object> modelTemplate = (Map<String, Object>) ((List<Object>) models.get("models")).get(0);
                 if (modelTemplate != null && modelTemplate.containsKey("model")) {
                     CodegenModel m = (CodegenModel) modelTemplate.get("model");
-                    if (m.isAlias && !ModelUtils.isGenerateAliasAsModel()) {
+                    if (m.isAlias && !(config instanceof PythonClientExperimentalCodegen))  {
+                        // alias to number, string, enum, etc, which should not be generated as model
+                        // for PythonClientExperimentalCodegen, all aliases are generated as models
                         continue;  // Don't create user-defined classes for aliases
                     }
                 }
@@ -942,7 +945,6 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
      * Returns the path of a template, allowing access to the template where consuming literal contents aren't desirable or possible.
      *
      * @param name the template name (e.g. model.mustache)
-     *
      * @return The {@link Path} to the template
      */
     @Override
@@ -1062,21 +1064,21 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                 if (authMethods != null && !authMethods.isEmpty()) {
                     codegenOperation.authMethods = config.fromSecurity(authMethods);
                     List<Map<String, Object>> scopes = new ArrayList<Map<String, Object>>();
-                    if (codegenOperation.authMethods != null){
-                        for (CodegenSecurity security : codegenOperation.authMethods){
+                    if (codegenOperation.authMethods != null) {
+                        for (CodegenSecurity security : codegenOperation.authMethods) {
                             if (security != null && security.isBasicBearer != null && security.isBasicBearer &&
-                               securities != null){
-                                for (SecurityRequirement req : securities){
+                                    securities != null) {
+                                for (SecurityRequirement req : securities) {
                                     if (req == null) continue;
-                                    for (String key : req.keySet()){
-                                        if (security.name != null && key.equals(security.name)){
+                                    for (String key : req.keySet()) {
+                                        if (security.name != null && key.equals(security.name)) {
                                             int count = 0;
-                                            for (String sc : req.get(key)){
+                                            for (String sc : req.get(key)) {
                                                 Map<String, Object> scope = new HashMap<String, Object>();
                                                 scope.put("scope", sc);
                                                 scope.put("description", "");
                                                 count++;
-                                                if (req.get(key) != null && count < req.get(key).size()){
+                                                if (req.get(key) != null && count < req.get(key).size()) {
                                                     scope.put("hasMore", "true");
                                                 } else {
                                                     scope.put("hasMore", null);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java
@@ -78,10 +78,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
 
         // default this to true so the python ModelSimple models will be generated
         ModelUtils.setGenerateAliasAsModel(true);
-        if (additionalProperties.containsKey(CodegenConstants.GENERATE_ALIAS_AS_MODEL)) {
-          LOGGER.info(CodegenConstants.GENERATE_ALIAS_AS_MODEL + " is hard coded to true in this generator. Alias models will only be generated if they contain validations or enums");
-        }
-
+        LOGGER.info(CodegenConstants.GENERATE_ALIAS_AS_MODEL + " is hard coded to true in this generator. Alias models will only be generated if they contain validations or enums");
     }
 
     /**
@@ -108,6 +105,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
 
     /**
      * Return the default value of the property
+     *
      * @param p OpenAPI property object
      * @return string presentation of the default value of the property
      */
@@ -194,7 +192,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
             }
             return defaultValue;
         } else {
-            return  defaultObject.toString();
+            return defaultObject.toString();
         }
     }
 
@@ -387,7 +385,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
             } else {
                 if (cp.isEnum == true || cp.hasValidation == true) {
                     // this model has validations and/or enums so we will generate it
-                    Schema sc =  ModelUtils.getSchemaFromResponse(response);
+                    Schema sc = ModelUtils.getSchemaFromResponse(response);
                     newBaseType = ModelUtils.getSimpleRef(sc.get$ref());
                 }
             }
@@ -406,9 +404,9 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
     /**
      * Set op's returnBaseType, returnType, examples etc.
      *
-     * @param operation endpoint Operation
-     * @param schemas a map of the schemas in the openapi spec
-     * @param op endpoint CodegenOperation
+     * @param operation      endpoint Operation
+     * @param schemas        a map of the schemas in the openapi spec
+     * @param op             endpoint CodegenOperation
      * @param methodResponse the default ApiResponse for the endpoint
      */
     @Override
@@ -568,7 +566,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
 
         // fix all property references to non-object models, make those properties non-primitive and
         // set their dataType and complexType to the model name, so documentation will refer to the correct model
-        ArrayList<List<CodegenProperty>> listOfLists= new ArrayList<List<CodegenProperty>>();
+        ArrayList<List<CodegenProperty>> listOfLists = new ArrayList<List<CodegenProperty>>();
         listOfLists.add(result.vars);
         listOfLists.add(result.allVars);
         listOfLists.add(result.requiredVars);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- Fix generateAliasAsModels in the default generator (line 496 - 498)
- minor code formatting

cc @OpenAPITools/generator-core-team 