### PR TITLE
Better tests for string (number)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1068,8 +1068,7 @@ public class DefaultCodegen implements CodegenConfig {
         typeMapping.put("file", "File");
         typeMapping.put("UUID", "UUID");
         typeMapping.put("URI", "URI");
-        typeMapping.put("BigDecimal", "BigDecimal"); //TODO need the mapping?
-
+        typeMapping.put("BigDecimal", "BigDecimal");
 
         instantiationTypes = new HashMap<String, String>();
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -181,6 +181,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         typeMapping.put("long", "long?");
         typeMapping.put("double", "double?");
         typeMapping.put("number", "decimal?");
+        typeMapping.put("BigDecimal", "decimal?");
         typeMapping.put("DateTime", "DateTime?");
         typeMapping.put("date", "DateTime?");
         typeMapping.put("file", "System.IO.Stream");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -96,6 +96,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         typeMapping.put("number", "float32");
         typeMapping.put("float", "float32");
         typeMapping.put("double", "float64");
+        typeMapping.put("BigDecimal", "float64");
         typeMapping.put("boolean", "bool");
         typeMapping.put("string", "string");
         typeMapping.put("UUID", "string");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -95,6 +95,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         typeMapping.put("long", "long");
         typeMapping.put("double", "double");
         typeMapping.put("number", "decimal");
+        typeMapping.put("BigDecimal", "decimal");
         typeMapping.put("DateTime", "DateTime");
         typeMapping.put("date", "DateTime");
         typeMapping.put("UUID", "Guid");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpNetCoreClientCodegen.java
@@ -94,6 +94,7 @@ public class CSharpNetCoreClientCodegen extends AbstractCSharpCodegen {
         typeMapping.put("long", "long");
         typeMapping.put("double", "double");
         typeMapping.put("number", "decimal");
+        typeMapping.put("BigDecimal", "decimal");
         typeMapping.put("DateTime", "DateTime");
         typeMapping.put("date", "DateTime");
         typeMapping.put("file", "System.IO.Stream");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellHttpClientCodegen.java
@@ -222,6 +222,7 @@ public class HaskellHttpClientCodegen extends DefaultCodegen implements CodegenC
         typeMapping.put("float", "Float");
         typeMapping.put("double", "Double");
         typeMapping.put("number", "Double");
+        typeMapping.put("BigDecimal", "Double");
         typeMapping.put("integer", "Int");
         typeMapping.put("file", "FilePath");
         // lib

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -171,6 +171,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         typeMapping.put("file", "FilePath");
         typeMapping.put("binary", "FilePath");
         typeMapping.put("number", "Double");
+        typeMapping.put("BigDecimal", "Double");
         typeMapping.put("any", "Value");
         typeMapping.put("UUID", "UUID");
         typeMapping.put("URI", "Text");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavascriptClientCodegen.java
@@ -144,6 +144,7 @@ public class JavascriptClientCodegen extends DefaultCodegen implements CodegenCo
         typeMapping.put("int", "Number");
         typeMapping.put("float", "Number");
         typeMapping.put("number", "Number");
+        typeMapping.put("BigDecimal", "Number");
         typeMapping.put("DateTime", "Date");
         typeMapping.put("date", "Date");
         typeMapping.put("long", "Number");

--- a/modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1403,6 +1403,9 @@ definitions:
         format: password
         maxLength: 64
         minLength: 10
+      BigDecimal:
+        type: string
+        format: number
   EnumClass:
     type: string
     default: '-efg'

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/FormatTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/FormatTest.md
@@ -16,6 +16,7 @@ Name | Type | Description | Notes
 **DateTime** | **DateTime** |  | [optional] 
 **Uuid** | **Guid** |  | [optional] 
 **Password** | **string** |  | 
+**BigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/FormatTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/FormatTest.md
@@ -16,7 +16,7 @@ Name | Type | Description | Notes
 **DateTime** | **DateTime** |  | [optional] 
 **Uuid** | **Guid** |  | [optional] 
 **Password** | **string** |  | 
-**BigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
+**BigDecimal** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -53,7 +53,8 @@ namespace Org.OpenAPITools.Model
         /// <param name="dateTime">dateTime.</param>
         /// <param name="uuid">uuid.</param>
         /// <param name="password">password (required).</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string))
+        /// <param name="bigDecimal">bigDecimal.</param>
+        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), BigDecimal bigDecimal = default(BigDecimal))
         {
             // to ensure "number" is required (not null)
             if (number == null)
@@ -104,6 +105,7 @@ namespace Org.OpenAPITools.Model
             this.Binary = binary;
             this.DateTime = dateTime;
             this.Uuid = uuid;
+            this.BigDecimal = bigDecimal;
         }
         
         /// <summary>
@@ -186,6 +188,12 @@ namespace Org.OpenAPITools.Model
         public string Password { get; set; }
 
         /// <summary>
+        /// Gets or Sets BigDecimal
+        /// </summary>
+        [DataMember(Name="BigDecimal", EmitDefaultValue=false)]
+        public BigDecimal BigDecimal { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -206,6 +214,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DateTime: ").Append(DateTime).Append("\n");
             sb.Append("  Uuid: ").Append(Uuid).Append("\n");
             sb.Append("  Password: ").Append(Password).Append("\n");
+            sb.Append("  BigDecimal: ").Append(BigDecimal).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -268,6 +277,8 @@ namespace Org.OpenAPITools.Model
                     hashCode = hashCode * 59 + this.Uuid.GetHashCode();
                 if (this.Password != null)
                     hashCode = hashCode * 59 + this.Password.GetHashCode();
+                if (this.BigDecimal != null)
+                    hashCode = hashCode * 59 + this.BigDecimal.GetHashCode();
                 return hashCode;
             }
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="password">password (required).</param>
         /// <param name="bigDecimal">bigDecimal.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), BigDecimal bigDecimal = default(BigDecimal))
+        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), decimal bigDecimal = default(decimal))
         {
             // to ensure "number" is required (not null)
             if (number == null)
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BigDecimal
         /// </summary>
         [DataMember(Name="BigDecimal", EmitDefaultValue=false)]
-        public BigDecimal BigDecimal { get; set; }
+        public decimal BigDecimal { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -277,8 +277,7 @@ namespace Org.OpenAPITools.Model
                     hashCode = hashCode * 59 + this.Uuid.GetHashCode();
                 if (this.Password != null)
                     hashCode = hashCode * 59 + this.Password.GetHashCode();
-                if (this.BigDecimal != null)
-                    hashCode = hashCode * 59 + this.BigDecimal.GetHashCode();
+                hashCode = hashCode * 59 + this.BigDecimal.GetHashCode();
                 return hashCode;
             }
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/FormatTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/FormatTest.md
@@ -16,6 +16,7 @@ Name | Type | Description | Notes
 **DateTime** | **DateTime** |  | [optional] 
 **Uuid** | **Guid** |  | [optional] 
 **Password** | **string** |  | 
+**BigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/FormatTest.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/FormatTest.md
@@ -16,7 +16,7 @@ Name | Type | Description | Notes
 **DateTime** | **DateTime** |  | [optional] 
 **Uuid** | **Guid** |  | [optional] 
 **Password** | **string** |  | 
-**BigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
+**BigDecimal** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -53,7 +53,8 @@ namespace Org.OpenAPITools.Model
         /// <param name="dateTime">dateTime.</param>
         /// <param name="uuid">uuid.</param>
         /// <param name="password">password (required).</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string))
+        /// <param name="bigDecimal">bigDecimal.</param>
+        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), BigDecimal bigDecimal = default(BigDecimal))
         {
             // to ensure "number" is required (not null)
             if (number == null)
@@ -104,6 +105,7 @@ namespace Org.OpenAPITools.Model
             this.Binary = binary;
             this.DateTime = dateTime;
             this.Uuid = uuid;
+            this.BigDecimal = bigDecimal;
         }
         
         /// <summary>
@@ -186,6 +188,12 @@ namespace Org.OpenAPITools.Model
         public string Password { get; set; }
 
         /// <summary>
+        /// Gets or Sets BigDecimal
+        /// </summary>
+        [DataMember(Name="BigDecimal", EmitDefaultValue=false)]
+        public BigDecimal BigDecimal { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -206,6 +214,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DateTime: ").Append(DateTime).Append("\n");
             sb.Append("  Uuid: ").Append(Uuid).Append("\n");
             sb.Append("  Password: ").Append(Password).Append("\n");
+            sb.Append("  BigDecimal: ").Append(BigDecimal).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -268,6 +277,8 @@ namespace Org.OpenAPITools.Model
                     hashCode = hashCode * 59 + this.Uuid.GetHashCode();
                 if (this.Password != null)
                     hashCode = hashCode * 59 + this.Password.GetHashCode();
+                if (this.BigDecimal != null)
+                    hashCode = hashCode * 59 + this.BigDecimal.GetHashCode();
                 return hashCode;
             }
         }

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="password">password (required).</param>
         /// <param name="bigDecimal">bigDecimal.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), BigDecimal bigDecimal = default(BigDecimal))
+        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), decimal bigDecimal = default(decimal))
         {
             // to ensure "number" is required (not null)
             if (number == null)
@@ -191,7 +191,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BigDecimal
         /// </summary>
         [DataMember(Name="BigDecimal", EmitDefaultValue=false)]
-        public BigDecimal BigDecimal { get; set; }
+        public decimal BigDecimal { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -277,8 +277,7 @@ namespace Org.OpenAPITools.Model
                     hashCode = hashCode * 59 + this.Uuid.GetHashCode();
                 if (this.Password != null)
                     hashCode = hashCode * 59 + this.Password.GetHashCode();
-                if (this.BigDecimal != null)
-                    hashCode = hashCode * 59 + this.BigDecimal.GetHashCode();
+                hashCode = hashCode * 59 + this.BigDecimal.GetHashCode();
                 return hashCode;
             }
         }

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FormatTest.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **DateTime** | **DateTime** |  | [optional] 
 **Uuid** | **Guid** |  | [optional] 
 **Password** | **string** |  | 
-**BigDecimal** | **decimal?** |  | [optional] 
+**BigDecimal** | **decimal** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models)
 [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FormatTest.md
@@ -18,6 +18,7 @@ Name | Type | Description | Notes
 **DateTime** | **DateTime** |  | [optional] 
 **Uuid** | **Guid** |  | [optional] 
 **Password** | **string** |  | 
+**BigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models)
 [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FormatTest.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **DateTime** | **DateTime** |  | [optional] 
 **Uuid** | **Guid** |  | [optional] 
 **Password** | **string** |  | 
-**BigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
+**BigDecimal** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models)
 [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="password">password (required).</param>
         /// <param name="bigDecimal">bigDecimal.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), decimal? bigDecimal = default(decimal?))
+        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), decimal bigDecimal = default(decimal))
         {
             // to ensure "number" is required (not null)
             if (number == null)
@@ -189,7 +189,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BigDecimal
         /// </summary>
         [DataMember(Name="BigDecimal", EmitDefaultValue=false)]
-        public decimal? BigDecimal { get; set; }
+        public decimal BigDecimal { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="password">password (required).</param>
         /// <param name="bigDecimal">bigDecimal.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), BigDecimal bigDecimal = default(BigDecimal))
+        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), decimal? bigDecimal = default(decimal?))
         {
             // to ensure "number" is required (not null)
             if (number == null)
@@ -189,7 +189,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets BigDecimal
         /// </summary>
         [DataMember(Name="BigDecimal", EmitDefaultValue=false)]
-        public BigDecimal BigDecimal { get; set; }
+        public decimal? BigDecimal { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -51,7 +51,8 @@ namespace Org.OpenAPITools.Model
         /// <param name="dateTime">dateTime.</param>
         /// <param name="uuid">uuid.</param>
         /// <param name="password">password (required).</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string))
+        /// <param name="bigDecimal">bigDecimal.</param>
+        public FormatTest(int integer = default(int), int int32 = default(int), long int64 = default(long), decimal number = default(decimal), float _float = default(float), double _double = default(double), string _string = default(string), byte[] _byte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), BigDecimal bigDecimal = default(BigDecimal))
         {
             // to ensure "number" is required (not null)
             if (number == null)
@@ -102,6 +103,7 @@ namespace Org.OpenAPITools.Model
             this.Binary = binary;
             this.DateTime = dateTime;
             this.Uuid = uuid;
+            this.BigDecimal = bigDecimal;
         }
         
         /// <summary>
@@ -184,6 +186,12 @@ namespace Org.OpenAPITools.Model
         public string Password { get; set; }
 
         /// <summary>
+        /// Gets or Sets BigDecimal
+        /// </summary>
+        [DataMember(Name="BigDecimal", EmitDefaultValue=false)]
+        public BigDecimal BigDecimal { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -204,6 +212,7 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DateTime: ").Append(DateTime).Append("\n");
             sb.Append("  Uuid: ").Append(Uuid).Append("\n");
             sb.Append("  Password: ").Append(Password).Append("\n");
+            sb.Append("  BigDecimal: ").Append(BigDecimal).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -302,6 +311,11 @@ namespace Org.OpenAPITools.Model
                     this.Password == input.Password ||
                     (this.Password != null &&
                     this.Password.Equals(input.Password))
+                ) && 
+                (
+                    this.BigDecimal == input.BigDecimal ||
+                    (this.BigDecimal != null &&
+                    this.BigDecimal.Equals(input.BigDecimal))
                 );
         }
 
@@ -340,6 +354,8 @@ namespace Org.OpenAPITools.Model
                     hashCode = hashCode * 59 + this.Uuid.GetHashCode();
                 if (this.Password != null)
                     hashCode = hashCode * 59 + this.Password.GetHashCode();
+                if (this.BigDecimal != null)
+                    hashCode = hashCode * 59 + this.BigDecimal.GetHashCode();
                 return hashCode;
             }
         }

--- a/samples/client/petstore/elixir/lib/openapi_petstore/model/format_test.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/model/format_test.ex
@@ -21,7 +21,8 @@ defmodule OpenapiPetstore.Model.FormatTest do
     :"date",
     :"dateTime",
     :"uuid",
-    :"password"
+    :"password",
+    :"BigDecimal"
   ]
 
   @type t :: %__MODULE__{
@@ -37,7 +38,8 @@ defmodule OpenapiPetstore.Model.FormatTest do
     :"date" => Date.t,
     :"dateTime" => DateTime.t | nil,
     :"uuid" => String.t | nil,
-    :"password" => String.t
+    :"password" => String.t,
+    :"BigDecimal" => String.t | nil
   }
 end
 
@@ -46,6 +48,7 @@ defimpl Poison.Decoder, for: OpenapiPetstore.Model.FormatTest do
   def decode(value, options) do
     value
     |> deserialize(:"date", :date, nil, options)
+    |> deserialize(:"BigDecimal", :struct, OpenapiPetstore.Model.String.t, options)
   end
 end
 

--- a/samples/client/petstore/go/go-petstore-withXml/api/openapi.yaml
+++ b/samples/client/petstore/go/go-petstore-withXml/api/openapi.yaml
@@ -1491,6 +1491,9 @@ components:
           maxLength: 64
           minLength: 10
           type: string
+        BigDecimal:
+          format: number
+          type: string
       required:
       - byte
       - date

--- a/samples/client/petstore/go/go-petstore-withXml/docs/FormatTest.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/FormatTest.md
@@ -17,7 +17,7 @@ Name | Type | Description | Notes
 **DateTime** | [**time.Time**](time.Time.md) |  | [optional] 
 **Uuid** | **string** |  | [optional] 
 **Password** | **string** |  | 
-**BigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
+**BigDecimal** | **float64** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore-withXml/docs/FormatTest.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/FormatTest.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **DateTime** | [**time.Time**](time.Time.md) |  | [optional] 
 **Uuid** | **string** |  | [optional] 
 **Password** | **string** |  | 
+**BigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore-withXml/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore-withXml/model_format_test_.go
@@ -28,5 +28,5 @@ type FormatTest struct {
 	DateTime time.Time `json:"dateTime,omitempty" xml:"dateTime"`
 	Uuid string `json:"uuid,omitempty" xml:"uuid"`
 	Password string `json:"password" xml:"password"`
-	BigDecimal BigDecimal `json:"BigDecimal,omitempty" xml:"BigDecimal"`
+	BigDecimal float64 `json:"BigDecimal,omitempty" xml:"BigDecimal"`
 }

--- a/samples/client/petstore/go/go-petstore-withXml/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore-withXml/model_format_test_.go
@@ -28,4 +28,5 @@ type FormatTest struct {
 	DateTime time.Time `json:"dateTime,omitempty" xml:"dateTime"`
 	Uuid string `json:"uuid,omitempty" xml:"uuid"`
 	Password string `json:"password" xml:"password"`
+	BigDecimal BigDecimal `json:"BigDecimal,omitempty" xml:"BigDecimal"`
 }

--- a/samples/client/petstore/go/go-petstore/api/openapi.yaml
+++ b/samples/client/petstore/go/go-petstore/api/openapi.yaml
@@ -1491,6 +1491,9 @@ components:
           maxLength: 64
           minLength: 10
           type: string
+        BigDecimal:
+          format: number
+          type: string
       required:
       - byte
       - date

--- a/samples/client/petstore/go/go-petstore/docs/FormatTest.md
+++ b/samples/client/petstore/go/go-petstore/docs/FormatTest.md
@@ -17,7 +17,7 @@ Name | Type | Description | Notes
 **DateTime** | [**time.Time**](time.Time.md) |  | [optional] 
 **Uuid** | **string** |  | [optional] 
 **Password** | **string** |  | 
-**BigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
+**BigDecimal** | **float64** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore/docs/FormatTest.md
+++ b/samples/client/petstore/go/go-petstore/docs/FormatTest.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **DateTime** | [**time.Time**](time.Time.md) |  | [optional] 
 **Uuid** | **string** |  | [optional] 
 **Password** | **string** |  | 
+**BigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -27,4 +27,5 @@ type FormatTest struct {
 	DateTime time.Time `json:"dateTime,omitempty"`
 	Uuid string `json:"uuid,omitempty"`
 	Password string `json:"password"`
+	BigDecimal BigDecimal `json:"BigDecimal,omitempty"`
 }

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -27,5 +27,5 @@ type FormatTest struct {
 	DateTime time.Time `json:"dateTime,omitempty"`
 	Uuid string `json:"uuid,omitempty"`
 	Password string `json:"password"`
-	BigDecimal BigDecimal `json:"BigDecimal,omitempty"`
+	BigDecimal float64 `json:"BigDecimal,omitempty"`
 }

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Model.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Model.hs
@@ -1075,6 +1075,7 @@ data FormatTest = FormatTest
   , formatTestDateTime :: !(Maybe DateTime) -- ^ "dateTime"
   , formatTestUuid :: !(Maybe Text) -- ^ "uuid"
   , formatTestPassword :: !(Text) -- ^ /Required/ "password"
+  , formatTestBigDecimal :: !(Maybe BigDecimal) -- ^ "BigDecimal"
   } deriving (P.Show, P.Eq, P.Typeable)
 
 -- | FromJSON FormatTest
@@ -1094,6 +1095,7 @@ instance A.FromJSON FormatTest where
       <*> (o .:? "dateTime")
       <*> (o .:? "uuid")
       <*> (o .:  "password")
+      <*> (o .:? "BigDecimal")
 
 -- | ToJSON FormatTest
 instance A.ToJSON FormatTest where
@@ -1112,6 +1114,7 @@ instance A.ToJSON FormatTest where
       , "dateTime" .= formatTestDateTime
       , "uuid" .= formatTestUuid
       , "password" .= formatTestPassword
+      , "BigDecimal" .= formatTestBigDecimal
       ]
 
 
@@ -1137,6 +1140,7 @@ mkFormatTest formatTestNumber formatTestByte formatTestDate formatTestPassword =
   , formatTestDateTime = Nothing
   , formatTestUuid = Nothing
   , formatTestPassword
+  , formatTestBigDecimal = Nothing
   }
 
 -- ** HasOnlyReadOnly

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Model.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Model.hs
@@ -1075,7 +1075,7 @@ data FormatTest = FormatTest
   , formatTestDateTime :: !(Maybe DateTime) -- ^ "dateTime"
   , formatTestUuid :: !(Maybe Text) -- ^ "uuid"
   , formatTestPassword :: !(Text) -- ^ /Required/ "password"
-  , formatTestBigDecimal :: !(Maybe BigDecimal) -- ^ "BigDecimal"
+  , formatTestBigDecimal :: !(Maybe Double) -- ^ "BigDecimal"
   } deriving (P.Show, P.Eq, P.Typeable)
 
 -- | FromJSON FormatTest

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/ModelLens.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/ModelLens.hs
@@ -488,7 +488,7 @@ formatTestPasswordL f FormatTest{..} = (\formatTestPassword -> FormatTest { form
 {-# INLINE formatTestPasswordL #-}
 
 -- | 'formatTestBigDecimal' Lens
-formatTestBigDecimalL :: Lens_' FormatTest (Maybe BigDecimal)
+formatTestBigDecimalL :: Lens_' FormatTest (Maybe Double)
 formatTestBigDecimalL f FormatTest{..} = (\formatTestBigDecimal -> FormatTest { formatTestBigDecimal, ..} ) <$> f formatTestBigDecimal
 {-# INLINE formatTestBigDecimalL #-}
 

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/ModelLens.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/ModelLens.hs
@@ -487,6 +487,11 @@ formatTestPasswordL :: Lens_' FormatTest (Text)
 formatTestPasswordL f FormatTest{..} = (\formatTestPassword -> FormatTest { formatTestPassword, ..} ) <$> f formatTestPassword
 {-# INLINE formatTestPasswordL #-}
 
+-- | 'formatTestBigDecimal' Lens
+formatTestBigDecimalL :: Lens_' FormatTest (Maybe BigDecimal)
+formatTestBigDecimalL f FormatTest{..} = (\formatTestBigDecimal -> FormatTest { formatTestBigDecimal, ..} ) <$> f formatTestBigDecimal
+{-# INLINE formatTestBigDecimalL #-}
+
 
 
 -- * HasOnlyReadOnly

--- a/samples/client/petstore/haskell-http-client/openapi.yaml
+++ b/samples/client/petstore/haskell-http-client/openapi.yaml
@@ -1491,6 +1491,9 @@ components:
           maxLength: 64
           minLength: 10
           type: string
+        BigDecimal:
+          format: number
+          type: string
       required:
       - byte
       - date

--- a/samples/client/petstore/haskell-http-client/tests/Instances.hs
+++ b/samples/client/petstore/haskell-http-client/tests/Instances.hs
@@ -354,7 +354,7 @@ genFormatTest n =
     <*> arbitraryReducedMaybe n -- formatTestDateTime :: Maybe DateTime
     <*> arbitraryReducedMaybe n -- formatTestUuid :: Maybe Text
     <*> arbitrary -- formatTestPassword :: Text
-    <*> arbitraryReducedMaybe n -- formatTestBigDecimal :: Maybe BigDecimal
+    <*> arbitraryReducedMaybe n -- formatTestBigDecimal :: Maybe Double
   
 instance Arbitrary HasOnlyReadOnly where
   arbitrary = sized genHasOnlyReadOnly

--- a/samples/client/petstore/haskell-http-client/tests/Instances.hs
+++ b/samples/client/petstore/haskell-http-client/tests/Instances.hs
@@ -354,6 +354,7 @@ genFormatTest n =
     <*> arbitraryReducedMaybe n -- formatTestDateTime :: Maybe DateTime
     <*> arbitraryReducedMaybe n -- formatTestUuid :: Maybe Text
     <*> arbitrary -- formatTestPassword :: Text
+    <*> arbitraryReducedMaybe n -- formatTestBigDecimal :: Maybe BigDecimal
   
 instance Arbitrary HasOnlyReadOnly where
   arbitrary = sized genHasOnlyReadOnly

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/feign10x/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/google-api-client/docs/FormatTest.md
+++ b/samples/client/petstore/java/google-api-client/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/jersey1/docs/FormatTest.md
+++ b/samples/client/petstore/java/jersey1/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/jersey2-java6/docs/FormatTest.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -43,7 +43,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -85,6 +86,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -431,6 +435,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
   if (this == o) {
@@ -452,12 +482,13 @@ public class FormatTest {
     ObjectUtils.equals(this.date, formatTest.date) &&
     ObjectUtils.equals(this.dateTime, formatTest.dateTime) &&
     ObjectUtils.equals(this.uuid, formatTest.uuid) &&
-    ObjectUtils.equals(this.password, formatTest.password);
+    ObjectUtils.equals(this.password, formatTest.password) &&
+    ObjectUtils.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return ObjectUtils.hashCodeMulti(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return ObjectUtils.hashCodeMulti(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -478,6 +509,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/jersey2-java8/docs/FormatTest.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/jersey2/docs/FormatTest.md
+++ b/samples/client/petstore/java/jersey2/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/native/docs/FormatTest.md
+++ b/samples/client/petstore/java/native/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FormatTest.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -88,6 +88,10 @@ public class FormatTest implements Parcelable {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+  public static final String SERIALIZED_NAME_BIG_DECIMAL = "BigDecimal";
+  @SerializedName(SERIALIZED_NAME_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
+
   public FormatTest() {
   }
 
@@ -409,6 +413,30 @@ public class FormatTest implements Parcelable {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -430,12 +458,13 @@ public class FormatTest implements Parcelable {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -456,6 +485,7 @@ public class FormatTest implements Parcelable {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -486,6 +516,7 @@ public class FormatTest implements Parcelable {
     out.writeValue(dateTime);
     out.writeValue(uuid);
     out.writeValue(password);
+    out.writeValue(bigDecimal);
   }
 
   FormatTest(Parcel in) {
@@ -502,6 +533,7 @@ public class FormatTest implements Parcelable {
     dateTime = (OffsetDateTime)in.readValue(OffsetDateTime.class.getClassLoader());
     uuid = (UUID)in.readValue(UUID.class.getClassLoader());
     password = (String)in.readValue(null);
+    bigDecimal = (BigDecimal)in.readValue(BigDecimal.class.getClassLoader());
   }
 
   public int describeContents() {

--- a/samples/client/petstore/java/okhttp-gson/docs/FormatTest.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,6 +86,10 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+  public static final String SERIALIZED_NAME_BIG_DECIMAL = "BigDecimal";
+  @SerializedName(SERIALIZED_NAME_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
+
 
   public FormatTest integer(Integer integer) {
     
@@ -405,6 +409,30 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -426,12 +454,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -452,6 +481,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/rest-assured/docs/FormatTest.md
+++ b/samples/client/petstore/java/rest-assured/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,6 +86,10 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+  public static final String SERIALIZED_NAME_BIG_DECIMAL = "BigDecimal";
+  @SerializedName(SERIALIZED_NAME_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
+
 
   public FormatTest integer(Integer integer) {
     
@@ -405,6 +409,30 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -426,12 +454,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -452,6 +481,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/resteasy/docs/FormatTest.md
+++ b/samples/client/petstore/java/resteasy/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/resttemplate-withXml/docs/FormatTest.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -46,7 +46,8 @@ import javax.xml.bind.annotation.*;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 @XmlRootElement(name = "FormatTest")
@@ -104,6 +105,10 @@ public class FormatTest {
   @XmlElement(name = "password")
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  @XmlElement(name = "BigDecimal")
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -463,6 +468,33 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JacksonXmlProperty(localName = "BigDecimal")
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -484,12 +516,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -510,6 +543,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/resttemplate/docs/FormatTest.md
+++ b/samples/client/petstore/java/resttemplate/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,6 +86,10 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+  public static final String SERIALIZED_NAME_BIG_DECIMAL = "BigDecimal";
+  @SerializedName(SERIALIZED_NAME_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
+
 
   public FormatTest integer(Integer integer) {
     
@@ -405,6 +409,30 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -426,12 +454,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -452,6 +481,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/retrofit2-play24/docs/FormatTest.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play24/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -46,7 +46,8 @@ import javax.validation.Valid;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -88,6 +89,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -443,6 +447,33 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @Valid
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -464,12 +495,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -490,6 +522,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/retrofit2-play25/docs/FormatTest.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play25/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -46,7 +46,8 @@ import javax.validation.Valid;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -88,6 +89,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -443,6 +447,33 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @Valid
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -464,12 +495,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -490,6 +522,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/retrofit2-play26/docs/FormatTest.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -46,7 +46,8 @@ import javax.validation.Valid;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -88,6 +89,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -443,6 +447,33 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @Valid
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -464,12 +495,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -490,6 +522,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/retrofit2/docs/FormatTest.md
+++ b/samples/client/petstore/java/retrofit2/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,6 +86,10 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+  public static final String SERIALIZED_NAME_BIG_DECIMAL = "BigDecimal";
+  @SerializedName(SERIALIZED_NAME_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
+
 
   public FormatTest integer(Integer integer) {
     
@@ -405,6 +409,30 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -426,12 +454,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -452,6 +481,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/retrofit2rx/docs/FormatTest.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,6 +86,10 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+  public static final String SERIALIZED_NAME_BIG_DECIMAL = "BigDecimal";
+  @SerializedName(SERIALIZED_NAME_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
+
 
   public FormatTest integer(Integer integer) {
     
@@ -405,6 +409,30 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -426,12 +454,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -452,6 +481,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/retrofit2rx2/docs/FormatTest.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -86,6 +86,10 @@ public class FormatTest {
   @SerializedName(SERIALIZED_NAME_PASSWORD)
   private String password;
 
+  public static final String SERIALIZED_NAME_BIG_DECIMAL = "BigDecimal";
+  @SerializedName(SERIALIZED_NAME_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
+
 
   public FormatTest integer(Integer integer) {
     
@@ -405,6 +409,30 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -426,12 +454,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -452,6 +481,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/vertx/docs/FormatTest.md
+++ b/samples/client/petstore/java/vertx/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/java/webclient/docs/FormatTest.md
+++ b/samples/client/petstore/java/webclient/docs/FormatTest.md
@@ -19,6 +19,7 @@ Name | Type | Description | Notes
 **dateTime** | [**OffsetDateTime**](OffsetDateTime.md) |  |  [optional]
 **uuid** | [**UUID**](UUID.md) |  |  [optional]
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  |  [optional]
 
 
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -44,7 +44,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest {
@@ -86,6 +87,9 @@ public class FormatTest {
 
   public static final String JSON_PROPERTY_PASSWORD = "password";
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  private BigDecimal bigDecimal;
 
 
   public FormatTest integer(Integer integer) {
@@ -432,6 +436,32 @@ public class FormatTest {
   }
 
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -453,12 +483,13 @@ public class FormatTest {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, Arrays.hashCode(_byte), binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -479,6 +510,7 @@ public class FormatTest {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/client/petstore/javascript-es6/docs/FormatTest.md
+++ b/samples/client/petstore/javascript-es6/docs/FormatTest.md
@@ -17,6 +17,6 @@ Name | Type | Description | Notes
 **dateTime** | **Date** |  | [optional] 
 **uuid** | **String** |  | [optional] 
 **password** | **String** |  | 
-**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
+**bigDecimal** | **Number** |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-es6/docs/FormatTest.md
+++ b/samples/client/petstore/javascript-es6/docs/FormatTest.md
@@ -17,5 +17,6 @@ Name | Type | Description | Notes
 **dateTime** | **Date** |  | [optional] 
 **uuid** | **String** |  | [optional] 
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-es6/src/model/FormatTest.js
+++ b/samples/client/petstore/javascript-es6/src/model/FormatTest.js
@@ -12,7 +12,6 @@
  */
 
 import ApiClient from '../ApiClient';
-import BigDecimal from './BigDecimal';
 
 /**
  * The FormatTest model module.
@@ -96,7 +95,7 @@ class FormatTest {
                 obj['password'] = ApiClient.convertToType(data['password'], 'String');
             }
             if (data.hasOwnProperty('BigDecimal')) {
-                obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], BigDecimal);
+                obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], 'Number');
             }
         }
         return obj;
@@ -171,7 +170,7 @@ FormatTest.prototype['uuid'] = undefined;
 FormatTest.prototype['password'] = undefined;
 
 /**
- * @member {module:model/BigDecimal} BigDecimal
+ * @member {Number} BigDecimal
  */
 FormatTest.prototype['BigDecimal'] = undefined;
 

--- a/samples/client/petstore/javascript-es6/src/model/FormatTest.js
+++ b/samples/client/petstore/javascript-es6/src/model/FormatTest.js
@@ -12,6 +12,7 @@
  */
 
 import ApiClient from '../ApiClient';
+import BigDecimal from './BigDecimal';
 
 /**
  * The FormatTest model module.
@@ -94,6 +95,9 @@ class FormatTest {
             if (data.hasOwnProperty('password')) {
                 obj['password'] = ApiClient.convertToType(data['password'], 'String');
             }
+            if (data.hasOwnProperty('BigDecimal')) {
+                obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], BigDecimal);
+            }
         }
         return obj;
     }
@@ -165,6 +169,11 @@ FormatTest.prototype['uuid'] = undefined;
  * @member {String} password
  */
 FormatTest.prototype['password'] = undefined;
+
+/**
+ * @member {module:model/BigDecimal} BigDecimal
+ */
+FormatTest.prototype['BigDecimal'] = undefined;
 
 
 

--- a/samples/client/petstore/javascript-promise-es6/docs/FormatTest.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/FormatTest.md
@@ -17,6 +17,6 @@ Name | Type | Description | Notes
 **dateTime** | **Date** |  | [optional] 
 **uuid** | **String** |  | [optional] 
 **password** | **String** |  | 
-**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
+**bigDecimal** | **Number** |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-promise-es6/docs/FormatTest.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/FormatTest.md
@@ -17,5 +17,6 @@ Name | Type | Description | Notes
 **dateTime** | **Date** |  | [optional] 
 **uuid** | **String** |  | [optional] 
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-promise-es6/src/model/FormatTest.js
+++ b/samples/client/petstore/javascript-promise-es6/src/model/FormatTest.js
@@ -12,7 +12,6 @@
  */
 
 import ApiClient from '../ApiClient';
-import BigDecimal from './BigDecimal';
 
 /**
  * The FormatTest model module.
@@ -96,7 +95,7 @@ class FormatTest {
                 obj['password'] = ApiClient.convertToType(data['password'], 'String');
             }
             if (data.hasOwnProperty('BigDecimal')) {
-                obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], BigDecimal);
+                obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], 'Number');
             }
         }
         return obj;
@@ -171,7 +170,7 @@ FormatTest.prototype['uuid'] = undefined;
 FormatTest.prototype['password'] = undefined;
 
 /**
- * @member {module:model/BigDecimal} BigDecimal
+ * @member {Number} BigDecimal
  */
 FormatTest.prototype['BigDecimal'] = undefined;
 

--- a/samples/client/petstore/javascript-promise-es6/src/model/FormatTest.js
+++ b/samples/client/petstore/javascript-promise-es6/src/model/FormatTest.js
@@ -12,6 +12,7 @@
  */
 
 import ApiClient from '../ApiClient';
+import BigDecimal from './BigDecimal';
 
 /**
  * The FormatTest model module.
@@ -94,6 +95,9 @@ class FormatTest {
             if (data.hasOwnProperty('password')) {
                 obj['password'] = ApiClient.convertToType(data['password'], 'String');
             }
+            if (data.hasOwnProperty('BigDecimal')) {
+                obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], BigDecimal);
+            }
         }
         return obj;
     }
@@ -165,6 +169,11 @@ FormatTest.prototype['uuid'] = undefined;
  * @member {String} password
  */
 FormatTest.prototype['password'] = undefined;
+
+/**
+ * @member {module:model/BigDecimal} BigDecimal
+ */
+FormatTest.prototype['BigDecimal'] = undefined;
 
 
 

--- a/samples/client/petstore/javascript-promise/docs/FormatTest.md
+++ b/samples/client/petstore/javascript-promise/docs/FormatTest.md
@@ -17,6 +17,6 @@ Name | Type | Description | Notes
 **dateTime** | **Date** |  | [optional] 
 **uuid** | **String** |  | [optional] 
 **password** | **String** |  | 
-**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
+**bigDecimal** | **Number** |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-promise/docs/FormatTest.md
+++ b/samples/client/petstore/javascript-promise/docs/FormatTest.md
@@ -17,5 +17,6 @@ Name | Type | Description | Notes
 **dateTime** | **Date** |  | [optional] 
 **uuid** | **String** |  | [optional] 
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-promise/src/model/FormatTest.js
+++ b/samples/client/petstore/javascript-promise/src/model/FormatTest.js
@@ -16,18 +16,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['ApiClient'], factory);
+    define(['ApiClient', 'model/BigDecimal'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('../ApiClient'));
+    module.exports = factory(require('../ApiClient'), require('./BigDecimal'));
   } else {
     // Browser globals (root is window)
     if (!root.OpenApiPetstore) {
       root.OpenApiPetstore = {};
     }
-    root.OpenApiPetstore.FormatTest = factory(root.OpenApiPetstore.ApiClient);
+    root.OpenApiPetstore.FormatTest = factory(root.OpenApiPetstore.ApiClient, root.OpenApiPetstore.BigDecimal);
   }
-}(this, function(ApiClient) {
+}(this, function(ApiClient, BigDecimal) {
   'use strict';
 
 
@@ -105,6 +105,9 @@
       if (data.hasOwnProperty('password')) {
         obj['password'] = ApiClient.convertToType(data['password'], 'String');
       }
+      if (data.hasOwnProperty('BigDecimal')) {
+        obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], BigDecimal);
+      }
     }
     return obj;
   }
@@ -161,6 +164,10 @@
    * @member {String} password
    */
   exports.prototype['password'] = undefined;
+  /**
+   * @member {module:model/BigDecimal} BigDecimal
+   */
+  exports.prototype['BigDecimal'] = undefined;
 
 
 

--- a/samples/client/petstore/javascript-promise/src/model/FormatTest.js
+++ b/samples/client/petstore/javascript-promise/src/model/FormatTest.js
@@ -16,18 +16,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['ApiClient', 'model/BigDecimal'], factory);
+    define(['ApiClient'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('../ApiClient'), require('./BigDecimal'));
+    module.exports = factory(require('../ApiClient'));
   } else {
     // Browser globals (root is window)
     if (!root.OpenApiPetstore) {
       root.OpenApiPetstore = {};
     }
-    root.OpenApiPetstore.FormatTest = factory(root.OpenApiPetstore.ApiClient, root.OpenApiPetstore.BigDecimal);
+    root.OpenApiPetstore.FormatTest = factory(root.OpenApiPetstore.ApiClient);
   }
-}(this, function(ApiClient, BigDecimal) {
+}(this, function(ApiClient) {
   'use strict';
 
 
@@ -106,7 +106,7 @@
         obj['password'] = ApiClient.convertToType(data['password'], 'String');
       }
       if (data.hasOwnProperty('BigDecimal')) {
-        obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], BigDecimal);
+        obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], 'Number');
       }
     }
     return obj;
@@ -165,7 +165,7 @@
    */
   exports.prototype['password'] = undefined;
   /**
-   * @member {module:model/BigDecimal} BigDecimal
+   * @member {Number} BigDecimal
    */
   exports.prototype['BigDecimal'] = undefined;
 

--- a/samples/client/petstore/javascript/docs/FormatTest.md
+++ b/samples/client/petstore/javascript/docs/FormatTest.md
@@ -17,6 +17,6 @@ Name | Type | Description | Notes
 **dateTime** | **Date** |  | [optional] 
 **uuid** | **String** |  | [optional] 
 **password** | **String** |  | 
-**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
+**bigDecimal** | **Number** |  | [optional] 
 
 

--- a/samples/client/petstore/javascript/docs/FormatTest.md
+++ b/samples/client/petstore/javascript/docs/FormatTest.md
@@ -17,5 +17,6 @@ Name | Type | Description | Notes
 **dateTime** | **Date** |  | [optional] 
 **uuid** | **String** |  | [optional] 
 **password** | **String** |  | 
+**bigDecimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 

--- a/samples/client/petstore/javascript/src/model/FormatTest.js
+++ b/samples/client/petstore/javascript/src/model/FormatTest.js
@@ -16,18 +16,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['ApiClient'], factory);
+    define(['ApiClient', 'model/BigDecimal'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('../ApiClient'));
+    module.exports = factory(require('../ApiClient'), require('./BigDecimal'));
   } else {
     // Browser globals (root is window)
     if (!root.OpenApiPetstore) {
       root.OpenApiPetstore = {};
     }
-    root.OpenApiPetstore.FormatTest = factory(root.OpenApiPetstore.ApiClient);
+    root.OpenApiPetstore.FormatTest = factory(root.OpenApiPetstore.ApiClient, root.OpenApiPetstore.BigDecimal);
   }
-}(this, function(ApiClient) {
+}(this, function(ApiClient, BigDecimal) {
   'use strict';
 
 
@@ -105,6 +105,9 @@
       if (data.hasOwnProperty('password')) {
         obj['password'] = ApiClient.convertToType(data['password'], 'String');
       }
+      if (data.hasOwnProperty('BigDecimal')) {
+        obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], BigDecimal);
+      }
     }
     return obj;
   }
@@ -161,6 +164,10 @@
    * @member {String} password
    */
   exports.prototype['password'] = undefined;
+  /**
+   * @member {module:model/BigDecimal} BigDecimal
+   */
+  exports.prototype['BigDecimal'] = undefined;
 
 
 

--- a/samples/client/petstore/javascript/src/model/FormatTest.js
+++ b/samples/client/petstore/javascript/src/model/FormatTest.js
@@ -16,18 +16,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['ApiClient', 'model/BigDecimal'], factory);
+    define(['ApiClient'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('../ApiClient'), require('./BigDecimal'));
+    module.exports = factory(require('../ApiClient'));
   } else {
     // Browser globals (root is window)
     if (!root.OpenApiPetstore) {
       root.OpenApiPetstore = {};
     }
-    root.OpenApiPetstore.FormatTest = factory(root.OpenApiPetstore.ApiClient, root.OpenApiPetstore.BigDecimal);
+    root.OpenApiPetstore.FormatTest = factory(root.OpenApiPetstore.ApiClient);
   }
-}(this, function(ApiClient, BigDecimal) {
+}(this, function(ApiClient) {
   'use strict';
 
 
@@ -106,7 +106,7 @@
         obj['password'] = ApiClient.convertToType(data['password'], 'String');
       }
       if (data.hasOwnProperty('BigDecimal')) {
-        obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], BigDecimal);
+        obj['BigDecimal'] = ApiClient.convertToType(data['BigDecimal'], 'Number');
       }
     }
     return obj;
@@ -165,7 +165,7 @@
    */
   exports.prototype['password'] = undefined;
   /**
-   * @member {module:model/BigDecimal} BigDecimal
+   * @member {Number} BigDecimal
    */
   exports.prototype['BigDecimal'] = undefined;
 

--- a/samples/client/petstore/perl/docs/FormatTest.md
+++ b/samples/client/petstore/perl/docs/FormatTest.md
@@ -21,6 +21,7 @@ Name | Type | Description | Notes
 **date_time** | **DateTime** |  | [optional] 
 **uuid** | **string** |  | [optional] 
 **password** | **string** |  | 
+**big_decimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Object/FormatTest.pm
@@ -30,6 +30,7 @@ use Log::Any qw($log);
 use Date::Parse;
 use DateTime;
 
+use WWW::OpenAPIClient::Object::BigDecimal;
 
 use base ("Class::Accessor", "Class::Data::Inheritable");
 
@@ -252,6 +253,13 @@ __PACKAGE__->method_documentation({
         format => '',
         read_only => '',
             },
+    'big_decimal' => {
+        datatype => 'BigDecimal',
+        base_name => 'BigDecimal',
+        description => '',
+        format => '',
+        read_only => '',
+            },
 });
 
 __PACKAGE__->openapi_types( {
@@ -267,7 +275,8 @@ __PACKAGE__->openapi_types( {
     'date' => 'DateTime',
     'date_time' => 'DateTime',
     'uuid' => 'string',
-    'password' => 'string'
+    'password' => 'string',
+    'big_decimal' => 'BigDecimal'
 } );
 
 __PACKAGE__->attribute_map( {
@@ -283,7 +292,8 @@ __PACKAGE__->attribute_map( {
     'date' => 'date',
     'date_time' => 'dateTime',
     'uuid' => 'uuid',
-    'password' => 'password'
+    'password' => 'password',
+    'big_decimal' => 'BigDecimal'
 } );
 
 __PACKAGE__->mk_accessors(keys %{__PACKAGE__->attribute_map});

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/FormatTest.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/FormatTest.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **date_time** | [**\DateTime**](\DateTime.md) |  | [optional] 
 **uuid** | **string** |  | [optional] 
 **password** | **string** |  | 
+**big_decimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -69,7 +69,8 @@ class FormatTest implements ModelInterface, ArrayAccess
         'date' => '\DateTime',
         'date_time' => '\DateTime',
         'uuid' => 'string',
-        'password' => 'string'
+        'password' => 'string',
+        'big_decimal' => 'BigDecimal'
     ];
 
     /**
@@ -90,7 +91,8 @@ class FormatTest implements ModelInterface, ArrayAccess
         'date' => 'date',
         'date_time' => 'date-time',
         'uuid' => 'uuid',
-        'password' => 'password'
+        'password' => 'password',
+        'big_decimal' => 'number'
     ];
 
     /**
@@ -132,7 +134,8 @@ class FormatTest implements ModelInterface, ArrayAccess
         'date' => 'date',
         'date_time' => 'dateTime',
         'uuid' => 'uuid',
-        'password' => 'password'
+        'password' => 'password',
+        'big_decimal' => 'BigDecimal'
     ];
 
     /**
@@ -153,7 +156,8 @@ class FormatTest implements ModelInterface, ArrayAccess
         'date' => 'setDate',
         'date_time' => 'setDateTime',
         'uuid' => 'setUuid',
-        'password' => 'setPassword'
+        'password' => 'setPassword',
+        'big_decimal' => 'setBigDecimal'
     ];
 
     /**
@@ -174,7 +178,8 @@ class FormatTest implements ModelInterface, ArrayAccess
         'date' => 'getDate',
         'date_time' => 'getDateTime',
         'uuid' => 'getUuid',
-        'password' => 'getPassword'
+        'password' => 'getPassword',
+        'big_decimal' => 'getBigDecimal'
     ];
 
     /**
@@ -250,6 +255,7 @@ class FormatTest implements ModelInterface, ArrayAccess
         $this->container['date_time'] = isset($data['date_time']) ? $data['date_time'] : null;
         $this->container['uuid'] = isset($data['uuid']) ? $data['uuid'] : null;
         $this->container['password'] = isset($data['password']) ? $data['password'] : null;
+        $this->container['big_decimal'] = isset($data['big_decimal']) ? $data['big_decimal'] : null;
     }
 
     /**
@@ -709,6 +715,30 @@ class FormatTest implements ModelInterface, ArrayAccess
         }
 
         $this->container['password'] = $password;
+
+        return $this;
+    }
+
+    /**
+     * Gets big_decimal
+     *
+     * @return BigDecimal|null
+     */
+    public function getBigDecimal()
+    {
+        return $this->container['big_decimal'];
+    }
+
+    /**
+     * Sets big_decimal
+     *
+     * @param BigDecimal|null $big_decimal big_decimal
+     *
+     * @return $this
+     */
+    public function setBigDecimal($big_decimal)
+    {
+        $this->container['big_decimal'] = $big_decimal;
 
         return $this;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/FormatTestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/FormatTestTest.php
@@ -168,4 +168,11 @@ class FormatTestTest extends TestCase
     public function testPropertyPassword()
     {
     }
+
+    /**
+     * Test attribute "big_decimal"
+     */
+    public function testPropertyBigDecimal()
+    {
+    }
 }

--- a/samples/client/petstore/python-asyncio/docs/FormatTest.md
+++ b/samples/client/petstore/python-asyncio/docs/FormatTest.md
@@ -16,6 +16,7 @@ Name | Type | Description | Notes
 **date_time** | **datetime** |  | [optional] 
 **uuid** | **str** |  | [optional] 
 **password** | **str** |  | 
+**big_decimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-asyncio/petstore_api/models/format_test.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/models/format_test.py
@@ -43,7 +43,8 @@ class FormatTest(object):
         'date': 'date',
         'date_time': 'datetime',
         'uuid': 'str',
-        'password': 'str'
+        'password': 'str',
+        'big_decimal': 'BigDecimal'
     }
 
     attribute_map = {
@@ -59,10 +60,11 @@ class FormatTest(object):
         'date': 'date',
         'date_time': 'dateTime',
         'uuid': 'uuid',
-        'password': 'password'
+        'password': 'password',
+        'big_decimal': 'BigDecimal'
     }
 
-    def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None):  # noqa: E501
+    def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None, big_decimal=None):  # noqa: E501
         """FormatTest - a model defined in OpenAPI"""  # noqa: E501
 
         self._integer = None
@@ -78,6 +80,7 @@ class FormatTest(object):
         self._date_time = None
         self._uuid = None
         self._password = None
+        self._big_decimal = None
         self.discriminator = None
 
         if integer is not None:
@@ -102,6 +105,8 @@ class FormatTest(object):
         if uuid is not None:
             self.uuid = uuid
         self.password = password
+        if big_decimal is not None:
+            self.big_decimal = big_decimal
 
     @property
     def integer(self):
@@ -411,6 +416,27 @@ class FormatTest(object):
             raise ValueError("Invalid value for `password`, length must be greater than or equal to `10`")  # noqa: E501
 
         self._password = password
+
+    @property
+    def big_decimal(self):
+        """Gets the big_decimal of this FormatTest.  # noqa: E501
+
+
+        :return: The big_decimal of this FormatTest.  # noqa: E501
+        :rtype: BigDecimal
+        """
+        return self._big_decimal
+
+    @big_decimal.setter
+    def big_decimal(self, big_decimal):
+        """Sets the big_decimal of this FormatTest.
+
+
+        :param big_decimal: The big_decimal of this FormatTest.  # noqa: E501
+        :type: BigDecimal
+        """
+
+        self._big_decimal = big_decimal
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/client/petstore/python-tornado/docs/FormatTest.md
+++ b/samples/client/petstore/python-tornado/docs/FormatTest.md
@@ -16,6 +16,7 @@ Name | Type | Description | Notes
 **date_time** | **datetime** |  | [optional] 
 **uuid** | **str** |  | [optional] 
 **password** | **str** |  | 
+**big_decimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-tornado/petstore_api/models/format_test.py
+++ b/samples/client/petstore/python-tornado/petstore_api/models/format_test.py
@@ -43,7 +43,8 @@ class FormatTest(object):
         'date': 'date',
         'date_time': 'datetime',
         'uuid': 'str',
-        'password': 'str'
+        'password': 'str',
+        'big_decimal': 'BigDecimal'
     }
 
     attribute_map = {
@@ -59,10 +60,11 @@ class FormatTest(object):
         'date': 'date',
         'date_time': 'dateTime',
         'uuid': 'uuid',
-        'password': 'password'
+        'password': 'password',
+        'big_decimal': 'BigDecimal'
     }
 
-    def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None):  # noqa: E501
+    def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None, big_decimal=None):  # noqa: E501
         """FormatTest - a model defined in OpenAPI"""  # noqa: E501
 
         self._integer = None
@@ -78,6 +80,7 @@ class FormatTest(object):
         self._date_time = None
         self._uuid = None
         self._password = None
+        self._big_decimal = None
         self.discriminator = None
 
         if integer is not None:
@@ -102,6 +105,8 @@ class FormatTest(object):
         if uuid is not None:
             self.uuid = uuid
         self.password = password
+        if big_decimal is not None:
+            self.big_decimal = big_decimal
 
     @property
     def integer(self):
@@ -411,6 +416,27 @@ class FormatTest(object):
             raise ValueError("Invalid value for `password`, length must be greater than or equal to `10`")  # noqa: E501
 
         self._password = password
+
+    @property
+    def big_decimal(self):
+        """Gets the big_decimal of this FormatTest.  # noqa: E501
+
+
+        :return: The big_decimal of this FormatTest.  # noqa: E501
+        :rtype: BigDecimal
+        """
+        return self._big_decimal
+
+    @big_decimal.setter
+    def big_decimal(self, big_decimal):
+        """Sets the big_decimal of this FormatTest.
+
+
+        :param big_decimal: The big_decimal of this FormatTest.  # noqa: E501
+        :type: BigDecimal
+        """
+
+        self._big_decimal = big_decimal
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/client/petstore/python/docs/FormatTest.md
+++ b/samples/client/petstore/python/docs/FormatTest.md
@@ -16,6 +16,7 @@ Name | Type | Description | Notes
 **date_time** | **datetime** |  | [optional] 
 **uuid** | **str** |  | [optional] 
 **password** | **str** |  | 
+**big_decimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/client/petstore/python/petstore_api/models/format_test.py
@@ -43,7 +43,8 @@ class FormatTest(object):
         'date': 'date',
         'date_time': 'datetime',
         'uuid': 'str',
-        'password': 'str'
+        'password': 'str',
+        'big_decimal': 'BigDecimal'
     }
 
     attribute_map = {
@@ -59,10 +60,11 @@ class FormatTest(object):
         'date': 'date',
         'date_time': 'dateTime',
         'uuid': 'uuid',
-        'password': 'password'
+        'password': 'password',
+        'big_decimal': 'BigDecimal'
     }
 
-    def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None):  # noqa: E501
+    def __init__(self, integer=None, int32=None, int64=None, number=None, float=None, double=None, string=None, byte=None, binary=None, date=None, date_time=None, uuid=None, password=None, big_decimal=None):  # noqa: E501
         """FormatTest - a model defined in OpenAPI"""  # noqa: E501
 
         self._integer = None
@@ -78,6 +80,7 @@ class FormatTest(object):
         self._date_time = None
         self._uuid = None
         self._password = None
+        self._big_decimal = None
         self.discriminator = None
 
         if integer is not None:
@@ -102,6 +105,8 @@ class FormatTest(object):
         if uuid is not None:
             self.uuid = uuid
         self.password = password
+        if big_decimal is not None:
+            self.big_decimal = big_decimal
 
     @property
     def integer(self):
@@ -411,6 +416,27 @@ class FormatTest(object):
             raise ValueError("Invalid value for `password`, length must be greater than or equal to `10`")  # noqa: E501
 
         self._password = password
+
+    @property
+    def big_decimal(self):
+        """Gets the big_decimal of this FormatTest.  # noqa: E501
+
+
+        :return: The big_decimal of this FormatTest.  # noqa: E501
+        :rtype: BigDecimal
+        """
+        return self._big_decimal
+
+    @big_decimal.setter
+    def big_decimal(self, big_decimal):
+        """Sets the big_decimal of this FormatTest.
+
+
+        :param big_decimal: The big_decimal of this FormatTest.  # noqa: E501
+        :type: BigDecimal
+        """
+
+        self._big_decimal = big_decimal
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/client/petstore/ruby/docs/FormatTest.md
+++ b/samples/client/petstore/ruby/docs/FormatTest.md
@@ -17,6 +17,7 @@ Name | Type | Description | Notes
 **date_time** | **DateTime** |  | [optional] 
 **uuid** | **String** |  | [optional] 
 **password** | **String** |  | 
+**big_decimal** | [**BigDecimal**](BigDecimal.md) |  | [optional] 
 
 ## Code Sample
 
@@ -35,7 +36,8 @@ instance = Petstore::FormatTest.new(integer: null,
                                  date: null,
                                  date_time: null,
                                  uuid: 72f98069-206d-4f12-9f12-3d1e525a8e84,
-                                 password: null)
+                                 password: null,
+                                 big_decimal: null)
 ```
 
 

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -40,6 +40,8 @@ module Petstore
 
     attr_accessor :password
 
+    attr_accessor :big_decimal
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -55,7 +57,8 @@ module Petstore
         :'date' => :'date',
         :'date_time' => :'dateTime',
         :'uuid' => :'uuid',
-        :'password' => :'password'
+        :'password' => :'password',
+        :'big_decimal' => :'BigDecimal'
       }
     end
 
@@ -74,7 +77,8 @@ module Petstore
         :'date' => :'Date',
         :'date_time' => :'DateTime',
         :'uuid' => :'String',
-        :'password' => :'String'
+        :'password' => :'String',
+        :'big_decimal' => :'BigDecimal'
       }
     end
 
@@ -143,6 +147,10 @@ module Petstore
 
       if attributes.key?(:'password')
         self.password = attributes[:'password']
+      end
+
+      if attributes.key?(:'big_decimal')
+        self.big_decimal = attributes[:'big_decimal']
       end
     end
 
@@ -386,7 +394,8 @@ module Petstore
           date == o.date &&
           date_time == o.date_time &&
           uuid == o.uuid &&
-          password == o.password
+          password == o.password &&
+          big_decimal == o.big_decimal
     end
 
     # @see the `==` method
@@ -398,7 +407,7 @@ module Petstore
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [integer, int32, int64, number, float, double, string, byte, binary, date, date_time, uuid, password].hash
+      [integer, int32, int64, number, float, double, string, byte, binary, date, date_time, uuid, password, big_decimal].hash
     end
 
     # Builds the object from hash

--- a/samples/client/petstore/ruby/spec/models/format_test_spec.rb
+++ b/samples/client/petstore/ruby/spec/models/format_test_spec.rb
@@ -110,4 +110,10 @@ describe 'FormatTest' do
     end
   end
 
+  describe 'test attribute "big_decimal"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
 end

--- a/samples/schema/petstore/mysql/mysql_schema.sql
+++ b/samples/schema/petstore/mysql/mysql_schema.sql
@@ -273,7 +273,8 @@ CREATE TABLE IF NOT EXISTS `format_test` (
   `date` DATE NOT NULL,
   `dateTime` DATETIME DEFAULT NULL,
   `uuid` TEXT DEFAULT NULL,
-  `password` VARCHAR(64) NOT NULL
+  `password` VARCHAR(64) NOT NULL,
+  `BigDecimal` DECIMAL(20, 9) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --

--- a/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/java-msf4j/src/gen/java/org/openapitools/model/FormatTest.java
@@ -54,6 +54,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -298,6 +301,24 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @ApiModelProperty(value = "")
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -320,12 +341,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -346,6 +368,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/FormatTest.java
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/app/apimodels/FormatTest.java
@@ -55,6 +55,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -308,6 +311,24 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+   /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @Valid
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -330,12 +351,13 @@ public class FormatTest   {
         Objects.equals(date, formatTest.date) &&
         Objects.equals(dateTime, formatTest.dateTime) &&
         Objects.equals(uuid, formatTest.uuid) &&
-        Objects.equals(password, formatTest.password);
+        Objects.equals(password, formatTest.password) &&
+        Objects.equals(bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @SuppressWarnings("StringBufferReplaceableByString")
@@ -357,6 +379,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/java-play-framework-fake-endpoints/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/public/openapi.json
@@ -2021,6 +2021,10 @@
             "maxLength" : 64,
             "minLength" : 10,
             "type" : "string"
+          },
+          "BigDecimal" : {
+            "format" : "number",
+            "type" : "string"
           }
         },
         "required" : [ "byte", "date", "number", "password" ],

--- a/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-cxf/src/gen/java/org/openapitools/model/FormatTest.java
@@ -59,6 +59,9 @@ public class FormatTest  {
 
   @ApiModelProperty(required = true, value = "")
   private String password;
+
+  @ApiModelProperty(value = "")
+  private BigDecimal bigDecimal;
  /**
    * Get integer
    * minimum: 10
@@ -307,6 +310,24 @@ public class FormatTest  {
     return this;
   }
 
+ /**
+   * Get bigDecimal
+   * @return bigDecimal
+  **/
+  @JsonProperty("BigDecimal")
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
 
   @Override
   public String toString() {
@@ -326,6 +347,7 @@ public class FormatTest  {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/model/FormatTest.java
@@ -44,7 +44,8 @@ import javax.validation.Valid;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest  implements Serializable {
@@ -99,6 +100,10 @@ public class FormatTest  implements Serializable {
   public static final String JSON_PROPERTY_PASSWORD = "password";
   @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
 
   public FormatTest integer(Integer integer) {
     this.integer = integer;
@@ -370,6 +375,26 @@ public class FormatTest  implements Serializable {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+   **/
+  @JsonProperty("BigDecimal")
+  @ApiModelProperty(value = "")
+  
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -392,12 +417,13 @@ public class FormatTest  implements Serializable {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -419,6 +445,7 @@ public class FormatTest  implements Serializable {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
@@ -34,6 +34,7 @@ public class FormatTest  implements Serializable {
   private @Valid Date dateTime;
   private @Valid UUID uuid;
   private @Valid String password;
+  private @Valid BigDecimal bigDecimal;
 
   /**
    * minimum: 10
@@ -270,6 +271,23 @@ public class FormatTest  implements Serializable {
     this.password = password;
   }
 
+  /**
+   **/
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("BigDecimal")
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -292,12 +310,13 @@ public class FormatTest  implements Serializable {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -318,6 +337,7 @@ public class FormatTest  implements Serializable {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec-interface/src/main/openapi/openapi.yaml
@@ -1626,6 +1626,9 @@ components:
           maxLength: 64
           minLength: 10
           type: string
+        BigDecimal:
+          format: number
+          type: string
       required:
       - byte
       - date

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
@@ -34,6 +34,7 @@ public class FormatTest  implements Serializable {
   private @Valid Date dateTime;
   private @Valid UUID uuid;
   private @Valid String password;
+  private @Valid BigDecimal bigDecimal;
 
   /**
    * minimum: 10
@@ -270,6 +271,23 @@ public class FormatTest  implements Serializable {
     this.password = password;
   }
 
+  /**
+   **/
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  
+  @ApiModelProperty(value = "")
+  @JsonProperty("BigDecimal")
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -292,12 +310,13 @@ public class FormatTest  implements Serializable {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -318,6 +337,7 @@ public class FormatTest  implements Serializable {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec/src/main/openapi/openapi.yaml
@@ -1626,6 +1626,9 @@ components:
           maxLength: 64
           minLength: 10
           type: string
+        BigDecimal:
+          format: number
+          type: string
       required:
       - byte
       - date

--- a/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey1-useTags/src/gen/java/org/openapitools/model/FormatTest.java
@@ -42,7 +42,8 @@ import javax.validation.Valid;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest   {
@@ -97,6 +98,10 @@ public class FormatTest   {
   public static final String JSON_PROPERTY_PASSWORD = "password";
   @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
 
   public FormatTest integer(Integer integer) {
     this.integer = integer;
@@ -368,6 +373,26 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+   **/
+  @JsonProperty("BigDecimal")
+  @ApiModelProperty(value = "")
+  
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -390,12 +415,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -417,6 +443,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey1/src/gen/java/org/openapitools/model/FormatTest.java
@@ -42,7 +42,8 @@ import javax.validation.Valid;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest   {
@@ -97,6 +98,10 @@ public class FormatTest   {
   public static final String JSON_PROPERTY_PASSWORD = "password";
   @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
 
   public FormatTest integer(Integer integer) {
     this.integer = integer;
@@ -368,6 +373,26 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+   **/
+  @JsonProperty("BigDecimal")
+  @ApiModelProperty(value = "")
+  
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -390,12 +415,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -417,6 +443,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/model/FormatTest.java
@@ -42,7 +42,8 @@ import javax.validation.Valid;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest   {
@@ -97,6 +98,10 @@ public class FormatTest   {
   public static final String JSON_PROPERTY_PASSWORD = "password";
   @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
 
   public FormatTest integer(Integer integer) {
     this.integer = integer;
@@ -368,6 +373,26 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+   **/
+  @JsonProperty("BigDecimal")
+  @ApiModelProperty(value = "")
+  
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -390,12 +415,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -417,6 +443,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/model/FormatTest.java
@@ -42,7 +42,8 @@ import javax.validation.Valid;
   FormatTest.JSON_PROPERTY_DATE,
   FormatTest.JSON_PROPERTY_DATE_TIME,
   FormatTest.JSON_PROPERTY_UUID,
-  FormatTest.JSON_PROPERTY_PASSWORD
+  FormatTest.JSON_PROPERTY_PASSWORD,
+  FormatTest.JSON_PROPERTY_BIG_DECIMAL
 })
 
 public class FormatTest   {
@@ -97,6 +98,10 @@ public class FormatTest   {
   public static final String JSON_PROPERTY_PASSWORD = "password";
   @JsonProperty(JSON_PROPERTY_PASSWORD)
   private String password;
+
+  public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  @JsonProperty(JSON_PROPERTY_BIG_DECIMAL)
+  private BigDecimal bigDecimal;
 
   public FormatTest integer(Integer integer) {
     this.integer = integer;
@@ -368,6 +373,26 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+   **/
+  @JsonProperty("BigDecimal")
+  @ApiModelProperty(value = "")
+  
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -390,12 +415,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
 
@@ -417,6 +443,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/php-slim/lib/Model/FormatTest.php
+++ b/samples/server/petstore/php-slim/lib/Model/FormatTest.php
@@ -63,4 +63,7 @@ class FormatTest
     
     /** @var string $password */
     private $password;
+    
+    /** @var BigDecimal $bigDecimal */
+    private $bigDecimal;
 }

--- a/samples/server/petstore/php-ze-ph/src/App/DTO/FormatTest.php
+++ b/samples/server/petstore/php-ze-ph/src/App/DTO/FormatTest.php
@@ -103,4 +103,11 @@ class FormatTest
      * @var string
      */
     public $password;
+    /**
+     * @DTA\Data(field="BigDecimal", nullable=true)
+     * @DTA\Strategy(name="Object", options={"type":BigDecimal::class})
+     * @DTA\Validator(name="Dictionary", options={"type":BigDecimal::class})
+     * @var BigDecimal
+     */
+    public $big_decimal;
 }

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
@@ -1626,6 +1626,9 @@ components:
           maxLength: 64
           minLength: 10
           type: string
+        BigDecimal:
+          format: number
+          type: string
       required:
       - byte
       - date

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FormatTest.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/FormatTest.java
@@ -58,6 +58,9 @@ public class FormatTest   {
   @JsonProperty("password")
   private String password;
 
+  @JsonProperty("BigDecimal")
+  private BigDecimal bigDecimal;
+
   public FormatTest integer(Integer integer) {
     this.integer = integer;
     return this;
@@ -337,6 +340,27 @@ public class FormatTest   {
     this.password = password;
   }
 
+  public FormatTest bigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+    return this;
+  }
+
+  /**
+   * Get bigDecimal
+   * @return bigDecimal
+  */
+  @ApiModelProperty(value = "")
+
+  @Valid
+
+  public BigDecimal getBigDecimal() {
+    return bigDecimal;
+  }
+
+  public void setBigDecimal(BigDecimal bigDecimal) {
+    this.bigDecimal = bigDecimal;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -359,12 +383,13 @@ public class FormatTest   {
         Objects.equals(this.date, formatTest.date) &&
         Objects.equals(this.dateTime, formatTest.dateTime) &&
         Objects.equals(this.uuid, formatTest.uuid) &&
-        Objects.equals(this.password, formatTest.password);
+        Objects.equals(this.password, formatTest.password) &&
+        Objects.equals(this.bigDecimal, formatTest.bigDecimal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password);
+    return Objects.hash(integer, int32, int64, number, _float, _double, string, _byte, binary, date, dateTime, uuid, password, bigDecimal);
   }
 
   @Override
@@ -385,6 +410,7 @@ public class FormatTest   {
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
+    sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Better tests for string (number)

The new mapping for `type: string, format: number` may be changed to something else (other primitive types or class) without further notice in the future.

cc @OpenAPITools/generator-core-team 
