### PR TITLE
typescript-node: form data file

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptNodeClientCodegen.java
@@ -261,13 +261,12 @@ public class TypeScriptNodeClientCodegen extends AbstractTypeScriptClientCodegen
         if (isLanguagePrimitive(openAPIType) || isLanguageGenericType(openAPIType)) {
             return openAPIType;
         }
-        applyLocalTypeMapping(openAPIType);
-        return openAPIType;
+        return applyLocalTypeMapping(openAPIType);
     }
 
     private String applyLocalTypeMapping(String type) {
         if (typeMapping.containsKey(type)) {
-            type = typeMapping.get(type);
+            return typeMapping.get(type);
         }
         return type;
     }

--- a/modules/openapi-generator/src/main/resources/typescript-node/api-all.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-all.mustache
@@ -8,12 +8,25 @@ import { {{ classname }} } from './{{ classFilename }}';
 export * from './{{ classFilename }}Interface'
 {{/withInterfaces}}
 {{/apis}}
-import http = require('http');
+import * as fs from 'fs';
+import * as http from 'http';
+
 export class HttpError extends Error {
     constructor (public response: http.{{#supportsES6}}IncomingMessage{{/supportsES6}}{{^supportsES6}}ClientResponse{{/supportsES6}}, public body: any, public statusCode?: number) {
         super('HTTP request failed');
         this.name = 'HttpError';
     }
 }
+
+export interface RequestDetailedFile {
+    value: Buffer;
+    options?: {
+        filename?: string;
+        contentType?: string;
+    }
+}
+
+export type RequestFile = string | Buffer | fs.ReadStream | RequestDetailedFile;
+
 export const APIS = [{{#apis}}{{#operations}}{{ classname }}{{/operations}}{{^-last}}, {{/-last}}{{/apis}}];
 {{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/api-single.mustache
@@ -12,7 +12,7 @@ import { ObjectSerializer, Authentication, VoidAuth } from '../model/models';
 import { HttpBasicAuth, ApiKeyAuth, OAuth } from '../model/models';
 {{/hasAuthMethods}}
 
-import { HttpError } from './apis';
+import { HttpError, RequestFile } from './apis';
 
 let defaultBasePath = '{{{basePath}}}';
 

--- a/samples/client/petstore/typescript-node/default/api/apis.ts
+++ b/samples/client/petstore/typescript-node/default/api/apis.ts
@@ -4,11 +4,24 @@ export * from './storeApi';
 import { StoreApi } from './storeApi';
 export * from './userApi';
 import { UserApi } from './userApi';
-import http = require('http');
+import * as fs from 'fs';
+import * as http from 'http';
+
 export class HttpError extends Error {
     constructor (public response: http.ClientResponse, public body: any, public statusCode?: number) {
         super('HTTP request failed');
         this.name = 'HttpError';
     }
 }
+
+export interface RequestDetailedFile {
+    value: Buffer;
+    options?: {
+        filename?: string;
+        contentType?: string;
+    }
+}
+
+export type RequestFile = string | Buffer | fs.ReadStream | RequestDetailedFile;
+
 export const APIS = [PetApi, StoreApi, UserApi];

--- a/samples/client/petstore/typescript-node/default/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/petApi.ts
@@ -20,7 +20,7 @@ import { Pet } from '../model/pet';
 import { ObjectSerializer, Authentication, VoidAuth } from '../model/models';
 import { HttpBasicAuth, ApiKeyAuth, OAuth } from '../model/models';
 
-import { HttpError } from './apis';
+import { HttpError, RequestFile } from './apis';
 
 let defaultBasePath = 'http://petstore.swagger.io/v2';
 
@@ -528,7 +528,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public async uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
+    public async uploadFile (petId: number, additionalMetadata?: string, file?: RequestFile, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};

--- a/samples/client/petstore/typescript-node/default/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/storeApi.ts
@@ -19,7 +19,7 @@ import { Order } from '../model/order';
 import { ObjectSerializer, Authentication, VoidAuth } from '../model/models';
 import { HttpBasicAuth, ApiKeyAuth, OAuth } from '../model/models';
 
-import { HttpError } from './apis';
+import { HttpError, RequestFile } from './apis';
 
 let defaultBasePath = 'http://petstore.swagger.io/v2';
 

--- a/samples/client/petstore/typescript-node/default/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/default/api/userApi.ts
@@ -18,7 +18,7 @@ import { User } from '../model/user';
 
 import { ObjectSerializer, Authentication, VoidAuth } from '../model/models';
 
-import { HttpError } from './apis';
+import { HttpError, RequestFile } from './apis';
 
 let defaultBasePath = 'http://petstore.swagger.io/v2';
 

--- a/samples/client/petstore/typescript-node/npm/api/apis.ts
+++ b/samples/client/petstore/typescript-node/npm/api/apis.ts
@@ -4,11 +4,24 @@ export * from './storeApi';
 import { StoreApi } from './storeApi';
 export * from './userApi';
 import { UserApi } from './userApi';
-import http = require('http');
+import * as fs from 'fs';
+import * as http from 'http';
+
 export class HttpError extends Error {
     constructor (public response: http.ClientResponse, public body: any, public statusCode?: number) {
         super('HTTP request failed');
         this.name = 'HttpError';
     }
 }
+
+export interface RequestDetailedFile {
+    value: Buffer;
+    options?: {
+        filename?: string;
+        contentType?: string;
+    }
+}
+
+export type RequestFile = string | Buffer | fs.ReadStream | RequestDetailedFile;
+
 export const APIS = [PetApi, StoreApi, UserApi];

--- a/samples/client/petstore/typescript-node/npm/api/petApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/petApi.ts
@@ -20,7 +20,7 @@ import { Pet } from '../model/pet';
 import { ObjectSerializer, Authentication, VoidAuth } from '../model/models';
 import { HttpBasicAuth, ApiKeyAuth, OAuth } from '../model/models';
 
-import { HttpError } from './apis';
+import { HttpError, RequestFile } from './apis';
 
 let defaultBasePath = 'http://petstore.swagger.io/v2';
 
@@ -528,7 +528,7 @@ export class PetApi {
      * @param additionalMetadata Additional data to pass to server
      * @param file file to upload
      */
-    public async uploadFile (petId: number, additionalMetadata?: string, file?: Buffer, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
+    public async uploadFile (petId: number, additionalMetadata?: string, file?: RequestFile, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: ApiResponse;  }> {
         const localVarPath = this.basePath + '/pet/{petId}/uploadImage'
             .replace('{' + 'petId' + '}', encodeURIComponent(String(petId)));
         let localVarQueryParameters: any = {};

--- a/samples/client/petstore/typescript-node/npm/api/storeApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/storeApi.ts
@@ -19,7 +19,7 @@ import { Order } from '../model/order';
 import { ObjectSerializer, Authentication, VoidAuth } from '../model/models';
 import { HttpBasicAuth, ApiKeyAuth, OAuth } from '../model/models';
 
-import { HttpError } from './apis';
+import { HttpError, RequestFile } from './apis';
 
 let defaultBasePath = 'http://petstore.swagger.io/v2';
 

--- a/samples/client/petstore/typescript-node/npm/api/userApi.ts
+++ b/samples/client/petstore/typescript-node/npm/api/userApi.ts
@@ -18,7 +18,7 @@ import { User } from '../model/user';
 
 import { ObjectSerializer, Authentication, VoidAuth } from '../model/models';
 
-import { HttpError } from './apis';
+import { HttpError, RequestFile } from './apis';
 
 let defaultBasePath = 'http://petstore.swagger.io/v2';
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
@akehir @macjohnny

### Description of the PR

Add options to specify a from data file

Be able to specify file options as described on
https://github.com/request/request in the 'multipart/form-data
(Multipart Form Uploads)' section).

Related to #3944

I am new to the OpenApiGenerator and unsure if I did the java part correctly...

