### PR TITLE
[java][client] Fix regression in Java XML serialization. Fixes #4014

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -26,6 +26,9 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     {{/mostInnerItems}}
     {{/isContainer}}
     {{/isEnum}}
+  {{#gson}}
+  public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
+  {{/gson}}
   {{#withXml}}
   {{#isXmlAttribute}}
   @XmlAttribute(name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
@@ -48,7 +51,6 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{/isXmlAttribute}}
   {{/withXml}}
   {{#gson}}
-  public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
   @SerializedName(SERIALIZED_NAME_{{nameInSnakeCase}})
   {{/gson}}
   {{#jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -29,6 +29,9 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{#gson}}
   public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
   {{/gson}}
+  {{#jackson}}
+  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
+  {{/jackson}}
   {{#withXml}}
   {{#isXmlAttribute}}
   @XmlAttribute(name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
@@ -53,9 +56,6 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{#gson}}
   @SerializedName(SERIALIZED_NAME_{{nameInSnakeCase}})
   {{/gson}}
-  {{#jackson}}
-  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
-  {{/jackson}}
   {{#vendorExtensions.isJacksonOptionalNullable}}
   {{#isContainer}}
   private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>undefined();

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -38,8 +38,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesAnyType")
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private String name;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -39,8 +39,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesArray")
 public class AdditionalPropertiesArray extends HashMap<String, List> {
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private String name;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -38,8 +38,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesBoolean")
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private String name;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -50,72 +50,72 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesClass")
 public class AdditionalPropertiesClass {
+  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP_STRING = "map_string";
   private Map<String, String> mapString = null;
 
+  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=BigDecimal
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP_NUMBER = "map_number";
   private Map<String, BigDecimal> mapNumber = null;
 
+  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP_INTEGER = "map_integer";
   private Map<String, Integer> mapInteger = null;
 
+  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Boolean
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP_BOOLEAN = "map_boolean";
   private Map<String, Boolean> mapBoolean = null;
 
+  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;Integer&gt;
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP_ARRAY_INTEGER = "map_array_integer";
   private Map<String, List<Integer>> mapArrayInteger = null;
 
+  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;Object&gt;
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP_ARRAY_ANYTYPE = "map_array_anytype";
   private Map<String, List<Object>> mapArrayAnytype = null;
 
+  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Map&lt;String, String&gt;
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP_MAP_STRING = "map_map_string";
   private Map<String, Map<String, String>> mapMapString = null;
 
+  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Map&lt;String, Object&gt;
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP_MAP_ANYTYPE = "map_map_anytype";
   private Map<String, Map<String, Object>> mapMapAnytype = null;
 
-  @XmlElement(name = "anytype_1")
   public static final String JSON_PROPERTY_ANYTYPE1 = "anytype_1";
+  @XmlElement(name = "anytype_1")
   private Object anytype1;
 
-  @XmlElement(name = "anytype_2")
   public static final String JSON_PROPERTY_ANYTYPE2 = "anytype_2";
+  @XmlElement(name = "anytype_2")
   private Object anytype2;
 
-  @XmlElement(name = "anytype_3")
   public static final String JSON_PROPERTY_ANYTYPE3 = "anytype_3";
+  @XmlElement(name = "anytype_3")
   private Object anytype3;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -38,8 +38,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesInteger")
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private String name;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -39,8 +39,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesNumber")
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private String name;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -38,8 +38,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesObject")
 public class AdditionalPropertiesObject extends HashMap<String, Map> {
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private String name;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -38,8 +38,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "AdditionalPropertiesString")
 public class AdditionalPropertiesString extends HashMap<String, String> {
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private String name;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Animal.java
@@ -45,12 +45,12 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Animal")
 public class Animal {
-  @XmlElement(name = "className")
   public static final String JSON_PROPERTY_CLASS_NAME = "className";
+  @XmlElement(name = "className")
   private String className;
 
-  @XmlElement(name = "color")
   public static final String JSON_PROPERTY_COLOR = "color";
+  @XmlElement(name = "color")
   private String color = "red";
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -39,11 +39,11 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ArrayOfArrayOfNumberOnly")
 public class ArrayOfArrayOfNumberOnly {
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
   // Is a container wrapped=false
   // items.name=arrayArrayNumber items.baseName=arrayArrayNumber items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;BigDecimal&gt;
   @XmlElement(name = "arrayArrayNumber")
-  public static final String JSON_PROPERTY_ARRAY_ARRAY_NUMBER = "ArrayArrayNumber";
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -39,11 +39,11 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ArrayOfNumberOnly")
 public class ArrayOfNumberOnly {
+  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
   // Is a container wrapped=false
   // items.name=arrayNumber items.baseName=arrayNumber items.xmlName= items.xmlNamespace=
   // items.example= items.type=BigDecimal
   @XmlElement(name = "arrayNumber")
-  public static final String JSON_PROPERTY_ARRAY_NUMBER = "ArrayNumber";
   private List<BigDecimal> arrayNumber = null;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -41,25 +41,25 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ArrayTest")
 public class ArrayTest {
+  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
   // Is a container wrapped=false
   // items.name=arrayOfString items.baseName=arrayOfString items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "arrayOfString")
-  public static final String JSON_PROPERTY_ARRAY_OF_STRING = "array_of_string";
   private List<String> arrayOfString = null;
 
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
   // Is a container wrapped=false
   // items.name=arrayArrayOfInteger items.baseName=arrayArrayOfInteger items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;Long&gt;
   @XmlElement(name = "arrayArrayOfInteger")
-  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_INTEGER = "array_array_of_integer";
   private List<List<Long>> arrayArrayOfInteger = null;
 
+  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
   // Is a container wrapped=false
   // items.name=arrayArrayOfModel items.baseName=arrayArrayOfModel items.xmlName= items.xmlNamespace=
   // items.example= items.type=List&lt;ReadOnlyFirst&gt;
   @XmlElement(name = "arrayArrayOfModel")
-  public static final String JSON_PROPERTY_ARRAY_ARRAY_OF_MODEL = "array_array_of_model";
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -41,28 +41,28 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Capitalization")
 public class Capitalization {
-  @XmlElement(name = "smallCamel")
   public static final String JSON_PROPERTY_SMALL_CAMEL = "smallCamel";
+  @XmlElement(name = "smallCamel")
   private String smallCamel;
 
-  @XmlElement(name = "CapitalCamel")
   public static final String JSON_PROPERTY_CAPITAL_CAMEL = "CapitalCamel";
+  @XmlElement(name = "CapitalCamel")
   private String capitalCamel;
 
-  @XmlElement(name = "small_Snake")
   public static final String JSON_PROPERTY_SMALL_SNAKE = "small_Snake";
+  @XmlElement(name = "small_Snake")
   private String smallSnake;
 
-  @XmlElement(name = "Capital_Snake")
   public static final String JSON_PROPERTY_CAPITAL_SNAKE = "Capital_Snake";
+  @XmlElement(name = "Capital_Snake")
   private String capitalSnake;
 
-  @XmlElement(name = "SCA_ETH_Flow_Points")
   public static final String JSON_PROPERTY_SC_A_E_T_H_FLOW_POINTS = "SCA_ETH_Flow_Points";
+  @XmlElement(name = "SCA_ETH_Flow_Points")
   private String scAETHFlowPoints;
 
-  @XmlElement(name = "ATT_NAME")
   public static final String JSON_PROPERTY_A_T_T_N_A_M_E = "ATT_NAME";
+  @XmlElement(name = "ATT_NAME")
   private String ATT_NAME;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Cat.java
@@ -38,8 +38,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Cat")
 public class Cat extends Animal {
-  @XmlElement(name = "declawed")
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @XmlElement(name = "declawed")
   private Boolean declawed;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -36,8 +36,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "CatAllOf")
 public class CatAllOf {
-  @XmlElement(name = "declawed")
   public static final String JSON_PROPERTY_DECLAWED = "declawed";
+  @XmlElement(name = "declawed")
   private Boolean declawed;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Category.java
@@ -37,12 +37,12 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Category")
 public class Category {
-  @XmlElement(name = "id")
   public static final String JSON_PROPERTY_ID = "id";
+  @XmlElement(name = "id")
   private Long id;
 
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private String name = "default-name";
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -37,8 +37,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ClassModel")
 public class ClassModel {
-  @XmlElement(name = "_class")
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "_class";
+  @XmlElement(name = "_class")
   private String propertyClass;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Client.java
@@ -36,8 +36,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Client")
 public class Client {
-  @XmlElement(name = "client")
   public static final String JSON_PROPERTY_CLIENT = "client";
+  @XmlElement(name = "client")
   private String client;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Dog.java
@@ -38,8 +38,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Dog")
 public class Dog extends Animal {
-  @XmlElement(name = "breed")
   public static final String JSON_PROPERTY_BREED = "breed";
+  @XmlElement(name = "breed")
   private String breed;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -36,8 +36,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "DogAllOf")
 public class DogAllOf {
-  @XmlElement(name = "breed")
   public static final String JSON_PROPERTY_BREED = "breed";
+  @XmlElement(name = "breed")
   private String breed;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -74,8 +74,8 @@ public class EnumArrays {
     }
   }
 
-  @XmlElement(name = "just_symbol")
   public static final String JSON_PROPERTY_JUST_SYMBOL = "just_symbol";
+  @XmlElement(name = "just_symbol")
   private JustSymbolEnum justSymbol;
 
   /**
@@ -113,11 +113,11 @@ public class EnumArrays {
     }
   }
 
+  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
   // Is a container wrapped=false
   // items.name=arrayEnum items.baseName=arrayEnum items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "arrayEnum")
-  public static final String JSON_PROPERTY_ARRAY_ENUM = "array_enum";
   private List<ArrayEnumEnum> arrayEnum = null;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -78,8 +78,8 @@ public class EnumTest {
     }
   }
 
-  @XmlElement(name = "enum_string")
   public static final String JSON_PROPERTY_ENUM_STRING = "enum_string";
+  @XmlElement(name = "enum_string")
   private EnumStringEnum enumString;
 
   /**
@@ -119,8 +119,8 @@ public class EnumTest {
     }
   }
 
-  @XmlElement(name = "enum_string_required")
   public static final String JSON_PROPERTY_ENUM_STRING_REQUIRED = "enum_string_required";
+  @XmlElement(name = "enum_string_required")
   private EnumStringRequiredEnum enumStringRequired;
 
   /**
@@ -158,8 +158,8 @@ public class EnumTest {
     }
   }
 
-  @XmlElement(name = "enum_integer")
   public static final String JSON_PROPERTY_ENUM_INTEGER = "enum_integer";
+  @XmlElement(name = "enum_integer")
   private EnumIntegerEnum enumInteger;
 
   /**
@@ -197,12 +197,12 @@ public class EnumTest {
     }
   }
 
-  @XmlElement(name = "enum_number")
   public static final String JSON_PROPERTY_ENUM_NUMBER = "enum_number";
+  @XmlElement(name = "enum_number")
   private EnumNumberEnum enumNumber;
 
-  @XmlElement(name = "outerEnum")
   public static final String JSON_PROPERTY_OUTER_ENUM = "outerEnum";
+  @XmlElement(name = "outerEnum")
   private OuterEnum outerEnum;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -39,15 +39,15 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "FileSchemaTestClass")
 public class FileSchemaTestClass {
-  @XmlElement(name = "file")
   public static final String JSON_PROPERTY_FILE = "file";
+  @XmlElement(name = "file")
   private java.io.File file;
 
+  public static final String JSON_PROPERTY_FILES = "files";
   // Is a container wrapped=false
   // items.name=files items.baseName=files items.xmlName= items.xmlNamespace=
   // items.example= items.type=java.io.File
   @XmlElement(name = "files")
-  public static final String JSON_PROPERTY_FILES = "files";
   private List<java.io.File> files = null;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -54,60 +54,60 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "FormatTest")
 public class FormatTest {
-  @XmlElement(name = "integer")
   public static final String JSON_PROPERTY_INTEGER = "integer";
+  @XmlElement(name = "integer")
   private Integer integer;
 
-  @XmlElement(name = "int32")
   public static final String JSON_PROPERTY_INT32 = "int32";
+  @XmlElement(name = "int32")
   private Integer int32;
 
-  @XmlElement(name = "int64")
   public static final String JSON_PROPERTY_INT64 = "int64";
+  @XmlElement(name = "int64")
   private Long int64;
 
-  @XmlElement(name = "number")
   public static final String JSON_PROPERTY_NUMBER = "number";
+  @XmlElement(name = "number")
   private BigDecimal number;
 
-  @XmlElement(name = "float")
   public static final String JSON_PROPERTY_FLOAT = "float";
+  @XmlElement(name = "float")
   private Float _float;
 
-  @XmlElement(name = "double")
   public static final String JSON_PROPERTY_DOUBLE = "double";
+  @XmlElement(name = "double")
   private Double _double;
 
-  @XmlElement(name = "string")
   public static final String JSON_PROPERTY_STRING = "string";
+  @XmlElement(name = "string")
   private String string;
 
-  @XmlElement(name = "byte")
   public static final String JSON_PROPERTY_BYTE = "byte";
+  @XmlElement(name = "byte")
   private byte[] _byte;
 
-  @XmlElement(name = "binary")
   public static final String JSON_PROPERTY_BINARY = "binary";
+  @XmlElement(name = "binary")
   private File binary;
 
-  @XmlElement(name = "date")
   public static final String JSON_PROPERTY_DATE = "date";
+  @XmlElement(name = "date")
   private LocalDate date;
 
-  @XmlElement(name = "dateTime")
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @XmlElement(name = "dateTime")
   private OffsetDateTime dateTime;
 
-  @XmlElement(name = "uuid")
   public static final String JSON_PROPERTY_UUID = "uuid";
+  @XmlElement(name = "uuid")
   private UUID uuid;
 
-  @XmlElement(name = "password")
   public static final String JSON_PROPERTY_PASSWORD = "password";
+  @XmlElement(name = "password")
   private String password;
 
-  @XmlElement(name = "BigDecimal")
   public static final String JSON_PROPERTY_BIG_DECIMAL = "BigDecimal";
+  @XmlElement(name = "BigDecimal")
   private BigDecimal bigDecimal;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -37,12 +37,12 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "HasOnlyReadOnly")
 public class HasOnlyReadOnly {
-  @XmlElement(name = "bar")
   public static final String JSON_PROPERTY_BAR = "bar";
+  @XmlElement(name = "bar")
   private String bar;
 
-  @XmlElement(name = "foo")
   public static final String JSON_PROPERTY_FOO = "foo";
+  @XmlElement(name = "foo")
   private String foo;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MapTest.java
@@ -42,11 +42,11 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "MapTest")
 public class MapTest {
+  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Map&lt;String, String&gt;
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP_MAP_OF_STRING = "map_map_of_string";
   private Map<String, Map<String, String>> mapMapOfString = null;
 
   /**
@@ -84,25 +84,25 @@ public class MapTest {
     }
   }
 
+  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP_OF_ENUM_STRING = "map_of_enum_string";
   private Map<String, InnerEnum> mapOfEnumString = null;
 
+  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Boolean
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_DIRECT_MAP = "direct_map";
   private Map<String, Boolean> directMap = null;
 
+  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Boolean
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_INDIRECT_MAP = "indirect_map";
   private Map<String, Boolean> indirectMap = null;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -44,19 +44,19 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "MixedPropertiesAndAdditionalPropertiesClass")
 public class MixedPropertiesAndAdditionalPropertiesClass {
-  @XmlElement(name = "uuid")
   public static final String JSON_PROPERTY_UUID = "uuid";
+  @XmlElement(name = "uuid")
   private UUID uuid;
 
-  @XmlElement(name = "dateTime")
   public static final String JSON_PROPERTY_DATE_TIME = "dateTime";
+  @XmlElement(name = "dateTime")
   private OffsetDateTime dateTime;
 
+  public static final String JSON_PROPERTY_MAP = "map";
   // Is a container wrapped=false
   // items.name=inner items.baseName=inner items.xmlName= items.xmlNamespace=
   // items.example= items.type=Animal
   @XmlElement(name = "inner")
-  public static final String JSON_PROPERTY_MAP = "map";
   private Map<String, Animal> map = null;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -38,12 +38,12 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Name")
 public class Model200Response {
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private Integer name;
 
-  @XmlElement(name = "class")
   public static final String JSON_PROPERTY_PROPERTY_CLASS = "class";
+  @XmlElement(name = "class")
   private String propertyClass;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -38,16 +38,16 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ModelApiResponse")
 public class ModelApiResponse {
-  @XmlElement(name = "code")
   public static final String JSON_PROPERTY_CODE = "code";
+  @XmlElement(name = "code")
   private Integer code;
 
-  @XmlElement(name = "type")
   public static final String JSON_PROPERTY_TYPE = "type";
+  @XmlElement(name = "type")
   private String type;
 
-  @XmlElement(name = "message")
   public static final String JSON_PROPERTY_MESSAGE = "message";
+  @XmlElement(name = "message")
   private String message;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -37,8 +37,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Return")
 public class ModelReturn {
-  @XmlElement(name = "return")
   public static final String JSON_PROPERTY_RETURN = "return";
+  @XmlElement(name = "return")
   private Integer _return;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Name.java
@@ -40,20 +40,20 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Name")
 public class Name {
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private Integer name;
 
-  @XmlElement(name = "snake_case")
   public static final String JSON_PROPERTY_SNAKE_CASE = "snake_case";
+  @XmlElement(name = "snake_case")
   private Integer snakeCase;
 
-  @XmlElement(name = "property")
   public static final String JSON_PROPERTY_PROPERTY = "property";
+  @XmlElement(name = "property")
   private String property;
 
-  @XmlElement(name = "123Number")
   public static final String JSON_PROPERTY_123NUMBER = "123Number";
+  @XmlElement(name = "123Number")
   private Integer _123number;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -37,8 +37,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "NumberOnly")
 public class NumberOnly {
-  @XmlElement(name = "JustNumber")
   public static final String JSON_PROPERTY_JUST_NUMBER = "JustNumber";
+  @XmlElement(name = "JustNumber")
   private BigDecimal justNumber;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Order.java
@@ -42,20 +42,20 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Order")
 public class Order {
-  @XmlElement(name = "id")
   public static final String JSON_PROPERTY_ID = "id";
+  @XmlElement(name = "id")
   private Long id;
 
-  @XmlElement(name = "petId")
   public static final String JSON_PROPERTY_PET_ID = "petId";
+  @XmlElement(name = "petId")
   private Long petId;
 
-  @XmlElement(name = "quantity")
   public static final String JSON_PROPERTY_QUANTITY = "quantity";
+  @XmlElement(name = "quantity")
   private Integer quantity;
 
-  @XmlElement(name = "shipDate")
   public static final String JSON_PROPERTY_SHIP_DATE = "shipDate";
+  @XmlElement(name = "shipDate")
   private OffsetDateTime shipDate;
 
   /**
@@ -95,12 +95,12 @@ public class Order {
     }
   }
 
-  @XmlElement(name = "status")
   public static final String JSON_PROPERTY_STATUS = "status";
+  @XmlElement(name = "status")
   private StatusEnum status;
 
-  @XmlElement(name = "complete")
   public static final String JSON_PROPERTY_COMPLETE = "complete";
+  @XmlElement(name = "complete")
   private Boolean complete = false;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -39,16 +39,16 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "OuterComposite")
 public class OuterComposite {
-  @XmlElement(name = "my_number")
   public static final String JSON_PROPERTY_MY_NUMBER = "my_number";
+  @XmlElement(name = "my_number")
   private BigDecimal myNumber;
 
-  @XmlElement(name = "my_string")
   public static final String JSON_PROPERTY_MY_STRING = "my_string";
+  @XmlElement(name = "my_string")
   private String myString;
 
-  @XmlElement(name = "my_boolean")
   public static final String JSON_PROPERTY_MY_BOOLEAN = "my_boolean";
+  @XmlElement(name = "my_boolean")
   private Boolean myBoolean;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Pet.java
@@ -45,32 +45,32 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Pet")
 public class Pet {
-  @XmlElement(name = "id")
   public static final String JSON_PROPERTY_ID = "id";
+  @XmlElement(name = "id")
   private Long id;
 
-  @XmlElement(name = "category")
   public static final String JSON_PROPERTY_CATEGORY = "category";
+  @XmlElement(name = "category")
   private Category category;
 
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private String name;
 
+  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
   // Is a container wrapped=true
   // items.name=photoUrls items.baseName=photoUrls items.xmlName= items.xmlNamespace=
   // items.example= items.type=String
   @XmlElement(name = "photoUrls")
   @XmlElementWrapper(name = "photoUrl")
-  public static final String JSON_PROPERTY_PHOTO_URLS = "photoUrls";
   private List<String> photoUrls = new ArrayList<String>();
 
+  public static final String JSON_PROPERTY_TAGS = "tags";
   // Is a container wrapped=true
   // items.name=tags items.baseName=tags items.xmlName= items.xmlNamespace=
   // items.example= items.type=Tag
   @XmlElement(name = "tags")
   @XmlElementWrapper(name = "tag")
-  public static final String JSON_PROPERTY_TAGS = "tags";
   private List<Tag> tags = null;
 
   /**
@@ -110,8 +110,8 @@ public class Pet {
     }
   }
 
-  @XmlElement(name = "status")
   public static final String JSON_PROPERTY_STATUS = "status";
+  @XmlElement(name = "status")
   private StatusEnum status;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -37,12 +37,12 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "ReadOnlyFirst")
 public class ReadOnlyFirst {
-  @XmlElement(name = "bar")
   public static final String JSON_PROPERTY_BAR = "bar";
+  @XmlElement(name = "bar")
   private String bar;
 
-  @XmlElement(name = "baz")
   public static final String JSON_PROPERTY_BAZ = "baz";
+  @XmlElement(name = "baz")
   private String baz;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -36,8 +36,8 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "$special[model.name]")
 public class SpecialModelName {
-  @XmlElement(name = "$special[property.name]")
   public static final String JSON_PROPERTY_$_SPECIAL_PROPERTY_NAME = "$special[property.name]";
+  @XmlElement(name = "$special[property.name]")
   private Long $specialPropertyName;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/Tag.java
@@ -37,12 +37,12 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "Tag")
 public class Tag {
-  @XmlElement(name = "id")
   public static final String JSON_PROPERTY_ID = "id";
+  @XmlElement(name = "id")
   private Long id;
 
-  @XmlElement(name = "name")
   public static final String JSON_PROPERTY_NAME = "name";
+  @XmlElement(name = "name")
   private String name;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -43,27 +43,27 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "TypeHolderDefault")
 public class TypeHolderDefault {
-  @XmlElement(name = "string_item")
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @XmlElement(name = "string_item")
   private String stringItem = "what";
 
-  @XmlElement(name = "number_item")
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @XmlElement(name = "number_item")
   private BigDecimal numberItem;
 
-  @XmlElement(name = "integer_item")
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @XmlElement(name = "integer_item")
   private Integer integerItem;
 
-  @XmlElement(name = "bool_item")
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @XmlElement(name = "bool_item")
   private Boolean boolItem = true;
 
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
   // Is a container wrapped=false
   // items.name=arrayItem items.baseName=arrayItem items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "arrayItem")
-  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -44,31 +44,31 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "TypeHolderExample")
 public class TypeHolderExample {
-  @XmlElement(name = "string_item")
   public static final String JSON_PROPERTY_STRING_ITEM = "string_item";
+  @XmlElement(name = "string_item")
   private String stringItem;
 
-  @XmlElement(name = "number_item")
   public static final String JSON_PROPERTY_NUMBER_ITEM = "number_item";
+  @XmlElement(name = "number_item")
   private BigDecimal numberItem;
 
-  @XmlElement(name = "float_item")
   public static final String JSON_PROPERTY_FLOAT_ITEM = "float_item";
+  @XmlElement(name = "float_item")
   private Float floatItem;
 
-  @XmlElement(name = "integer_item")
   public static final String JSON_PROPERTY_INTEGER_ITEM = "integer_item";
+  @XmlElement(name = "integer_item")
   private Integer integerItem;
 
-  @XmlElement(name = "bool_item")
   public static final String JSON_PROPERTY_BOOL_ITEM = "bool_item";
+  @XmlElement(name = "bool_item")
   private Boolean boolItem;
 
+  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
   // Is a container wrapped=false
   // items.name=arrayItem items.baseName=arrayItem items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "arrayItem")
-  public static final String JSON_PROPERTY_ARRAY_ITEM = "array_item";
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/User.java
@@ -43,36 +43,36 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(localName = "User")
 public class User {
-  @XmlElement(name = "id")
   public static final String JSON_PROPERTY_ID = "id";
+  @XmlElement(name = "id")
   private Long id;
 
-  @XmlElement(name = "username")
   public static final String JSON_PROPERTY_USERNAME = "username";
+  @XmlElement(name = "username")
   private String username;
 
-  @XmlElement(name = "firstName")
   public static final String JSON_PROPERTY_FIRST_NAME = "firstName";
+  @XmlElement(name = "firstName")
   private String firstName;
 
-  @XmlElement(name = "lastName")
   public static final String JSON_PROPERTY_LAST_NAME = "lastName";
+  @XmlElement(name = "lastName")
   private String lastName;
 
-  @XmlElement(name = "email")
   public static final String JSON_PROPERTY_EMAIL = "email";
+  @XmlElement(name = "email")
   private String email;
 
-  @XmlElement(name = "password")
   public static final String JSON_PROPERTY_PASSWORD = "password";
+  @XmlElement(name = "password")
   private String password;
 
-  @XmlElement(name = "phone")
   public static final String JSON_PROPERTY_PHONE = "phone";
+  @XmlElement(name = "phone")
   private String phone;
 
-  @XmlElement(name = "userStatus")
   public static final String JSON_PROPERTY_USER_STATUS = "userStatus";
+  @XmlElement(name = "userStatus")
   private Integer userStatus;
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -67,152 +67,152 @@ import javax.xml.bind.annotation.*;
 @XmlAccessorType(XmlAccessType.FIELD)
 @JacksonXmlRootElement(namespace="http://a.com/schema", localName = "XmlItem")
 public class XmlItem {
-  @XmlAttribute(name = "attribute_string")
   public static final String JSON_PROPERTY_ATTRIBUTE_STRING = "attribute_string";
+  @XmlAttribute(name = "attribute_string")
   private String attributeString;
 
-  @XmlAttribute(name = "attribute_number")
   public static final String JSON_PROPERTY_ATTRIBUTE_NUMBER = "attribute_number";
+  @XmlAttribute(name = "attribute_number")
   private BigDecimal attributeNumber;
 
-  @XmlAttribute(name = "attribute_integer")
   public static final String JSON_PROPERTY_ATTRIBUTE_INTEGER = "attribute_integer";
+  @XmlAttribute(name = "attribute_integer")
   private Integer attributeInteger;
 
-  @XmlAttribute(name = "attribute_boolean")
   public static final String JSON_PROPERTY_ATTRIBUTE_BOOLEAN = "attribute_boolean";
+  @XmlAttribute(name = "attribute_boolean")
   private Boolean attributeBoolean;
 
+  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
   // Is a container wrapped=true
   // items.name=wrappedArray items.baseName=wrappedArray items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "wrappedArray")
   @XmlElementWrapper(name = "wrapped_array")
-  public static final String JSON_PROPERTY_WRAPPED_ARRAY = "wrapped_array";
   private List<Integer> wrappedArray = null;
 
-  @XmlElement(name = "xml_name_string")
   public static final String JSON_PROPERTY_NAME_STRING = "name_string";
+  @XmlElement(name = "xml_name_string")
   private String nameString;
 
-  @XmlElement(name = "xml_name_number")
   public static final String JSON_PROPERTY_NAME_NUMBER = "name_number";
+  @XmlElement(name = "xml_name_number")
   private BigDecimal nameNumber;
 
-  @XmlElement(name = "xml_name_integer")
   public static final String JSON_PROPERTY_NAME_INTEGER = "name_integer";
+  @XmlElement(name = "xml_name_integer")
   private Integer nameInteger;
 
-  @XmlElement(name = "xml_name_boolean")
   public static final String JSON_PROPERTY_NAME_BOOLEAN = "name_boolean";
+  @XmlElement(name = "xml_name_boolean")
   private Boolean nameBoolean;
 
+  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
   // Is a container wrapped=false
   // items.name=nameArray items.baseName=nameArray items.xmlName=xml_name_array_item items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "xml_name_array_item")
-  public static final String JSON_PROPERTY_NAME_ARRAY = "name_array";
   private List<Integer> nameArray = null;
 
+  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
   // Is a container wrapped=true
   // items.name=nameWrappedArray items.baseName=nameWrappedArray items.xmlName=xml_name_wrapped_array_item items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "xml_name_wrapped_array_item")
   @XmlElementWrapper(name = "xml_name_wrapped_array")
-  public static final String JSON_PROPERTY_NAME_WRAPPED_ARRAY = "name_wrapped_array";
   private List<Integer> nameWrappedArray = null;
 
-  @XmlElement(name = "prefix_string")
   public static final String JSON_PROPERTY_PREFIX_STRING = "prefix_string";
+  @XmlElement(name = "prefix_string")
   private String prefixString;
 
-  @XmlElement(name = "prefix_number")
   public static final String JSON_PROPERTY_PREFIX_NUMBER = "prefix_number";
+  @XmlElement(name = "prefix_number")
   private BigDecimal prefixNumber;
 
-  @XmlElement(name = "prefix_integer")
   public static final String JSON_PROPERTY_PREFIX_INTEGER = "prefix_integer";
+  @XmlElement(name = "prefix_integer")
   private Integer prefixInteger;
 
-  @XmlElement(name = "prefix_boolean")
   public static final String JSON_PROPERTY_PREFIX_BOOLEAN = "prefix_boolean";
+  @XmlElement(name = "prefix_boolean")
   private Boolean prefixBoolean;
 
+  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
   // Is a container wrapped=false
   // items.name=prefixArray items.baseName=prefixArray items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "prefixArray")
-  public static final String JSON_PROPERTY_PREFIX_ARRAY = "prefix_array";
   private List<Integer> prefixArray = null;
 
+  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
   // Is a container wrapped=true
   // items.name=prefixWrappedArray items.baseName=prefixWrappedArray items.xmlName= items.xmlNamespace=
   // items.example= items.type=Integer
   @XmlElement(name = "prefixWrappedArray")
   @XmlElementWrapper(name = "prefix_wrapped_array")
-  public static final String JSON_PROPERTY_PREFIX_WRAPPED_ARRAY = "prefix_wrapped_array";
   private List<Integer> prefixWrappedArray = null;
 
-  @XmlElement(namespace="http://a.com/schema", name = "namespace_string")
   public static final String JSON_PROPERTY_NAMESPACE_STRING = "namespace_string";
+  @XmlElement(namespace="http://a.com/schema", name = "namespace_string")
   private String namespaceString;
 
-  @XmlElement(namespace="http://b.com/schema", name = "namespace_number")
   public static final String JSON_PROPERTY_NAMESPACE_NUMBER = "namespace_number";
+  @XmlElement(namespace="http://b.com/schema", name = "namespace_number")
   private BigDecimal namespaceNumber;
 
-  @XmlElement(namespace="http://c.com/schema", name = "namespace_integer")
   public static final String JSON_PROPERTY_NAMESPACE_INTEGER = "namespace_integer";
+  @XmlElement(namespace="http://c.com/schema", name = "namespace_integer")
   private Integer namespaceInteger;
 
-  @XmlElement(namespace="http://d.com/schema", name = "namespace_boolean")
   public static final String JSON_PROPERTY_NAMESPACE_BOOLEAN = "namespace_boolean";
+  @XmlElement(namespace="http://d.com/schema", name = "namespace_boolean")
   private Boolean namespaceBoolean;
 
+  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
   // Is a container wrapped=false
   // items.name=namespaceArray items.baseName=namespaceArray items.xmlName= items.xmlNamespace=http://e.com/schema
   // items.example= items.type=Integer
   @XmlElement(namespace="http://e.com/schema", name = "namespaceArray")
-  public static final String JSON_PROPERTY_NAMESPACE_ARRAY = "namespace_array";
   private List<Integer> namespaceArray = null;
 
+  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
   // Is a container wrapped=true
   // items.name=namespaceWrappedArray items.baseName=namespaceWrappedArray items.xmlName= items.xmlNamespace=http://g.com/schema
   // items.example= items.type=Integer
   @XmlElement(namespace="http://g.com/schema", name = "namespaceWrappedArray")
   @XmlElementWrapper(namespace="http://f.com/schema", name = "namespace_wrapped_array")
-  public static final String JSON_PROPERTY_NAMESPACE_WRAPPED_ARRAY = "namespace_wrapped_array";
   private List<Integer> namespaceWrappedArray = null;
 
-  @XmlElement(namespace="http://a.com/schema", name = "prefix_ns_string")
   public static final String JSON_PROPERTY_PREFIX_NS_STRING = "prefix_ns_string";
+  @XmlElement(namespace="http://a.com/schema", name = "prefix_ns_string")
   private String prefixNsString;
 
-  @XmlElement(namespace="http://b.com/schema", name = "prefix_ns_number")
   public static final String JSON_PROPERTY_PREFIX_NS_NUMBER = "prefix_ns_number";
+  @XmlElement(namespace="http://b.com/schema", name = "prefix_ns_number")
   private BigDecimal prefixNsNumber;
 
-  @XmlElement(namespace="http://c.com/schema", name = "prefix_ns_integer")
   public static final String JSON_PROPERTY_PREFIX_NS_INTEGER = "prefix_ns_integer";
+  @XmlElement(namespace="http://c.com/schema", name = "prefix_ns_integer")
   private Integer prefixNsInteger;
 
-  @XmlElement(namespace="http://d.com/schema", name = "prefix_ns_boolean")
   public static final String JSON_PROPERTY_PREFIX_NS_BOOLEAN = "prefix_ns_boolean";
+  @XmlElement(namespace="http://d.com/schema", name = "prefix_ns_boolean")
   private Boolean prefixNsBoolean;
 
+  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
   // Is a container wrapped=false
   // items.name=prefixNsArray items.baseName=prefixNsArray items.xmlName= items.xmlNamespace=http://e.com/schema
   // items.example= items.type=Integer
   @XmlElement(namespace="http://e.com/schema", name = "prefixNsArray")
-  public static final String JSON_PROPERTY_PREFIX_NS_ARRAY = "prefix_ns_array";
   private List<Integer> prefixNsArray = null;
 
+  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
   // Is a container wrapped=true
   // items.name=prefixNsWrappedArray items.baseName=prefixNsWrappedArray items.xmlName= items.xmlNamespace=http://g.com/schema
   // items.example= items.type=Integer
   @XmlElement(namespace="http://g.com/schema", name = "prefixNsWrappedArray")
   @XmlElementWrapper(namespace="http://f.com/schema", name = "prefix_ns_wrapped_array")
-  public static final String JSON_PROPERTY_PREFIX_NS_WRAPPED_ARRAY = "prefix_ns_wrapped_array";
   private List<Integer> prefixNsWrappedArray = null;
 
 


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)

### Description of the PR

Fixes regression reported in #4014.

@RockyMM since the current test cases don't cover this, could you try to grab this patch and verify that it fixes the regresssion? Thanks!