### PR TITLE
[C++] [Pistache] Removed deprecated warnings

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/main-api-server.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/main-api-server.mustache
@@ -13,11 +13,12 @@
 #include "{{classname}}Impl.h"{{/operations}}{{/apis}}{{/apiInfo}}
 
 #define PISTACHE_SERVER_THREADS     2
-#define PISTACHE_SERVER_MAX_PAYLOAD 32768
+#define PISTACHE_SERVER_MAX_REQUEST_SIZE 32768
+#define PISTACHE_SERVER_MAX_RESPONSE_SIZE 32768
 
 static Pistache::Http::Endpoint *httpEndpoint;
 #ifdef __linux__
-static void sigHandler(int sig){
+static void sigHandler [[noreturn]] (int sig){
     switch(sig){
         case SIGINT:
         case SIGQUIT:
@@ -61,7 +62,8 @@ int main() {
     auto opts = Pistache::Http::Endpoint::options()
         .threads(PISTACHE_SERVER_THREADS);
     opts.flags(Pistache::Tcp::Options::ReuseAddr);
-    opts.maxPayload(PISTACHE_SERVER_MAX_PAYLOAD);
+    opts.maxRequestSize(PISTACHE_SERVER_MAX_REQUEST_SIZE);
+    opts.maxResponseSize(PISTACHE_SERVER_MAX_REQUEST_SIZE);
     httpEndpoint->init(opts);
 
     {{#apiInfo}}{{#apis}}{{#operations}}

--- a/modules/openapi-generator/src/main/resources/cpp-pistache-server/main-api-server.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-pistache-server/main-api-server.mustache
@@ -63,7 +63,7 @@ int main() {
         .threads(PISTACHE_SERVER_THREADS);
     opts.flags(Pistache::Tcp::Options::ReuseAddr);
     opts.maxRequestSize(PISTACHE_SERVER_MAX_REQUEST_SIZE);
-    opts.maxResponseSize(PISTACHE_SERVER_MAX_REQUEST_SIZE);
+    opts.maxResponseSize(PISTACHE_SERVER_MAX_RESPONSE_SIZE);
     httpEndpoint->init(opts);
 
     {{#apiInfo}}{{#apis}}{{#operations}}

--- a/samples/server/petstore/cpp-pistache/main-api-server.cpp
+++ b/samples/server/petstore/cpp-pistache/main-api-server.cpp
@@ -75,7 +75,7 @@ int main() {
         .threads(PISTACHE_SERVER_THREADS);
     opts.flags(Pistache::Tcp::Options::ReuseAddr);
     opts.maxRequestSize(PISTACHE_SERVER_MAX_REQUEST_SIZE);
-    opts.maxResponseSize(PISTACHE_SERVER_MAX_REQUEST_SIZE);
+    opts.maxResponseSize(PISTACHE_SERVER_MAX_RESPONSE_SIZE);
     httpEndpoint->init(opts);
 
     

--- a/samples/server/petstore/cpp-pistache/main-api-server.cpp
+++ b/samples/server/petstore/cpp-pistache/main-api-server.cpp
@@ -25,11 +25,12 @@
 #include "UserApiImpl.h"
 
 #define PISTACHE_SERVER_THREADS     2
-#define PISTACHE_SERVER_MAX_PAYLOAD 32768
+#define PISTACHE_SERVER_MAX_REQUEST_SIZE 32768
+#define PISTACHE_SERVER_MAX_RESPONSE_SIZE 32768
 
 static Pistache::Http::Endpoint *httpEndpoint;
 #ifdef __linux__
-static void sigHandler(int sig){
+static void sigHandler [[noreturn]] (int sig){
     switch(sig){
         case SIGINT:
         case SIGQUIT:
@@ -73,7 +74,8 @@ int main() {
     auto opts = Pistache::Http::Endpoint::options()
         .threads(PISTACHE_SERVER_THREADS);
     opts.flags(Pistache::Tcp::Options::ReuseAddr);
-    opts.maxPayload(PISTACHE_SERVER_MAX_PAYLOAD);
+    opts.maxRequestSize(PISTACHE_SERVER_MAX_REQUEST_SIZE);
+    opts.maxResponseSize(PISTACHE_SERVER_MAX_REQUEST_SIZE);
     httpEndpoint->init(opts);
 
     


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Remove warnings in pistache main.cpp

@ravinikam  @stkrwork @martindelille  @muttleyxd