### PR TITLE
[Golang] Allow retrieving the underlying configuration for APIClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -169,6 +169,11 @@ func (c *APIClient) ChangeBasePath(path string) {
 	c.cfg.BasePath = path
 }
 
+// Allow modification of underlying config for alternate implementations and testing
+func (c *APIClient) GetConfig() *Configuration {
+	return c.cfg
+}
+
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -170,6 +170,7 @@ func (c *APIClient) ChangeBasePath(path string) {
 }
 
 // Allow modification of underlying config for alternate implementations and testing
+// Caution: modifying the configuration while live can cause data races and potentially unwanted behavior
 func (c *APIClient) GetConfig() *Configuration {
 	return c.cfg
 }

--- a/samples/client/petstore/go/go-petstore-withXml/client.go
+++ b/samples/client/petstore/go/go-petstore-withXml/client.go
@@ -182,6 +182,7 @@ func (c *APIClient) ChangeBasePath(path string) {
 }
 
 // Allow modification of underlying config for alternate implementations and testing
+// Caution: modifying the configuration while live can cause data races and potentially unwanted behavior
 func (c *APIClient) GetConfig() *Configuration {
 	return c.cfg
 }

--- a/samples/client/petstore/go/go-petstore-withXml/client.go
+++ b/samples/client/petstore/go/go-petstore-withXml/client.go
@@ -181,6 +181,11 @@ func (c *APIClient) ChangeBasePath(path string) {
 	c.cfg.BasePath = path
 }
 
+// Allow modification of underlying config for alternate implementations and testing
+func (c *APIClient) GetConfig() *Configuration {
+	return c.cfg
+}
+
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -180,6 +180,11 @@ func (c *APIClient) ChangeBasePath(path string) {
 	c.cfg.BasePath = path
 }
 
+// Allow modification of underlying config for alternate implementations and testing
+func (c *APIClient) GetConfig() *Configuration {
+	return c.cfg
+}
+
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -181,6 +181,7 @@ func (c *APIClient) ChangeBasePath(path string) {
 }
 
 // Allow modification of underlying config for alternate implementations and testing
+// Caution: modifying the configuration while live can cause data races and potentially unwanted behavior
 func (c *APIClient) GetConfig() *Configuration {
 	return c.cfg
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -184,6 +184,7 @@ func (c *APIClient) ChangeBasePath(path string) {
 }
 
 // Allow modification of underlying config for alternate implementations and testing
+// Caution: modifying the configuration while live can cause data races and potentially unwanted behavior
 func (c *APIClient) GetConfig() *Configuration {
 	return c.cfg
 }

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -183,6 +183,11 @@ func (c *APIClient) ChangeBasePath(path string) {
 	c.cfg.BasePath = path
 }
 
+// Allow modification of underlying config for alternate implementations and testing
+func (c *APIClient) GetConfig() *Configuration {
+	return c.cfg
+}
+
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)
  - Needed for dynamically changing the underlying implementations and for testing
  - Fixes #1321, Fixes #3412
  - FYI, I considered exporting the cfg variable instead, but thought this was a more backward compatible change.
  - Travis build on my branch passed.

cc @antihax @bvwells @grokify @kemokemo @bkabrda since this is a Go related change.