### PR TITLE
Store multiple bodyParams with mediaType appropriately

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -28,7 +28,7 @@ public class CodegenParameter {
             isCookieParam, isBodyParam, hasMore, isContainer,
             secondaryParam, isCollectionFormatMulti, isPrimitiveType, isModel;
     public String baseName, paramName, dataType, datatypeWithEnum, dataFormat,
-            collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName;
+            collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName, contentType;
 
     public String example; // example value (x-example)
     public String jsonSchema;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2713,13 +2713,20 @@ public class DefaultCodegen implements CodegenConfig {
 
                     bodyParams.add(bodyParam);
 
-                    if (prependFormOrBodyParameters) {
-                        allParams.add(bodyParam);
-                    }
-
                     // add example
                     if (schemas != null) {
                         op.requestBodyExamples = new ExampleGenerator(schemas, this.openAPI).generate(null, new ArrayList<String>(getConsumesInfo(this.openAPI, operation)), bodyParam.baseType);
+                    }
+                }
+                // TODO: many generators expect allParams to only have one bodyParam in it
+                // generators should either expect multiple bodyParam options in the allParams,
+                // or the bodyParam should be excluded from allParams and treated specially.
+                if (prependFormOrBodyParameters) {
+                    try {
+                        CodegenParameter firstBodyParam = requestBodyParams.get(0);
+                        allParams.add(firstBodyParam);
+                    } catch (IndexOutOfBoundsException e) {
+                        LOGGER.warn("No bodyParam available to prepend to allParams");
                     }
                 }
             }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2768,8 +2768,13 @@ public class DefaultCodegen implements CodegenConfig {
                 allParams.add(cp.copy());
             }
 
-            for (CodegenParameter cp : bodyParams) {
-                allParams.add(cp.copy());
+            // TODO: many generators expect allParams to only have one bodyParam in it
+            // generators should either expect multiple bodyParam options in the allParams,
+            // or the bodyParam should be excluded from allParams and treated specially.
+            try {
+                allParams.add(bodyParams.get(0).copy());
+            } catch (IndexOutOfBoundsException e) {
+                LOGGER.warn("No bodyParam available to append to allParams");
             }
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientExperimentalCodegen.java
@@ -314,8 +314,9 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
     }
 
     @Override
-    public CodegenParameter fromRequestBody(RequestBody body, Set<String> imports, String bodyParameterName) {
-        CodegenParameter result = super.fromRequestBody(body, imports, bodyParameterName);
+    public List<CodegenParameter> fromRequestBody(RequestBody body, Set<String> imports, String bodyParameterName) {
+        List<CodegenParameter> results = super.fromRequestBody(body, imports, bodyParameterName);
+        CodegenParameter result = results.get(0);
         // if we generated a model with a non-object type because it has validations or enums,
         // make sure that the datatype of that body parameter refers to our model class
         Content content = body.getContent();
@@ -325,7 +326,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
         Schema schema = mediaType.getSchema();
         String ref = schema.get$ref();
         if (ref == null) {
-            return result;
+            return results;
         }
         String modelName = ModelUtils.getSimpleRef(ref);
         // the result lacks validation info so we need to make a CodegenProperty from the schema to check
@@ -346,7 +347,7 @@ public class PythonClientExperimentalCodegen extends PythonClientCodegen {
                 result.example = modelName + "(" + result.example + ")";
             }
         }
-        return result;
+        return results;
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -786,9 +786,10 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
     // Thus, we grab the inner schema beforehand, and then tinker afterwards to
     // restore things to sensible values.
     @Override
-    public CodegenParameter fromRequestBody(RequestBody body, Set<String> imports, String bodyParameterName) {
+    public List<CodegenParameter> fromRequestBody(RequestBody body, Set<String> imports, String bodyParameterName) {
         Schema original_schema = ModelUtils.getSchemaFromRequestBody(body);
-        CodegenParameter codegenParameter = super.fromRequestBody(body, imports, bodyParameterName);
+        List<CodegenParameter> codegenParameters = super.fromRequestBody(body, imports, bodyParameterName);
+        CodegenParameter codegenParameter = codegenParameters.get(0);
 
         if (StringUtils.isNotBlank(original_schema.get$ref())) {
             // Undo the mess `super.fromRequestBody` made - re-wrap the inner
@@ -809,7 +810,7 @@ public class RustServerCodegen extends DefaultCodegen implements CodegenConfig {
             }
         }
 
-        return codegenParameter;
+        return codegenParameters;
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -922,7 +922,7 @@ public class DefaultCodegenTest {
 
         RequestBody body = openAPI.getPaths().get("/examples").getPost().getRequestBody();
 
-        CodegenParameter codegenParameter = codegen.fromRequestBody(body, imports, "");
+        CodegenParameter codegenParameter = codegen.fromRequestBody(body, imports, "").get(0);
 
         Assert.assertTrue(codegenParameter.isContainer);
         Assert.assertTrue(codegenParameter.items.isModel);
@@ -940,11 +940,31 @@ public class DefaultCodegenTest {
 
         RequestBody body = openAPI.getPaths().get("/examples").getPost().getRequestBody();
 
-        CodegenParameter codegenParameter = codegen.fromRequestBody(body, imports, "");
+        CodegenParameter codegenParameter = codegen.fromRequestBody(body, imports, "").get(0);
 
         Assert.assertTrue(codegenParameter.isContainer);
         Assert.assertTrue(codegenParameter.items.isModel);
         Assert.assertFalse(codegenParameter.items.isContainer);
+    }
+
+    @Test
+    public void multipleRequestBodyParams() {
+        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/request_body_two_content_types.yaml");
+        new InlineModelResolver().flatten(openAPI);
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Set<String> imports = new HashSet<>();
+
+        RequestBody body = openAPI.getPaths().get("/transactions").getPost().getRequestBody();
+
+        List<CodegenParameter> codegenParameters = codegen.fromRequestBody(body, imports, "");
+
+        Assert.assertEquals(2, codegenParameters.size());
+
+        List<String> paramContentTypes = codegenParameters.stream().map(param -> param.contentType).collect(Collectors.toList());
+        Assert.assertTrue(paramContentTypes.contains("application/vnd.transaction.transaction.v1+json"));
+        Assert.assertTrue(paramContentTypes.contains("application/vnd.transaction.transaction.v2+json"));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/bash/BashTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/bash/BashTest.java
@@ -76,7 +76,7 @@ public class BashTest {
                 addPetOperation,
                 null);
 
-        Assert.assertEquals(op.bodyParams.size(), 1);
+        Assert.assertEquals(op.bodyParams.size(), 2);
 
         CodegenParameter p = op.bodyParams.get(0);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -77,7 +77,7 @@ public class JavaClientCodegenTest {
         RequestBody body1 = new RequestBody();
         body1.setDescription("A list of ids");
         body1.setContent(new Content().addMediaType("application/json", new MediaType().schema(new ArraySchema().items(new StringSchema()))));
-        CodegenParameter codegenParameter1 = codegen.fromRequestBody(body1, new HashSet<String>(), null);
+        CodegenParameter codegenParameter1 = codegen.fromRequestBody(body1, new HashSet<String>(), null).get(0);
         Assert.assertEquals(codegenParameter1.description, "A list of ids");
         Assert.assertEquals(codegenParameter1.dataType, "List<String>");
         Assert.assertEquals(codegenParameter1.baseType, "String");
@@ -85,7 +85,7 @@ public class JavaClientCodegenTest {
         RequestBody body2 = new RequestBody();
         body2.setDescription("A list of list of values");
         body2.setContent(new Content().addMediaType("application/json", new MediaType().schema(new ArraySchema().items(new ArraySchema().items(new IntegerSchema())))));
-        CodegenParameter codegenParameter2 = codegen.fromRequestBody(body2, new HashSet<String>(), null);
+        CodegenParameter codegenParameter2 = codegen.fromRequestBody(body2, new HashSet<String>(), null).get(0);
         Assert.assertEquals(codegenParameter2.description, "A list of list of values");
         Assert.assertEquals(codegenParameter2.dataType, "List<List<Integer>>");
         Assert.assertEquals(codegenParameter2.baseType, "List");
@@ -97,7 +97,7 @@ public class JavaClientCodegenTest {
         point.addProperties("message", new StringSchema());
         point.addProperties("x", new IntegerSchema().format(SchemaTypeUtil.INTEGER32_FORMAT));
         point.addProperties("y", new IntegerSchema().format(SchemaTypeUtil.INTEGER32_FORMAT));
-        CodegenParameter codegenParameter3 = codegen.fromRequestBody(body3, new HashSet<String>(), null);
+        CodegenParameter codegenParameter3 = codegen.fromRequestBody(body3, new HashSet<String>(), null).get(0);
         Assert.assertEquals(codegenParameter3.description, "A list of points");
         Assert.assertEquals(codegenParameter3.dataType, "List<Point>");
         Assert.assertEquals(codegenParameter3.baseType, "Point");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -158,7 +158,7 @@ public class RubyClientCodegenTest {
         final String path = "/pet";
         final Operation p = openAPI.getPaths().get(path).getPost();
         final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
-        Assert.assertEquals(op.bodyParams.size(), 1);
+        Assert.assertEquals(op.bodyParams.size(), 2);
         CodegenParameter bp = op.bodyParams.get(0);
         Assert.assertEquals(bp.example, "OnlinePetstore::Pet.new");
     }

--- a/modules/openapi-generator/src/test/resources/3_0/request_body_two_content_types.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/request_body_two_content_types.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+servers:
+  - url: 'http://test/'
+paths:
+  /transactions:
+    post:
+      summary: Endpoint for posting a new transaction
+      requestBody:
+        description: Post
+        content:
+          application/vnd.transaction.transaction.v1+json:
+            schema:
+              $ref: '#/components/schemas/TransactionV1'
+          application/vnd.transaction.transaction.v2+json:
+            schema:
+              $ref: '#/components/schemas/TransactionV2'
+      responses:
+        '204':
+          description: Transaction created
+components:
+  schemas:
+    TransactionV1:
+      type: object
+      properties:
+        test1:
+          type: string
+
+    TransactionV2:
+      type: object
+      properties:
+        test2:
+          type: string


### PR DESCRIPTION
### PR checklist

New to the project, so while I did my best to answer these questions, I know I did not fully grok the release process and some of the larger concerns that may need to be addressed by my change. 

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.

Not updating any language templates, so I'm guessing I don't need to do this? 

- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.

This doesn't seem to be a breaking change (new to this project though, so I could be missing something), so master?

- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

PR targets core, not a specific programming language.

### Description of the PR

Addresses  the issue raised in #3990:
*  Converts `DefaultCodgen.fromRequestBody` to return a `List<CodegenParameter>` instead of a single `CodegenParameter` (since requestBody's often contain _multiple_ Content Types.
* Adds a test for creating multiple `bodyParams` when there are multiple Content Types.
* Updates callers that depend on the singleton functionality to operate as thought there is a singleton (tried to keep the change as simple as possible for now, but these call sites should properly handle receiving multiple `CodegenParameter`s.

