### PR TITLE
Fix wrong variable name in LessThan and LessThanOrEqual asserts

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/api_input_validation.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api_input_validation.mustache
@@ -67,10 +67,10 @@
     {{/minimum}}
     {{#maximum}}
     {{#exclusiveMaximum}}
-        $asserts[] = new Assert\LessThan({{minimum}});
+        $asserts[] = new Assert\LessThan({{maximum}});
     {{/exclusiveMaximum}}
     {{^exclusiveMaximum}}
-        $asserts[] = new Assert\LessThanOrEqual({{minimum}});
+        $asserts[] = new Assert\LessThanOrEqual({{maximum}});
     {{/exclusiveMaximum}}
     {{/maximum}}
     {{#pattern}}

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/StoreController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/StoreController.php
@@ -224,7 +224,7 @@ class StoreController extends Controller
         $asserts[] = new Assert\NotNull();
         $asserts[] = new Assert\Type("int");
         $asserts[] = new Assert\GreaterThanOrEqual(1);
-        $asserts[] = new Assert\LessThanOrEqual(1);
+        $asserts[] = new Assert\LessThanOrEqual(5);
         $response = $this->validate($orderId, $asserts);
         if ($response instanceof Response) {
             return $response;


### PR DESCRIPTION
### PR checklist

- [+] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [+] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [+] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [+] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fix issue, that i described in https://github.com/OpenAPITools/openapi-generator/issues/3209
