### PR TITLE
fix(php): no need to serialize collections, Guzzle does that, fix #2292

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -196,23 +196,26 @@ class ObjectSerializer
      *
      * @return string
      */
-    public static function serializeCollection(array $collection, $collectionFormat, $allowCollectionFormatMulti = false)
+    public static function serializeCollection(array $collection, $style, $allowCollectionFormatMulti = false)
     {
         if ($allowCollectionFormatMulti && ('multi' === $collectionFormat)) {
             // http_build_query() almost does the job for us. We just
             // need to fix the result of multidimensional arrays.
             return preg_replace('/%5B[0-9]+%5D=/', '=', http_build_query($collection, '', '&'));
         }
-        switch ($collectionFormat) {
+        switch ($style) {
+            case 'pipeDelimited':
             case 'pipes':
                 return implode('|', $collection);
 
             case 'tsv':
                 return implode("\t", $collection);
 
+            case 'spaceDelimited':
             case 'ssv':
                 return implode(' ', $collection);
 
+            case 'simple':
             case 'csv':
                 // Deliberate fall through. CSV is default format.
             default:

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -472,16 +472,24 @@ use {{invokerPackage}}\ObjectSerializer;
         $multipart = false;
 
         {{#queryParams}}
+
         // query params
-        {{#collectionFormat}}
-        if (is_array(${{paramName}})) {
-            ${{paramName}} = ObjectSerializer::serializeCollection(${{paramName}}, '{{collectionFormat}}', true);
-        }
-        {{/collectionFormat}}
+        {{#isExplode}}
         if (${{paramName}} !== null) {
-            $queryParams['{{baseName}}'] = ObjectSerializer::toQueryValue(${{paramName}});
+            $queryParams['{{baseName}}'] = ${{paramName}};
         }
+        {{/isExplode}}
+        {{^isExplode}}
+        if (is_array(${{paramName}})) {
+            ${{paramName}} = ObjectSerializer::serializeCollection(${{paramName}}, '{{#style}}{{style}}{{/style}}{{^style}}{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}{{/style}}', true);
+        }
+        if (${{paramName}} !== null) {
+            $queryParams['{{baseName}}'] = ${{paramName}};
+        }
+        {{/isExplode}}
+
         {{/queryParams}}
+
         {{#headerParams}}
         // header params
         {{#collectionFormat}}

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -315,6 +315,7 @@ class AnotherFakeApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($body)) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -267,6 +267,7 @@ class FakeApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($xml_item)) {
@@ -521,6 +522,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -781,6 +783,7 @@ class FakeApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($body)) {
@@ -1035,6 +1038,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -1295,6 +1299,7 @@ class FakeApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($body)) {
@@ -1507,6 +1512,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -1734,10 +1740,16 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
-        if ($query !== null) {
-            $queryParams['query'] = ObjectSerializer::toQueryValue($query);
+        if (is_array($query)) {
+            $query = ObjectSerializer::serializeCollection($query, '', true);
         }
+        if ($query !== null) {
+            $queryParams['query'] = $query;
+        }
+
+
 
 
         // body params
@@ -2004,6 +2016,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -2356,6 +2369,7 @@ class FakeApi
 
 
 
+
         // form params
         if ($integer !== null) {
             $formParams['integer'] = ObjectSerializer::toFormValue($integer);
@@ -2660,25 +2674,43 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
         if (is_array($enum_query_string_array)) {
             $enum_query_string_array = ObjectSerializer::serializeCollection($enum_query_string_array, 'csv', true);
         }
         if ($enum_query_string_array !== null) {
-            $queryParams['enum_query_string_array'] = ObjectSerializer::toQueryValue($enum_query_string_array);
+            $queryParams['enum_query_string_array'] = $enum_query_string_array;
         }
+
+
         // query params
+        if (is_array($enum_query_string)) {
+            $enum_query_string = ObjectSerializer::serializeCollection($enum_query_string, '', true);
+        }
         if ($enum_query_string !== null) {
-            $queryParams['enum_query_string'] = ObjectSerializer::toQueryValue($enum_query_string);
+            $queryParams['enum_query_string'] = $enum_query_string;
         }
+
+
         // query params
+        if (is_array($enum_query_integer)) {
+            $enum_query_integer = ObjectSerializer::serializeCollection($enum_query_integer, '', true);
+        }
         if ($enum_query_integer !== null) {
-            $queryParams['enum_query_integer'] = ObjectSerializer::toQueryValue($enum_query_integer);
+            $queryParams['enum_query_integer'] = $enum_query_integer;
         }
+
+
         // query params
-        if ($enum_query_double !== null) {
-            $queryParams['enum_query_double'] = ObjectSerializer::toQueryValue($enum_query_double);
+        if (is_array($enum_query_double)) {
+            $enum_query_double = ObjectSerializer::serializeCollection($enum_query_double, '', true);
         }
+        if ($enum_query_double !== null) {
+            $queryParams['enum_query_double'] = $enum_query_double;
+        }
+
+
         // header params
         if (is_array($enum_header_string_array)) {
             $enum_header_string_array = ObjectSerializer::serializeCollection($enum_header_string_array, 'csv');
@@ -2969,22 +3001,43 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
+        if (is_array($required_string_group)) {
+            $required_string_group = ObjectSerializer::serializeCollection($required_string_group, '', true);
+        }
         if ($required_string_group !== null) {
-            $queryParams['required_string_group'] = ObjectSerializer::toQueryValue($required_string_group);
+            $queryParams['required_string_group'] = $required_string_group;
         }
+
+
         // query params
+        if (is_array($required_int64_group)) {
+            $required_int64_group = ObjectSerializer::serializeCollection($required_int64_group, '', true);
+        }
         if ($required_int64_group !== null) {
-            $queryParams['required_int64_group'] = ObjectSerializer::toQueryValue($required_int64_group);
+            $queryParams['required_int64_group'] = $required_int64_group;
         }
+
+
         // query params
+        if (is_array($string_group)) {
+            $string_group = ObjectSerializer::serializeCollection($string_group, '', true);
+        }
         if ($string_group !== null) {
-            $queryParams['string_group'] = ObjectSerializer::toQueryValue($string_group);
+            $queryParams['string_group'] = $string_group;
         }
+
+
         // query params
-        if ($int64_group !== null) {
-            $queryParams['int64_group'] = ObjectSerializer::toQueryValue($int64_group);
+        if (is_array($int64_group)) {
+            $int64_group = ObjectSerializer::serializeCollection($int64_group, '', true);
         }
+        if ($int64_group !== null) {
+            $queryParams['int64_group'] = $int64_group;
+        }
+
+
         // header params
         if ($required_boolean_group !== null) {
             $headerParams['required_boolean_group'] = ObjectSerializer::toHeaderValue($required_boolean_group);
@@ -3208,6 +3261,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -3438,6 +3492,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -3703,41 +3758,49 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
         if (is_array($pipe)) {
             $pipe = ObjectSerializer::serializeCollection($pipe, 'csv', true);
         }
         if ($pipe !== null) {
-            $queryParams['pipe'] = ObjectSerializer::toQueryValue($pipe);
+            $queryParams['pipe'] = $pipe;
         }
+
+
         // query params
         if (is_array($ioutil)) {
             $ioutil = ObjectSerializer::serializeCollection($ioutil, 'csv', true);
         }
         if ($ioutil !== null) {
-            $queryParams['ioutil'] = ObjectSerializer::toQueryValue($ioutil);
+            $queryParams['ioutil'] = $ioutil;
         }
+
+
         // query params
         if (is_array($http)) {
             $http = ObjectSerializer::serializeCollection($http, 'space', true);
         }
         if ($http !== null) {
-            $queryParams['http'] = ObjectSerializer::toQueryValue($http);
+            $queryParams['http'] = $http;
         }
+
+
         // query params
         if (is_array($url)) {
             $url = ObjectSerializer::serializeCollection($url, 'csv', true);
         }
         if ($url !== null) {
-            $queryParams['url'] = ObjectSerializer::toQueryValue($url);
+            $queryParams['url'] = $url;
         }
+
+
         // query params
-        if (is_array($context)) {
-            $context = ObjectSerializer::serializeCollection($context, 'multi', true);
-        }
         if ($context !== null) {
-            $queryParams['context'] = ObjectSerializer::toQueryValue($context);
+            $queryParams['context'] = $context;
         }
+
+
 
 
         // body params

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -315,6 +315,7 @@ class FakeClassnameTags123Api
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($body)) {

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -267,6 +267,7 @@ class PetApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($body)) {
@@ -492,6 +493,7 @@ class PetApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
         // header params
         if ($api_key !== null) {
@@ -773,13 +775,16 @@ class PetApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
         if (is_array($status)) {
             $status = ObjectSerializer::serializeCollection($status, 'csv', true);
         }
         if ($status !== null) {
-            $queryParams['status'] = ObjectSerializer::toQueryValue($status);
+            $queryParams['status'] = $status;
         }
+
+
 
 
         // body params
@@ -1048,13 +1053,16 @@ class PetApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
         if (is_array($tags)) {
             $tags = ObjectSerializer::serializeCollection($tags, 'csv', true);
         }
         if ($tags !== null) {
-            $queryParams['tags'] = ObjectSerializer::toQueryValue($tags);
+            $queryParams['tags'] = $tags;
         }
+
+
 
 
         // body params
@@ -1324,6 +1332,7 @@ class PetApi
         $multipart = false;
 
 
+
         // path params
         if ($pet_id !== null) {
             $resourcePath = str_replace(
@@ -1551,6 +1560,7 @@ class PetApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -1784,6 +1794,7 @@ class PetApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params
@@ -2078,6 +2089,7 @@ class PetApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params
@@ -2379,6 +2391,7 @@ class PetApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -266,6 +266,7 @@ class StoreApi
         $multipart = false;
 
 
+
         // path params
         if ($order_id !== null) {
             $resourcePath = str_replace(
@@ -525,6 +526,7 @@ class StoreApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -803,6 +805,7 @@ class StoreApi
         $multipart = false;
 
 
+
         // path params
         if ($order_id !== null) {
             $resourcePath = str_replace(
@@ -1073,6 +1076,7 @@ class StoreApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -267,6 +267,7 @@ class UserApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($body)) {
@@ -483,6 +484,7 @@ class UserApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -705,6 +707,7 @@ class UserApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($body)) {
@@ -921,6 +924,7 @@ class UserApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params
@@ -1193,6 +1197,7 @@ class UserApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params
@@ -1477,14 +1482,25 @@ class UserApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
+        if (is_array($username)) {
+            $username = ObjectSerializer::serializeCollection($username, '', true);
+        }
         if ($username !== null) {
-            $queryParams['username'] = ObjectSerializer::toQueryValue($username);
+            $queryParams['username'] = $username;
         }
+
+
         // query params
-        if ($password !== null) {
-            $queryParams['password'] = ObjectSerializer::toQueryValue($password);
+        if (is_array($password)) {
+            $password = ObjectSerializer::serializeCollection($password, '', true);
         }
+        if ($password !== null) {
+            $queryParams['password'] = $password;
+        }
+
+
 
 
         // body params
@@ -1689,6 +1705,7 @@ class UserApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -1916,6 +1933,7 @@ class UserApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -206,23 +206,26 @@ class ObjectSerializer
      *
      * @return string
      */
-    public static function serializeCollection(array $collection, $collectionFormat, $allowCollectionFormatMulti = false)
+    public static function serializeCollection(array $collection, $style, $allowCollectionFormatMulti = false)
     {
         if ($allowCollectionFormatMulti && ('multi' === $collectionFormat)) {
             // http_build_query() almost does the job for us. We just
             // need to fix the result of multidimensional arrays.
             return preg_replace('/%5B[0-9]+%5D=/', '=', http_build_query($collection, '', '&'));
         }
-        switch ($collectionFormat) {
+        switch ($style) {
+            case 'pipeDelimited':
             case 'pipes':
                 return implode('|', $collection);
 
             case 'tsv':
                 return implode("\t", $collection);
 
+            case 'spaceDelimited':
             case 'ssv':
                 return implode(' ', $collection);
 
+            case 'simple':
             case 'csv':
                 // Deliberate fall through. CSV is default format.
             default:

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -315,6 +315,7 @@ class AnotherFakeApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($client)) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -300,6 +300,7 @@ class DefaultApi
 
 
 
+
         // body params
         $_tempBody = null;
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -304,6 +304,7 @@ class FakeApi
 
 
 
+
         // body params
         $_tempBody = null;
 
@@ -555,6 +556,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -815,6 +817,7 @@ class FakeApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($outer_composite)) {
@@ -1069,6 +1072,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -1329,6 +1333,7 @@ class FakeApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($body)) {
@@ -1541,6 +1546,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -1768,10 +1774,13 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
         if ($query !== null) {
-            $queryParams['query'] = ObjectSerializer::toQueryValue($query);
+            $queryParams['query'] = $query;
         }
+
+
 
 
         // body params
@@ -2038,6 +2047,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -2390,6 +2400,7 @@ class FakeApi
 
 
 
+
         // form params
         if ($integer !== null) {
             $formParams['integer'] = ObjectSerializer::toFormValue($integer);
@@ -2694,25 +2705,31 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
-        if (is_array($enum_query_string_array)) {
-            $enum_query_string_array = ObjectSerializer::serializeCollection($enum_query_string_array, 'multi', true);
-        }
         if ($enum_query_string_array !== null) {
-            $queryParams['enum_query_string_array'] = ObjectSerializer::toQueryValue($enum_query_string_array);
+            $queryParams['enum_query_string_array'] = $enum_query_string_array;
         }
+
+
         // query params
         if ($enum_query_string !== null) {
-            $queryParams['enum_query_string'] = ObjectSerializer::toQueryValue($enum_query_string);
+            $queryParams['enum_query_string'] = $enum_query_string;
         }
+
+
         // query params
         if ($enum_query_integer !== null) {
-            $queryParams['enum_query_integer'] = ObjectSerializer::toQueryValue($enum_query_integer);
+            $queryParams['enum_query_integer'] = $enum_query_integer;
         }
+
+
         // query params
         if ($enum_query_double !== null) {
-            $queryParams['enum_query_double'] = ObjectSerializer::toQueryValue($enum_query_double);
+            $queryParams['enum_query_double'] = $enum_query_double;
         }
+
+
         // header params
         if (is_array($enum_header_string_array)) {
             $enum_header_string_array = ObjectSerializer::serializeCollection($enum_header_string_array, 'csv');
@@ -3003,22 +3020,31 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
         if ($required_string_group !== null) {
-            $queryParams['required_string_group'] = ObjectSerializer::toQueryValue($required_string_group);
+            $queryParams['required_string_group'] = $required_string_group;
         }
+
+
         // query params
         if ($required_int64_group !== null) {
-            $queryParams['required_int64_group'] = ObjectSerializer::toQueryValue($required_int64_group);
+            $queryParams['required_int64_group'] = $required_int64_group;
         }
+
+
         // query params
         if ($string_group !== null) {
-            $queryParams['string_group'] = ObjectSerializer::toQueryValue($string_group);
+            $queryParams['string_group'] = $string_group;
         }
+
+
         // query params
         if ($int64_group !== null) {
-            $queryParams['int64_group'] = ObjectSerializer::toQueryValue($int64_group);
+            $queryParams['int64_group'] = $int64_group;
         }
+
+
         // header params
         if ($required_boolean_group !== null) {
             $headerParams['required_boolean_group'] = ObjectSerializer::toHeaderValue($required_boolean_group);
@@ -3249,6 +3275,7 @@ class FakeApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($request_body)) {
@@ -3476,6 +3503,7 @@ class FakeApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -3741,41 +3769,46 @@ class FakeApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
-        if (is_array($pipe)) {
-            $pipe = ObjectSerializer::serializeCollection($pipe, 'multi', true);
-        }
         if ($pipe !== null) {
-            $queryParams['pipe'] = ObjectSerializer::toQueryValue($pipe);
+            $queryParams['pipe'] = $pipe;
         }
+
+
         // query params
         if (is_array($ioutil)) {
             $ioutil = ObjectSerializer::serializeCollection($ioutil, 'csv', true);
         }
         if ($ioutil !== null) {
-            $queryParams['ioutil'] = ObjectSerializer::toQueryValue($ioutil);
+            $queryParams['ioutil'] = $ioutil;
         }
+
+
         // query params
         if (is_array($http)) {
             $http = ObjectSerializer::serializeCollection($http, 'space', true);
         }
         if ($http !== null) {
-            $queryParams['http'] = ObjectSerializer::toQueryValue($http);
+            $queryParams['http'] = $http;
         }
+
+
         // query params
         if (is_array($url)) {
             $url = ObjectSerializer::serializeCollection($url, 'csv', true);
         }
         if ($url !== null) {
-            $queryParams['url'] = ObjectSerializer::toQueryValue($url);
+            $queryParams['url'] = $url;
         }
+
+
         // query params
-        if (is_array($context)) {
-            $context = ObjectSerializer::serializeCollection($context, 'multi', true);
-        }
         if ($context !== null) {
-            $queryParams['context'] = ObjectSerializer::toQueryValue($context);
+            $queryParams['context'] = $context;
         }
+
+
 
 
         // body params

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -315,6 +315,7 @@ class FakeClassnameTags123Api
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($client)) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -287,6 +287,7 @@ class PetApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($pet)) {
@@ -518,6 +519,7 @@ class PetApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
         // header params
         if ($api_key !== null) {
@@ -799,13 +801,16 @@ class PetApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
         if (is_array($status)) {
             $status = ObjectSerializer::serializeCollection($status, 'csv', true);
         }
         if ($status !== null) {
-            $queryParams['status'] = ObjectSerializer::toQueryValue($status);
+            $queryParams['status'] = $status;
         }
+
+
 
 
         // body params
@@ -1074,13 +1079,16 @@ class PetApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
         if (is_array($tags)) {
             $tags = ObjectSerializer::serializeCollection($tags, 'csv', true);
         }
         if ($tags !== null) {
-            $queryParams['tags'] = ObjectSerializer::toQueryValue($tags);
+            $queryParams['tags'] = $tags;
         }
+
+
 
 
         // body params
@@ -1350,6 +1358,7 @@ class PetApi
         $multipart = false;
 
 
+
         // path params
         if ($pet_id !== null) {
             $resourcePath = str_replace(
@@ -1600,6 +1609,7 @@ class PetApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($pet)) {
@@ -1836,6 +1846,7 @@ class PetApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params
@@ -2130,6 +2141,7 @@ class PetApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params
@@ -2431,6 +2443,7 @@ class PetApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -266,6 +266,7 @@ class StoreApi
         $multipart = false;
 
 
+
         // path params
         if ($order_id !== null) {
             $resourcePath = str_replace(
@@ -525,6 +526,7 @@ class StoreApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -803,6 +805,7 @@ class StoreApi
         $multipart = false;
 
 
+
         // path params
         if ($order_id !== null) {
             $resourcePath = str_replace(
@@ -1073,6 +1076,7 @@ class StoreApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -267,6 +267,7 @@ class UserApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($user)) {
@@ -483,6 +484,7 @@ class UserApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -705,6 +707,7 @@ class UserApi
 
 
 
+
         // body params
         $_tempBody = null;
         if (isset($user)) {
@@ -921,6 +924,7 @@ class UserApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params
@@ -1193,6 +1197,7 @@ class UserApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params
@@ -1477,14 +1482,19 @@ class UserApi
         $httpBody = '';
         $multipart = false;
 
+
         // query params
         if ($username !== null) {
-            $queryParams['username'] = ObjectSerializer::toQueryValue($username);
+            $queryParams['username'] = $username;
         }
+
+
         // query params
         if ($password !== null) {
-            $queryParams['password'] = ObjectSerializer::toQueryValue($password);
+            $queryParams['password'] = $password;
         }
+
+
 
 
         // body params
@@ -1689,6 +1699,7 @@ class UserApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
 
@@ -1916,6 +1927,7 @@ class UserApi
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
+
 
 
         // path params

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -206,23 +206,26 @@ class ObjectSerializer
      *
      * @return string
      */
-    public static function serializeCollection(array $collection, $collectionFormat, $allowCollectionFormatMulti = false)
+    public static function serializeCollection(array $collection, $style, $allowCollectionFormatMulti = false)
     {
         if ($allowCollectionFormatMulti && ('multi' === $collectionFormat)) {
             // http_build_query() almost does the job for us. We just
             // need to fix the result of multidimensional arrays.
             return preg_replace('/%5B[0-9]+%5D=/', '=', http_build_query($collection, '', '&'));
         }
-        switch ($collectionFormat) {
+        switch ($style) {
+            case 'pipeDelimited':
             case 'pipes':
                 return implode('|', $collection);
 
             case 'tsv':
                 return implode("\t", $collection);
 
+            case 'spaceDelimited':
             case 'ssv':
                 return implode(' ', $collection);
 
+            case 'simple':
             case 'csv':
                 // Deliberate fall through. CSV is default format.
             default:


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Fixes #2292, Guzzle seems to handle collections and manual serialization breaks that functionality.

