### PR TITLE
typescript-fetch: fix return type of primitive value

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -232,7 +232,7 @@ export class {{classname}} extends runtime.BaseAPI {
         return new runtime.JSONApiResponse<any>(response);
         {{/isListContainer}}
         {{#returnSimpleType}}
-        return new runtime.TextApiResponse(response as any);
+        return new runtime.TextApiResponse(response) as any;
         {{/returnSimpleType}}
         {{/returnTypeIsPrimitive}}
         {{^returnTypeIsPrimitive}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -232,7 +232,7 @@ export class {{classname}} extends runtime.BaseAPI {
         return new runtime.JSONApiResponse<any>(response);
         {{/isListContainer}}
         {{#returnSimpleType}}
-        return new runtime.TextApiResponse(response);
+        return new runtime.TextApiResponse(response as any);
         {{/returnSimpleType}}
         {{/returnTypeIsPrimitive}}
         {{^returnTypeIsPrimitive}}

--- a/samples/client/petstore/typescript-fetch/builds/default/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/src/apis/UserApi.ts
@@ -244,7 +244,7 @@ export class UserApi extends runtime.BaseAPI {
             query: queryParameters,
         });
 
-        return new runtime.TextApiResponse(response);
+        return new runtime.TextApiResponse(response) as any;
     }
 
     /**

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -244,7 +244,7 @@ export class UserApi extends runtime.BaseAPI {
             query: queryParameters,
         });
 
-        return new runtime.TextApiResponse(response);
+        return new runtime.TextApiResponse(response) as any;
     }
 
     /**

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/apis/UserApi.ts
@@ -244,7 +244,7 @@ export class UserApi extends runtime.BaseAPI {
             query: queryParameters,
         });
 
-        return new runtime.TextApiResponse(response);
+        return new runtime.TextApiResponse(response) as any;
     }
 
     /**

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -244,7 +244,7 @@ export class UserApi extends runtime.BaseAPI {
             query: queryParameters,
         });
 
-        return new runtime.TextApiResponse(response);
+        return new runtime.TextApiResponse(response) as any;
     }
 
     /**

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/apis/UserApi.ts
@@ -244,7 +244,7 @@ export class UserApi extends runtime.BaseAPI {
             query: queryParameters,
         });
 
-        return new runtime.TextApiResponse(response);
+        return new runtime.TextApiResponse(response) as any;
     }
 
     /**

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/apis/UserApi.ts
@@ -244,7 +244,7 @@ export class UserApi extends runtime.BaseAPI {
             query: queryParameters,
         });
 
-        return new runtime.TextApiResponse(response);
+        return new runtime.TextApiResponse(response) as any;
     }
 
     /**

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -244,7 +244,7 @@ export class UserApi extends runtime.BaseAPI {
             query: queryParameters,
         });
 
-        return new runtime.TextApiResponse(response);
+        return new runtime.TextApiResponse(response) as any;
     }
 
     /**


### PR DESCRIPTION
Fixes #3709 
Fixes #2870.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

