### PR TITLE
[C++] [rest-sdk] Add missing enum processing in C++Abstract codegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Map;
 
 abstract public class AbstractCppCodegen extends DefaultCodegen implements CodegenConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCppCodegen.class);
@@ -305,5 +306,10 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
         if(!host.isEmpty()) {
             this.additionalProperties.put("serverHost", host);
         }
+    }
+    
+    @Override
+    public Map<String, Object> postProcessModels(Map<String, Object> objs) {
+        return postProcessModelsEnum(objs);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppQt5AbstractCodegen.java
@@ -333,11 +333,6 @@ public class CppQt5AbstractCodegen extends AbstractCppCodegen implements Codegen
     }
 
     @Override
-    public Map<String, Object> postProcessModels(Map<String, Object> objs) {
-        return postProcessModelsEnum(objs);
-    }
-
-    @Override
     public String toEnumValue(String value, String datatype) {
         return escapeText(value);
     }

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
@@ -42,14 +42,14 @@ public:
     enum class e{{classname}} 
     {
         {{#allowableValues}}
-        {{#values}}
+        {{#enumVars}}
         {{#enumDescription}}
         /// <summary>
         /// {{enumDescription}}
         /// </summary>
         {{/enumDescription}}
-        {{classname}}_{{.}}{{^last}},{{/last}}
-        {{/values}}
+        {{classname}}_{{{name}}}{{^last}},{{/last}}        
+        {{/enumVars}}        
         {{/allowableValues}}
     };
 

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
@@ -27,8 +27,8 @@ web::json::value {{classname}}::toJson() const
 {
     web::json::value val = web::json::value::object();
 
-    {{#allowableValues}}{{#values}}
-    if (m_value == e{{classname}}::{{classname}}_{{.}}) val = web::json::value::string(U("{{.}}"));{{/values}}{{/allowableValues}}
+    {{#allowableValues}}{{#enumVars}}
+    if (m_value == e{{classname}}::{{classname}}_{{name}}) val = web::json::value::string(U({{{value}}}));{{/enumVars}}{{/allowableValues}}
 
     return val;
 }
@@ -37,8 +37,8 @@ void {{classname}}::fromJson(const web::json::value& val)
 {
     auto s = val.as_string();
 
-    {{#allowableValues}}{{#values}}
-    if (s == utility::conversions::to_string_t("{{.}}")) m_value = e{{classname}}::{{classname}}_{{.}};{{/values}}{{/allowableValues}}
+    {{#allowableValues}}{{#enumVars}}
+    if (s == utility::conversions::to_string_t({{{value}}})) m_value = e{{classname}}::{{classname}}_{{name}};{{/enumVars}}{{/allowableValues}}
 }
 
 void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utility::string_t& prefix) const
@@ -51,8 +51,8 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
 
     utility::string_t s;
 
-    {{#allowableValues}}{{#values}}
-    if (m_value == e{{classname}}::{{classname}}_{{.}}) s = utility::conversions::to_string_t("{{.}}");{{/values}}{{/allowableValues}}
+    {{#allowableValues}}{{#enumVars}}
+    if (m_value == e{{classname}}::{{classname}}_{{name}}) s = utility::conversions::to_string_t({{{value}}});{{/enumVars}}{{/allowableValues}}
 
     multipart->add(ModelBase::toHttpContent(namePrefix, s));
 }
@@ -70,8 +70,8 @@ void {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
         s = ModelBase::stringFromHttpContent(multipart->getContent(namePrefix));
         e{{classname}} v;
         
-        {{#allowableValues}}{{#values}}
-        if (s == utility::conversions::to_string_t("{{.}}")) v = e{{classname}}::{{classname}}_{{.}};{{/values}}{{/allowableValues}}
+        {{#allowableValues}}{{#enumVars}}
+        if (s == utility::conversions::to_string_t({{{value}}})) v = e{{classname}}::{{classname}}_{{name}};{{/enumVars}}{{/allowableValues}}
 
         setValue(v);
     }


### PR DESCRIPTION
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [X] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Add missing enum processing in C++ codegen, already present for Qt5

- Applied changes from #2339 to Abstract Codegen instead of only Qt5
- Adapt the model mustache

Fixes #3970

@ravinikam @stkrwork @MartinDelille @muttleyxd

