### PR TITLE
[typescript][node]: Add accept header if produces is not empty

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -135,7 +135,13 @@ export class {{classname}} {
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
 {{#hasProduces}}
-        localVarHeaderParams.Accept = '{{#produces}}{{{mediaType}}}{{#hasMore}},{{/hasMore}}{{/produces}}';
+        const produces = [{{#produces}}'{{{mediaType}}}'{{#hasMore}}, {{/hasMore}}{{/produces}}];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
 {{/hasProduces}}
         let localVarFormParams: any = {};
 

--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -134,6 +134,9 @@ export class {{classname}} {
             .replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+{{#hasProduces}}
+        localVarHeaderParams.Accept = '{{#produces}}{{{mediaType}}}{{#hasMore}},{{/hasMore}}{{/produces}}';
+{{/hasProduces}}
         let localVarFormParams: any = {};
 
 {{#allParams}}

--- a/samples/client/petstore/typescript-node/default/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/petApi.ts
@@ -205,6 +205,7 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'status' is not null or undefined
@@ -266,6 +267,7 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'tags' is not null or undefined
@@ -328,6 +330,7 @@ export class PetApi {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
@@ -512,6 +515,7 @@ export class PetApi {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined

--- a/samples/client/petstore/typescript-node/default/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/petApi.ts
@@ -205,7 +205,13 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'status' is not null or undefined
@@ -267,7 +273,13 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'tags' is not null or undefined
@@ -330,7 +342,13 @@ export class PetApi {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
@@ -515,7 +533,13 @@ export class PetApi {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/json';
+        const produces = ['application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined

--- a/samples/client/petstore/typescript-node/default/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/storeApi.ts
@@ -137,7 +137,13 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/json';
+        const produces = ['application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         (<any>Object).assign(localVarHeaderParams, options.headers);
@@ -191,7 +197,13 @@ export class StoreApi {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'orderId' is not null or undefined
@@ -247,7 +259,13 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined

--- a/samples/client/petstore/typescript-node/default/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/storeApi.ts
@@ -137,6 +137,7 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/json';
         let localVarFormParams: any = {};
 
         (<any>Object).assign(localVarHeaderParams, options.headers);
@@ -190,6 +191,7 @@ export class StoreApi {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'orderId' is not null or undefined
@@ -245,6 +247,7 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined

--- a/samples/client/petstore/typescript-node/default/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/userApi.ts
@@ -301,6 +301,7 @@ export class UserApi {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
@@ -357,6 +358,7 @@ export class UserApi {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined

--- a/samples/client/petstore/typescript-node/default/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/userApi.ts
@@ -301,7 +301,13 @@ export class UserApi {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
@@ -358,7 +364,13 @@ export class UserApi {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined

--- a/samples/client/petstore/typescript-node/npm/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/petApi.ts
@@ -205,6 +205,7 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'status' is not null or undefined
@@ -266,6 +267,7 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'tags' is not null or undefined
@@ -328,6 +330,7 @@ export class PetApi {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
@@ -512,6 +515,7 @@ export class PetApi {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined

--- a/samples/client/petstore/typescript-node/npm/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/petApi.ts
@@ -205,7 +205,13 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/findByStatus';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'status' is not null or undefined
@@ -267,7 +273,13 @@ export class PetApi {
         const localVarPath = this.basePath + '/pet/findByTags';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'tags' is not null or undefined
@@ -330,7 +342,13 @@ export class PetApi {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined
@@ -515,7 +533,13 @@ export class PetApi {
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/json';
+        const produces = ['application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'petId' is not null or undefined

--- a/samples/client/petstore/typescript-node/npm/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/storeApi.ts
@@ -137,7 +137,13 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/json';
+        const produces = ['application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         (<any>Object).assign(localVarHeaderParams, options.headers);
@@ -191,7 +197,13 @@ export class StoreApi {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'orderId' is not null or undefined
@@ -247,7 +259,13 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined

--- a/samples/client/petstore/typescript-node/npm/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/storeApi.ts
@@ -137,6 +137,7 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/inventory';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/json';
         let localVarFormParams: any = {};
 
         (<any>Object).assign(localVarHeaderParams, options.headers);
@@ -190,6 +191,7 @@ export class StoreApi {
             .replace('{' + 'orderId' + '}', encodeURIComponent(String(orderId)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'orderId' is not null or undefined
@@ -245,6 +247,7 @@ export class StoreApi {
         const localVarPath = this.basePath + '/store/order';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'body' is not null or undefined

--- a/samples/client/petstore/typescript-node/npm/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/userApi.ts
@@ -301,6 +301,7 @@ export class UserApi {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
@@ -357,6 +358,7 @@ export class UserApi {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        localVarHeaderParams.Accept = 'application/xml,application/json';
         let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined

--- a/samples/client/petstore/typescript-node/npm/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/userApi.ts
@@ -301,7 +301,13 @@ export class UserApi {
             .replace('{' + 'username' + '}', encodeURIComponent(String(username)));
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined
@@ -358,7 +364,13 @@ export class UserApi {
         const localVarPath = this.basePath + '/user/login';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
-        localVarHeaderParams.Accept = 'application/xml,application/json';
+        const produces = ['application/xml', 'application/json'];
+        // give precedence to 'application/json'
+        if (produces.indexOf('application/json') >= 0) {
+            localVarHeaderParams.Accept = 'application/json';
+        } else {
+            localVarHeaderParams.Accept = produces.join(',');
+        }
         let localVarFormParams: any = {};
 
         // verify required parameter 'username' is not null or undefined


### PR DESCRIPTION
Uses the correct Accept media types as specified in the OpenApi
specifications.

relates to #3944

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@akehir @macjohnny
### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

