### PR TITLE
[PHP] Correctly format JSON in headers

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -140,7 +140,11 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-       return json_encode(ObjectSerializer::sanitizeForSerialization($value));
+        if (method_exists($value, 'toHeaderValue')) {
+            return $value->toHeaderValue();
+        }
+
+        return self::toString($value);
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -140,7 +140,7 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        return self::toString($value);
+       return json_encode(ObjectSerializer::sanitizeForSerialization($value));
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -140,7 +140,11 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        return str_replace(PHP_EOL, '', (string)$value);
+        if (method_exists($value, 'toHeaderValue')) {
+            return $value->toHeaderValue();
+        }
+
+        return self::toString($value);
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -140,11 +140,7 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        if (method_exists($value, 'toHeaderValue')) {
-            return $value->toHeaderValue();
-        }
-
-        return self::toString($value);
+        return str_replace(PHP_EOL, '', (string)$value);
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -410,4 +410,14 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -410,14 +410,4 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesAnyType.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesAnyType.php
@@ -292,6 +292,16 @@ class AdditionalPropertiesAnyType implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesAnyType.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesAnyType.php
@@ -292,16 +292,6 @@ class AdditionalPropertiesAnyType implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesArray.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesArray.php
@@ -292,16 +292,6 @@ class AdditionalPropertiesArray implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesArray.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesArray.php
@@ -292,6 +292,16 @@ class AdditionalPropertiesArray implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesBoolean.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesBoolean.php
@@ -292,6 +292,16 @@ class AdditionalPropertiesBoolean implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesBoolean.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesBoolean.php
@@ -292,16 +292,6 @@ class AdditionalPropertiesBoolean implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -592,16 +592,6 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -592,6 +592,16 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesInteger.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesInteger.php
@@ -292,16 +292,6 @@ class AdditionalPropertiesInteger implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesInteger.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesInteger.php
@@ -292,6 +292,16 @@ class AdditionalPropertiesInteger implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesNumber.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesNumber.php
@@ -292,6 +292,16 @@ class AdditionalPropertiesNumber implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesNumber.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesNumber.php
@@ -292,16 +292,6 @@ class AdditionalPropertiesNumber implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesObject.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesObject.php
@@ -292,16 +292,6 @@ class AdditionalPropertiesObject implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesObject.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesObject.php
@@ -292,6 +292,16 @@ class AdditionalPropertiesObject implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesString.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesString.php
@@ -292,16 +292,6 @@ class AdditionalPropertiesString implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesString.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesString.php
@@ -292,6 +292,16 @@ class AdditionalPropertiesString implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -328,16 +328,6 @@ class Animal implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -328,6 +328,16 @@ class Animal implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -352,16 +352,6 @@ class ApiResponse implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -352,6 +352,16 @@ class ApiResponse implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -292,6 +292,16 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -292,16 +292,6 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -292,6 +292,16 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -292,16 +292,6 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -352,16 +352,6 @@ class ArrayTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -352,6 +352,16 @@ class ArrayTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -442,16 +442,6 @@ class Capitalization implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -442,6 +442,16 @@ class Capitalization implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
@@ -286,6 +286,16 @@ class Cat extends Animal
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
@@ -286,16 +286,6 @@ class Cat extends Animal
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
@@ -292,16 +292,6 @@ class CatAllOf implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
@@ -292,6 +292,16 @@ class CatAllOf implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -325,16 +325,6 @@ class Category implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -325,6 +325,16 @@ class Category implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
@@ -293,6 +293,16 @@ class ClassModel implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
@@ -293,16 +293,6 @@ class ClassModel implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
@@ -292,6 +292,16 @@ class Client implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
@@ -292,16 +292,6 @@ class Client implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
@@ -286,6 +286,16 @@ class Dog extends Animal
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
@@ -286,16 +286,6 @@ class Dog extends Animal
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
@@ -292,6 +292,16 @@ class DogAllOf implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
@@ -292,16 +292,6 @@ class DogAllOf implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -378,6 +378,16 @@ class EnumArrays implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -378,16 +378,6 @@ class EnumArrays implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -547,6 +547,16 @@ class EnumTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -547,16 +547,6 @@ class EnumTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
@@ -293,6 +293,16 @@ class File implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
@@ -293,16 +293,6 @@ class File implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -322,6 +322,16 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -322,16 +322,6 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -807,6 +807,16 @@ class FormatTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -807,16 +807,6 @@ class FormatTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -322,16 +322,6 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -322,6 +322,16 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -406,16 +406,6 @@ class MapTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -406,6 +406,16 @@ class MapTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -352,16 +352,6 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -352,6 +352,16 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -323,16 +323,6 @@ class Model200Response implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -323,6 +323,16 @@ class Model200Response implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
@@ -292,16 +292,6 @@ class ModelList implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
@@ -292,6 +292,16 @@ class ModelList implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
@@ -293,16 +293,6 @@ class ModelReturn implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
@@ -293,6 +293,16 @@ class ModelReturn implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -386,16 +386,6 @@ class Name implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -386,6 +386,16 @@ class Name implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
@@ -292,16 +292,6 @@ class NumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
@@ -292,6 +292,16 @@ class NumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -476,6 +476,16 @@ class Order implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -476,16 +476,6 @@ class Order implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -352,6 +352,16 @@ class OuterComposite implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -352,16 +352,6 @@ class OuterComposite implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -482,16 +482,6 @@ class Pet implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -482,6 +482,16 @@ class Pet implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -322,16 +322,6 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -322,6 +322,16 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
@@ -292,16 +292,6 @@ class SpecialModelName implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
@@ -292,6 +292,16 @@ class SpecialModelName implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -322,6 +322,16 @@ class Tag implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -322,16 +322,6 @@ class Tag implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/TypeHolderDefault.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/TypeHolderDefault.php
@@ -427,16 +427,6 @@ class TypeHolderDefault implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/TypeHolderDefault.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/TypeHolderDefault.php
@@ -427,6 +427,16 @@ class TypeHolderDefault implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/TypeHolderExample.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/TypeHolderExample.php
@@ -460,6 +460,16 @@ class TypeHolderExample implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/TypeHolderExample.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/TypeHolderExample.php
@@ -460,16 +460,6 @@ class TypeHolderExample implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -502,6 +502,16 @@ class User implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -502,16 +502,6 @@ class User implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/XmlItem.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/XmlItem.php
@@ -1132,16 +1132,6 @@ class XmlItem implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/XmlItem.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/XmlItem.php
@@ -1132,6 +1132,16 @@ class XmlItem implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -150,7 +150,7 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        return self::toString($value);
+        return json_encode(ObjectSerializer::sanitizeForSerialization($value));
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -150,11 +150,7 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        if (method_exists($value, 'toHeaderValue')) {
-            return $value->toHeaderValue();
-        }
-
-        return self::toString($value);
+        return str_replace(PHP_EOL, '', (string)$value);
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -150,7 +150,11 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($value));
+        if (method_exists($value, 'toHeaderValue')) {
+            return $value->toHeaderValue();
+        }
+
+        return self::toString($value);
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -150,7 +150,11 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        return str_replace(PHP_EOL, '', (string)$value);
+        if (method_exists($value, 'toHeaderValue')) {
+            return $value->toHeaderValue();
+        }
+
+        return self::toString($value);
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -322,16 +322,6 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -322,6 +322,16 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -328,16 +328,6 @@ class Animal implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -328,6 +328,16 @@ class Animal implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -352,16 +352,6 @@ class ApiResponse implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -352,6 +352,16 @@ class ApiResponse implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -292,6 +292,16 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfArrayOfNumberOnly.php
@@ -292,16 +292,6 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -292,6 +292,16 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayOfNumberOnly.php
@@ -292,16 +292,6 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -352,16 +352,6 @@ class ArrayTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -352,6 +352,16 @@ class ArrayTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -442,16 +442,6 @@ class Capitalization implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -442,6 +442,16 @@ class Capitalization implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
@@ -286,6 +286,16 @@ class Cat extends Animal
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Cat.php
@@ -286,16 +286,6 @@ class Cat extends Animal
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
@@ -292,16 +292,6 @@ class CatAllOf implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/CatAllOf.php
@@ -292,6 +292,16 @@ class CatAllOf implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -325,16 +325,6 @@ class Category implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -325,6 +325,16 @@ class Category implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
@@ -293,6 +293,16 @@ class ClassModel implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ClassModel.php
@@ -293,16 +293,6 @@ class ClassModel implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
@@ -292,6 +292,16 @@ class Client implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Client.php
@@ -292,16 +292,6 @@ class Client implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
@@ -286,6 +286,16 @@ class Dog extends Animal
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Dog.php
@@ -286,16 +286,6 @@ class Dog extends Animal
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
@@ -292,6 +292,16 @@ class DogAllOf implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/DogAllOf.php
@@ -292,16 +292,6 @@ class DogAllOf implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -378,6 +378,16 @@ class EnumArrays implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -378,16 +378,6 @@ class EnumArrays implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -637,16 +637,6 @@ class EnumTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -637,6 +637,16 @@ class EnumTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
@@ -293,6 +293,16 @@ class File implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/File.php
@@ -293,16 +293,6 @@ class File implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -322,6 +322,16 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -322,16 +322,6 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
@@ -292,6 +292,16 @@ class Foo implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Foo.php
@@ -292,16 +292,6 @@ class Foo implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -846,16 +846,6 @@ class FormatTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -846,6 +846,16 @@ class FormatTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -322,16 +322,6 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -322,6 +322,16 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
@@ -293,16 +293,6 @@ class HealthCheckResult implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/HealthCheckResult.php
@@ -293,6 +293,16 @@ class HealthCheckResult implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject.php
@@ -322,16 +322,6 @@ class InlineObject implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject.php
@@ -322,6 +322,16 @@ class InlineObject implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject1.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject1.php
@@ -322,16 +322,6 @@ class InlineObject1 implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject1.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject1.php
@@ -322,6 +322,16 @@ class InlineObject1 implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject2.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject2.php
@@ -380,16 +380,6 @@ class InlineObject2 implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject2.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject2.php
@@ -380,6 +380,16 @@ class InlineObject2 implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject3.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject3.php
@@ -800,6 +800,16 @@ class InlineObject3 implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject3.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject3.php
@@ -800,16 +800,6 @@ class InlineObject3 implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject4.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject4.php
@@ -328,16 +328,6 @@ class InlineObject4 implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject4.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject4.php
@@ -328,6 +328,16 @@ class InlineObject4 implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject5.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject5.php
@@ -325,16 +325,6 @@ class InlineObject5 implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject5.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineObject5.php
@@ -325,6 +325,16 @@ class InlineObject5 implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineResponseDefault.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineResponseDefault.php
@@ -292,16 +292,6 @@ class InlineResponseDefault implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineResponseDefault.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/InlineResponseDefault.php
@@ -292,6 +292,16 @@ class InlineResponseDefault implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -406,16 +406,6 @@ class MapTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -406,6 +406,16 @@ class MapTest implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -352,16 +352,6 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -352,6 +352,16 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -323,16 +323,6 @@ class Model200Response implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -323,6 +323,16 @@ class Model200Response implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
@@ -292,16 +292,6 @@ class ModelList implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ModelList.php
@@ -292,6 +292,16 @@ class ModelList implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
@@ -293,16 +293,6 @@ class ModelReturn implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ModelReturn.php
@@ -293,6 +293,16 @@ class ModelReturn implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -386,16 +386,6 @@ class Name implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -386,6 +386,16 @@ class Name implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -622,16 +622,6 @@ class NullableClass implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -622,6 +622,16 @@ class NullableClass implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
@@ -292,16 +292,6 @@ class NumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/NumberOnly.php
@@ -292,6 +292,16 @@ class NumberOnly implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -476,6 +476,16 @@ class Order implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -476,16 +476,6 @@ class Order implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -352,6 +352,16 @@ class OuterComposite implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -352,16 +352,6 @@ class OuterComposite implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -482,16 +482,6 @@ class Pet implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -482,6 +482,16 @@ class Pet implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -322,16 +322,6 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -322,6 +322,16 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
@@ -292,16 +292,6 @@ class SpecialModelName implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/SpecialModelName.php
@@ -292,6 +292,16 @@ class SpecialModelName implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -322,6 +322,16 @@ class Tag implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -322,16 +322,6 @@ class Tag implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -502,6 +502,16 @@ class User implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
+
+    /**
+     * Gets a header-safe presentation of the object
+     *
+     * @return string
+     */
+    public function toHeaderValue()
+    {
+        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
+    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -502,16 +502,6 @@ class User implements ModelInterface, ArrayAccess
             JSON_PRETTY_PRINT
         );
     }
-
-    /**
-     * Gets a header-safe presentation of the object
-     *
-     * @return string
-     */
-    public function toHeaderValue()
-    {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($this));
-    }
 }
 
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -150,7 +150,7 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        return self::toString($value);
+        return json_encode(ObjectSerializer::sanitizeForSerialization($value));
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -150,11 +150,7 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        if (method_exists($value, 'toHeaderValue')) {
-            return $value->toHeaderValue();
-        }
-
-        return self::toString($value);
+        return str_replace(PHP_EOL, '', (string)$value);
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -150,7 +150,11 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        return json_encode(ObjectSerializer::sanitizeForSerialization($value));
+        if (method_exists($value, 'toHeaderValue')) {
+            return $value->toHeaderValue();
+        }
+
+        return self::toString($value);
     }
 
     /**

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -150,7 +150,11 @@ class ObjectSerializer
      */
     public static function toHeaderValue($value)
     {
-        return str_replace(PHP_EOL, '', (string)$value);
+        if (method_exists($value, 'toHeaderValue')) {
+            return $value->toHeaderValue();
+        }
+
+        return self::toString($value);
     }
 
     /**


### PR DESCRIPTION
`ObjectSerializer::toHeaderValue()` in the generated PHP code calls
`toString()` on the values, which formats JSON with the `JSON_PRETTY_PRINT`
option. This will result in a multi-line header which cannot be parsed
since linebreaks aren't allowed by RFC 7230.

In my case I have a header schema called `UpdateUser` which I had hoped
would be serialized as `{"type":"staff","id":123}`.

This PR adds a `toHeaderValue()` method to models which doesn't use `JSON_PRETTY_PRINT`. Works for me.

FYI @jebentier @dkarlovi @mandrean @jfastnacht @ackintosh @ybelenko @renepardon