### PR TITLE
[Java] Add fluent getters

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -95,6 +95,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   {{/parcelableModel}}
   {{#vars}}
 
+  public {{{datatypeWithEnum}}} {{name}}() {
+    return {{name}};
+  }
+
   {{^isReadOnly}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     {{#vendorExtensions.isJacksonOptionalNullable}}this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});{{/vendorExtensions.isJacksonOptionalNullable}}

--- a/modules/openapi-generator/src/main/resources/JavaInflector/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaInflector/pojo.mustache
@@ -27,6 +27,11 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   {{/vars}}
   {{#vars}}
+
+  public {{{datatypeWithEnum}}} {{name}}() {
+    return {{name}};
+  }
+
   /**{{#description}}
    * {{{description}}}{{/description}}{{#minimum}}
    * minimum: {{minimum}}{{/minimum}}{{#maximum}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/pojo.mustache
@@ -39,6 +39,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   {{/vars}}
   {{#vars}}
+  public {{{datatypeWithEnum}}} {{name}}() {
+    return {{name}};
+  }
+
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
     return this;

--- a/modules/openapi-generator/src/main/resources/JavaPlayFramework/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaPlayFramework/pojo.mustache
@@ -34,6 +34,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   {{/vars}}
   {{#vars}}
+  public {{{datatypeWithEnum}}} {{name}}() {
+    return {{name}};
+  }
+
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
     return this;

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -36,6 +36,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}
 
   {{/vars}}
   {{#vars}}
+  public {{{datatypeWithEnum}}} {{name}}() {
+    return {{name}};
+  }
+
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{#isNullable}}JsonNullable.of({{name}}){{/isNullable}}{{^isNullable}}{{name}}{{/isNullable}};
     return this;

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/pojo.mustache
@@ -30,6 +30,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   {{/vars}}
   {{#vars}}
+  public {{{datatypeWithEnum}}} {{name}}() {
+    return {{name}};
+  }
+
   {{^isReadOnly}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};

--- a/modules/openapi-generator/src/main/resources/java-pkmst/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/pojo.mustache
@@ -37,6 +37,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   {{/vars}}
   {{#vars}}
+  public {{{datatypeWithEnum}}} {{name}}() {
+    return {{name}};
+  }
+
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{name}};
     return this;

--- a/modules/openapi-generator/src/main/resources/java-undertow-server/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-undertow-server/pojo.mustache
@@ -9,6 +9,10 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
   private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};{{/vars}}
 
   {{#vars}}
+  public {{{datatypeWithEnum}}} {{name}}() {
+    return {{name}};
+  }
+
   /**{{#description}}
    * {{{description}}}{{/description}}{{#minimum}}
    * minimum: {{minimum}}{{/minimum}}{{#maximum}}

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesAnyType.java
@@ -37,6 +37,10 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> {
   private String name;
 
 
+  public String name() {
+    return name;
+  }
+
   public AdditionalPropertiesAnyType name(String name) {
     
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesArray.java
@@ -38,6 +38,10 @@ public class AdditionalPropertiesArray extends HashMap<String, List> {
   private String name;
 
 
+  public String name() {
+    return name;
+  }
+
   public AdditionalPropertiesArray name(String name) {
     
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesBoolean.java
@@ -37,6 +37,10 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> {
   private String name;
 
 
+  public String name() {
+    return name;
+  }
+
   public AdditionalPropertiesBoolean name(String name) {
     
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesClass.java
@@ -79,6 +79,10 @@ public class AdditionalPropertiesClass {
   private Object anytype3;
 
 
+  public Map<String, String> mapString() {
+    return mapString;
+  }
+
   public AdditionalPropertiesClass mapString(Map<String, String> mapString) {
     
     this.mapString = mapString;
@@ -112,6 +116,10 @@ public class AdditionalPropertiesClass {
     this.mapString = mapString;
   }
 
+
+  public Map<String, BigDecimal> mapNumber() {
+    return mapNumber;
+  }
 
   public AdditionalPropertiesClass mapNumber(Map<String, BigDecimal> mapNumber) {
     
@@ -147,6 +155,10 @@ public class AdditionalPropertiesClass {
   }
 
 
+  public Map<String, Integer> mapInteger() {
+    return mapInteger;
+  }
+
   public AdditionalPropertiesClass mapInteger(Map<String, Integer> mapInteger) {
     
     this.mapInteger = mapInteger;
@@ -180,6 +192,10 @@ public class AdditionalPropertiesClass {
     this.mapInteger = mapInteger;
   }
 
+
+  public Map<String, Boolean> mapBoolean() {
+    return mapBoolean;
+  }
 
   public AdditionalPropertiesClass mapBoolean(Map<String, Boolean> mapBoolean) {
     
@@ -215,6 +231,10 @@ public class AdditionalPropertiesClass {
   }
 
 
+  public Map<String, List<Integer>> mapArrayInteger() {
+    return mapArrayInteger;
+  }
+
   public AdditionalPropertiesClass mapArrayInteger(Map<String, List<Integer>> mapArrayInteger) {
     
     this.mapArrayInteger = mapArrayInteger;
@@ -248,6 +268,10 @@ public class AdditionalPropertiesClass {
     this.mapArrayInteger = mapArrayInteger;
   }
 
+
+  public Map<String, List<Object>> mapArrayAnytype() {
+    return mapArrayAnytype;
+  }
 
   public AdditionalPropertiesClass mapArrayAnytype(Map<String, List<Object>> mapArrayAnytype) {
     
@@ -283,6 +307,10 @@ public class AdditionalPropertiesClass {
   }
 
 
+  public Map<String, Map<String, String>> mapMapString() {
+    return mapMapString;
+  }
+
   public AdditionalPropertiesClass mapMapString(Map<String, Map<String, String>> mapMapString) {
     
     this.mapMapString = mapMapString;
@@ -316,6 +344,10 @@ public class AdditionalPropertiesClass {
     this.mapMapString = mapMapString;
   }
 
+
+  public Map<String, Map<String, Object>> mapMapAnytype() {
+    return mapMapAnytype;
+  }
 
   public AdditionalPropertiesClass mapMapAnytype(Map<String, Map<String, Object>> mapMapAnytype) {
     
@@ -351,6 +383,10 @@ public class AdditionalPropertiesClass {
   }
 
 
+  public Object anytype1() {
+    return anytype1;
+  }
+
   public AdditionalPropertiesClass anytype1(Object anytype1) {
     
     this.anytype1 = anytype1;
@@ -377,6 +413,10 @@ public class AdditionalPropertiesClass {
   }
 
 
+  public Object anytype2() {
+    return anytype2;
+  }
+
   public AdditionalPropertiesClass anytype2(Object anytype2) {
     
     this.anytype2 = anytype2;
@@ -402,6 +442,10 @@ public class AdditionalPropertiesClass {
     this.anytype2 = anytype2;
   }
 
+
+  public Object anytype3() {
+    return anytype3;
+  }
 
   public AdditionalPropertiesClass anytype3(Object anytype3) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesInteger.java
@@ -37,6 +37,10 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> {
   private String name;
 
 
+  public String name() {
+    return name;
+  }
+
   public AdditionalPropertiesInteger name(String name) {
     
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesNumber.java
@@ -38,6 +38,10 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> {
   private String name;
 
 
+  public String name() {
+    return name;
+  }
+
   public AdditionalPropertiesNumber name(String name) {
     
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesObject.java
@@ -37,6 +37,10 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> {
   private String name;
 
 
+  public String name() {
+    return name;
+  }
+
   public AdditionalPropertiesObject name(String name) {
     
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/AdditionalPropertiesString.java
@@ -37,6 +37,10 @@ public class AdditionalPropertiesString extends HashMap<String, String> {
   private String name;
 
 
+  public String name() {
+    return name;
+  }
+
   public AdditionalPropertiesString name(String name) {
     
     this.name = name;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Animal.java
@@ -47,6 +47,10 @@ public class Animal {
   private String color = "red";
 
 
+  public String className() {
+    return className;
+  }
+
   public Animal className(String className) {
     
     this.className = className;
@@ -71,6 +75,10 @@ public class Animal {
     this.className = className;
   }
 
+
+  public String color() {
+    return color;
+  }
 
   public Animal color(String color) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfArrayOfNumberOnly.java
@@ -38,6 +38,10 @@ public class ArrayOfArrayOfNumberOnly {
   private List<List<BigDecimal>> arrayArrayNumber = null;
 
 
+  public List<List<BigDecimal>> arrayArrayNumber() {
+    return arrayArrayNumber;
+  }
+
   public ArrayOfArrayOfNumberOnly arrayArrayNumber(List<List<BigDecimal>> arrayArrayNumber) {
     
     this.arrayArrayNumber = arrayArrayNumber;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayOfNumberOnly.java
@@ -38,6 +38,10 @@ public class ArrayOfNumberOnly {
   private List<BigDecimal> arrayNumber = null;
 
 
+  public List<BigDecimal> arrayNumber() {
+    return arrayNumber;
+  }
+
   public ArrayOfNumberOnly arrayNumber(List<BigDecimal> arrayNumber) {
     
     this.arrayNumber = arrayNumber;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ArrayTest.java
@@ -46,6 +46,10 @@ public class ArrayTest {
   private List<List<ReadOnlyFirst>> arrayArrayOfModel = null;
 
 
+  public List<String> arrayOfString() {
+    return arrayOfString;
+  }
+
   public ArrayTest arrayOfString(List<String> arrayOfString) {
     
     this.arrayOfString = arrayOfString;
@@ -80,6 +84,10 @@ public class ArrayTest {
   }
 
 
+  public List<List<Long>> arrayArrayOfInteger() {
+    return arrayArrayOfInteger;
+  }
+
   public ArrayTest arrayArrayOfInteger(List<List<Long>> arrayArrayOfInteger) {
     
     this.arrayArrayOfInteger = arrayArrayOfInteger;
@@ -113,6 +121,10 @@ public class ArrayTest {
     this.arrayArrayOfInteger = arrayArrayOfInteger;
   }
 
+
+  public List<List<ReadOnlyFirst>> arrayArrayOfModel() {
+    return arrayArrayOfModel;
+  }
 
   public ArrayTest arrayArrayOfModel(List<List<ReadOnlyFirst>> arrayArrayOfModel) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Capitalization.java
@@ -55,6 +55,10 @@ public class Capitalization {
   private String ATT_NAME;
 
 
+  public String smallCamel() {
+    return smallCamel;
+  }
+
   public Capitalization smallCamel(String smallCamel) {
     
     this.smallCamel = smallCamel;
@@ -80,6 +84,10 @@ public class Capitalization {
     this.smallCamel = smallCamel;
   }
 
+
+  public String capitalCamel() {
+    return capitalCamel;
+  }
 
   public Capitalization capitalCamel(String capitalCamel) {
     
@@ -107,6 +115,10 @@ public class Capitalization {
   }
 
 
+  public String smallSnake() {
+    return smallSnake;
+  }
+
   public Capitalization smallSnake(String smallSnake) {
     
     this.smallSnake = smallSnake;
@@ -132,6 +144,10 @@ public class Capitalization {
     this.smallSnake = smallSnake;
   }
 
+
+  public String capitalSnake() {
+    return capitalSnake;
+  }
 
   public Capitalization capitalSnake(String capitalSnake) {
     
@@ -159,6 +175,10 @@ public class Capitalization {
   }
 
 
+  public String scAETHFlowPoints() {
+    return scAETHFlowPoints;
+  }
+
   public Capitalization scAETHFlowPoints(String scAETHFlowPoints) {
     
     this.scAETHFlowPoints = scAETHFlowPoints;
@@ -184,6 +204,10 @@ public class Capitalization {
     this.scAETHFlowPoints = scAETHFlowPoints;
   }
 
+
+  public String ATT_NAME() {
+    return ATT_NAME;
+  }
 
   public Capitalization ATT_NAME(String ATT_NAME) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Cat.java
@@ -37,6 +37,10 @@ public class Cat extends Animal {
   private Boolean declawed;
 
 
+  public Boolean declawed() {
+    return declawed;
+  }
+
   public Cat declawed(Boolean declawed) {
     
     this.declawed = declawed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/CatAllOf.java
@@ -35,6 +35,10 @@ public class CatAllOf {
   private Boolean declawed;
 
 
+  public Boolean declawed() {
+    return declawed;
+  }
+
   public CatAllOf declawed(Boolean declawed) {
     
     this.declawed = declawed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Category.java
@@ -39,6 +39,10 @@ public class Category {
   private String name = "default-name";
 
 
+  public Long id() {
+    return id;
+  }
+
   public Category id(Long id) {
     
     this.id = id;
@@ -64,6 +68,10 @@ public class Category {
     this.id = id;
   }
 
+
+  public String name() {
+    return name;
+  }
 
   public Category name(String name) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ClassModel.java
@@ -36,6 +36,10 @@ public class ClassModel {
   private String propertyClass;
 
 
+  public String propertyClass() {
+    return propertyClass;
+  }
+
   public ClassModel propertyClass(String propertyClass) {
     
     this.propertyClass = propertyClass;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Client.java
@@ -35,6 +35,10 @@ public class Client {
   private String client;
 
 
+  public String client() {
+    return client;
+  }
+
   public Client client(String client) {
     
     this.client = client;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Dog.java
@@ -37,6 +37,10 @@ public class Dog extends Animal {
   private String breed;
 
 
+  public String breed() {
+    return breed;
+  }
+
   public Dog breed(String breed) {
     
     this.breed = breed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/DogAllOf.java
@@ -35,6 +35,10 @@ public class DogAllOf {
   private String breed;
 
 
+  public String breed() {
+    return breed;
+  }
+
   public DogAllOf breed(String breed) {
     
     this.breed = breed;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumArrays.java
@@ -111,6 +111,10 @@ public class EnumArrays {
   private List<ArrayEnumEnum> arrayEnum = null;
 
 
+  public JustSymbolEnum justSymbol() {
+    return justSymbol;
+  }
+
   public EnumArrays justSymbol(JustSymbolEnum justSymbol) {
     
     this.justSymbol = justSymbol;
@@ -136,6 +140,10 @@ public class EnumArrays {
     this.justSymbol = justSymbol;
   }
 
+
+  public List<ArrayEnumEnum> arrayEnum() {
+    return arrayEnum;
+  }
 
   public EnumArrays arrayEnum(List<ArrayEnumEnum> arrayEnum) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/EnumTest.java
@@ -196,6 +196,10 @@ public class EnumTest {
   private OuterEnum outerEnum;
 
 
+  public EnumStringEnum enumString() {
+    return enumString;
+  }
+
   public EnumTest enumString(EnumStringEnum enumString) {
     
     this.enumString = enumString;
@@ -222,6 +226,10 @@ public class EnumTest {
   }
 
 
+  public EnumStringRequiredEnum enumStringRequired() {
+    return enumStringRequired;
+  }
+
   public EnumTest enumStringRequired(EnumStringRequiredEnum enumStringRequired) {
     
     this.enumStringRequired = enumStringRequired;
@@ -246,6 +254,10 @@ public class EnumTest {
     this.enumStringRequired = enumStringRequired;
   }
 
+
+  public EnumIntegerEnum enumInteger() {
+    return enumInteger;
+  }
 
   public EnumTest enumInteger(EnumIntegerEnum enumInteger) {
     
@@ -273,6 +285,10 @@ public class EnumTest {
   }
 
 
+  public EnumNumberEnum enumNumber() {
+    return enumNumber;
+  }
+
   public EnumTest enumNumber(EnumNumberEnum enumNumber) {
     
     this.enumNumber = enumNumber;
@@ -298,6 +314,10 @@ public class EnumTest {
     this.enumNumber = enumNumber;
   }
 
+
+  public OuterEnum outerEnum() {
+    return outerEnum;
+  }
 
   public EnumTest outerEnum(OuterEnum outerEnum) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FileSchemaTestClass.java
@@ -41,6 +41,10 @@ public class FileSchemaTestClass {
   private List<java.io.File> files = null;
 
 
+  public java.io.File file() {
+    return file;
+  }
+
   public FileSchemaTestClass file(java.io.File file) {
     
     this.file = file;
@@ -66,6 +70,10 @@ public class FileSchemaTestClass {
     this.file = file;
   }
 
+
+  public List<java.io.File> files() {
+    return files;
+  }
 
   public FileSchemaTestClass files(List<java.io.File> files) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/FormatTest.java
@@ -92,6 +92,10 @@ public class FormatTest {
   private BigDecimal bigDecimal;
 
 
+  public Integer integer() {
+    return integer;
+  }
+
   public FormatTest integer(Integer integer) {
     
     this.integer = integer;
@@ -119,6 +123,10 @@ public class FormatTest {
     this.integer = integer;
   }
 
+
+  public Integer int32() {
+    return int32;
+  }
 
   public FormatTest int32(Integer int32) {
     
@@ -148,6 +156,10 @@ public class FormatTest {
   }
 
 
+  public Long int64() {
+    return int64;
+  }
+
   public FormatTest int64(Long int64) {
     
     this.int64 = int64;
@@ -173,6 +185,10 @@ public class FormatTest {
     this.int64 = int64;
   }
 
+
+  public BigDecimal number() {
+    return number;
+  }
 
   public FormatTest number(BigDecimal number) {
     
@@ -200,6 +216,10 @@ public class FormatTest {
     this.number = number;
   }
 
+
+  public Float _float() {
+    return _float;
+  }
 
   public FormatTest _float(Float _float) {
     
@@ -229,6 +249,10 @@ public class FormatTest {
   }
 
 
+  public Double _double() {
+    return _double;
+  }
+
   public FormatTest _double(Double _double) {
     
     this._double = _double;
@@ -257,6 +281,10 @@ public class FormatTest {
   }
 
 
+  public String string() {
+    return string;
+  }
+
   public FormatTest string(String string) {
     
     this.string = string;
@@ -283,6 +311,10 @@ public class FormatTest {
   }
 
 
+  public byte[] _byte() {
+    return _byte;
+  }
+
   public FormatTest _byte(byte[] _byte) {
     
     this._byte = _byte;
@@ -307,6 +339,10 @@ public class FormatTest {
     this._byte = _byte;
   }
 
+
+  public File binary() {
+    return binary;
+  }
 
   public FormatTest binary(File binary) {
     
@@ -334,6 +370,10 @@ public class FormatTest {
   }
 
 
+  public LocalDate date() {
+    return date;
+  }
+
   public FormatTest date(LocalDate date) {
     
     this.date = date;
@@ -358,6 +398,10 @@ public class FormatTest {
     this.date = date;
   }
 
+
+  public OffsetDateTime dateTime() {
+    return dateTime;
+  }
 
   public FormatTest dateTime(OffsetDateTime dateTime) {
     
@@ -385,6 +429,10 @@ public class FormatTest {
   }
 
 
+  public UUID uuid() {
+    return uuid;
+  }
+
   public FormatTest uuid(UUID uuid) {
     
     this.uuid = uuid;
@@ -411,6 +459,10 @@ public class FormatTest {
   }
 
 
+  public String password() {
+    return password;
+  }
+
   public FormatTest password(String password) {
     
     this.password = password;
@@ -435,6 +487,10 @@ public class FormatTest {
     this.password = password;
   }
 
+
+  public BigDecimal bigDecimal() {
+    return bigDecimal;
+  }
 
   public FormatTest bigDecimal(BigDecimal bigDecimal) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/HasOnlyReadOnly.java
@@ -39,6 +39,10 @@ public class HasOnlyReadOnly {
   private String foo;
 
 
+  public String bar() {
+    return bar;
+  }
+
    /**
    * Get bar
    * @return bar
@@ -54,6 +58,10 @@ public class HasOnlyReadOnly {
 
 
 
+
+  public String foo() {
+    return foo;
+  }
 
    /**
    * Get foo

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MapTest.java
@@ -85,6 +85,10 @@ public class MapTest {
   private Map<String, Boolean> indirectMap = null;
 
 
+  public Map<String, Map<String, String>> mapMapOfString() {
+    return mapMapOfString;
+  }
+
   public MapTest mapMapOfString(Map<String, Map<String, String>> mapMapOfString) {
     
     this.mapMapOfString = mapMapOfString;
@@ -118,6 +122,10 @@ public class MapTest {
     this.mapMapOfString = mapMapOfString;
   }
 
+
+  public Map<String, InnerEnum> mapOfEnumString() {
+    return mapOfEnumString;
+  }
 
   public MapTest mapOfEnumString(Map<String, InnerEnum> mapOfEnumString) {
     
@@ -153,6 +161,10 @@ public class MapTest {
   }
 
 
+  public Map<String, Boolean> directMap() {
+    return directMap;
+  }
+
   public MapTest directMap(Map<String, Boolean> directMap) {
     
     this.directMap = directMap;
@@ -186,6 +198,10 @@ public class MapTest {
     this.directMap = directMap;
   }
 
+
+  public Map<String, Boolean> indirectMap() {
+    return indirectMap;
+  }
 
   public MapTest indirectMap(Map<String, Boolean> indirectMap) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -49,6 +49,10 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   private Map<String, Animal> map = null;
 
 
+  public UUID uuid() {
+    return uuid;
+  }
+
   public MixedPropertiesAndAdditionalPropertiesClass uuid(UUID uuid) {
     
     this.uuid = uuid;
@@ -75,6 +79,10 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
   }
 
 
+  public OffsetDateTime dateTime() {
+    return dateTime;
+  }
+
   public MixedPropertiesAndAdditionalPropertiesClass dateTime(OffsetDateTime dateTime) {
     
     this.dateTime = dateTime;
@@ -100,6 +108,10 @@ public class MixedPropertiesAndAdditionalPropertiesClass {
     this.dateTime = dateTime;
   }
 
+
+  public Map<String, Animal> map() {
+    return map;
+  }
 
   public MixedPropertiesAndAdditionalPropertiesClass map(Map<String, Animal> map) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Model200Response.java
@@ -40,6 +40,10 @@ public class Model200Response {
   private String propertyClass;
 
 
+  public Integer name() {
+    return name;
+  }
+
   public Model200Response name(Integer name) {
     
     this.name = name;
@@ -65,6 +69,10 @@ public class Model200Response {
     this.name = name;
   }
 
+
+  public String propertyClass() {
+    return propertyClass;
+  }
 
   public Model200Response propertyClass(String propertyClass) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -43,6 +43,10 @@ public class ModelApiResponse {
   private String message;
 
 
+  public Integer code() {
+    return code;
+  }
+
   public ModelApiResponse code(Integer code) {
     
     this.code = code;
@@ -69,6 +73,10 @@ public class ModelApiResponse {
   }
 
 
+  public String type() {
+    return type;
+  }
+
   public ModelApiResponse type(String type) {
     
     this.type = type;
@@ -94,6 +102,10 @@ public class ModelApiResponse {
     this.type = type;
   }
 
+
+  public String message() {
+    return message;
+  }
 
   public ModelApiResponse message(String message) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ModelReturn.java
@@ -36,6 +36,10 @@ public class ModelReturn {
   private Integer _return;
 
 
+  public Integer _return() {
+    return _return;
+  }
+
   public ModelReturn _return(Integer _return) {
     
     this._return = _return;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Name.java
@@ -48,6 +48,10 @@ public class Name {
   private Integer _123number;
 
 
+  public Integer name() {
+    return name;
+  }
+
   public Name name(Integer name) {
     
     this.name = name;
@@ -73,6 +77,10 @@ public class Name {
   }
 
 
+  public Integer snakeCase() {
+    return snakeCase;
+  }
+
    /**
    * Get snakeCase
    * @return snakeCase
@@ -88,6 +96,10 @@ public class Name {
 
 
 
+
+  public String property() {
+    return property;
+  }
 
   public Name property(String property) {
     
@@ -114,6 +126,10 @@ public class Name {
     this.property = property;
   }
 
+
+  public Integer _123number() {
+    return _123number;
+  }
 
    /**
    * Get _123number

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/NumberOnly.java
@@ -36,6 +36,10 @@ public class NumberOnly {
   private BigDecimal justNumber;
 
 
+  public BigDecimal justNumber() {
+    return justNumber;
+  }
+
   public NumberOnly justNumber(BigDecimal justNumber) {
     
     this.justNumber = justNumber;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Order.java
@@ -93,6 +93,10 @@ public class Order {
   private Boolean complete = false;
 
 
+  public Long id() {
+    return id;
+  }
+
   public Order id(Long id) {
     
     this.id = id;
@@ -118,6 +122,10 @@ public class Order {
     this.id = id;
   }
 
+
+  public Long petId() {
+    return petId;
+  }
 
   public Order petId(Long petId) {
     
@@ -145,6 +153,10 @@ public class Order {
   }
 
 
+  public Integer quantity() {
+    return quantity;
+  }
+
   public Order quantity(Integer quantity) {
     
     this.quantity = quantity;
@@ -170,6 +182,10 @@ public class Order {
     this.quantity = quantity;
   }
 
+
+  public OffsetDateTime shipDate() {
+    return shipDate;
+  }
 
   public Order shipDate(OffsetDateTime shipDate) {
     
@@ -197,6 +213,10 @@ public class Order {
   }
 
 
+  public StatusEnum status() {
+    return status;
+  }
+
   public Order status(StatusEnum status) {
     
     this.status = status;
@@ -222,6 +242,10 @@ public class Order {
     this.status = status;
   }
 
+
+  public Boolean complete() {
+    return complete;
+  }
 
   public Order complete(Boolean complete) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/OuterComposite.java
@@ -44,6 +44,10 @@ public class OuterComposite {
   private Boolean myBoolean;
 
 
+  public BigDecimal myNumber() {
+    return myNumber;
+  }
+
   public OuterComposite myNumber(BigDecimal myNumber) {
     
     this.myNumber = myNumber;
@@ -70,6 +74,10 @@ public class OuterComposite {
   }
 
 
+  public String myString() {
+    return myString;
+  }
+
   public OuterComposite myString(String myString) {
     
     this.myString = myString;
@@ -95,6 +103,10 @@ public class OuterComposite {
     this.myString = myString;
   }
 
+
+  public Boolean myBoolean() {
+    return myBoolean;
+  }
 
   public OuterComposite myBoolean(Boolean myBoolean) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Pet.java
@@ -96,6 +96,10 @@ public class Pet {
   private StatusEnum status;
 
 
+  public Long id() {
+    return id;
+  }
+
   public Pet id(Long id) {
     
     this.id = id;
@@ -121,6 +125,10 @@ public class Pet {
     this.id = id;
   }
 
+
+  public Category category() {
+    return category;
+  }
 
   public Pet category(Category category) {
     
@@ -148,6 +156,10 @@ public class Pet {
   }
 
 
+  public String name() {
+    return name;
+  }
+
   public Pet name(String name) {
     
     this.name = name;
@@ -172,6 +184,10 @@ public class Pet {
     this.name = name;
   }
 
+
+  public List<String> photoUrls() {
+    return photoUrls;
+  }
 
   public Pet photoUrls(List<String> photoUrls) {
     
@@ -202,6 +218,10 @@ public class Pet {
     this.photoUrls = photoUrls;
   }
 
+
+  public List<Tag> tags() {
+    return tags;
+  }
 
   public Pet tags(List<Tag> tags) {
     
@@ -236,6 +256,10 @@ public class Pet {
     this.tags = tags;
   }
 
+
+  public StatusEnum status() {
+    return status;
+  }
 
   public Pet status(StatusEnum status) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/ReadOnlyFirst.java
@@ -39,6 +39,10 @@ public class ReadOnlyFirst {
   private String baz;
 
 
+  public String bar() {
+    return bar;
+  }
+
    /**
    * Get bar
    * @return bar
@@ -54,6 +58,10 @@ public class ReadOnlyFirst {
 
 
 
+
+  public String baz() {
+    return baz;
+  }
 
   public ReadOnlyFirst baz(String baz) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/SpecialModelName.java
@@ -35,6 +35,10 @@ public class SpecialModelName {
   private Long $specialPropertyName;
 
 
+  public Long $specialPropertyName() {
+    return $specialPropertyName;
+  }
+
   public SpecialModelName $specialPropertyName(Long $specialPropertyName) {
     
     this.$specialPropertyName = $specialPropertyName;

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/Tag.java
@@ -39,6 +39,10 @@ public class Tag {
   private String name;
 
 
+  public Long id() {
+    return id;
+  }
+
   public Tag id(Long id) {
     
     this.id = id;
@@ -64,6 +68,10 @@ public class Tag {
     this.id = id;
   }
 
+
+  public String name() {
+    return name;
+  }
 
   public Tag name(String name) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderDefault.java
@@ -54,6 +54,10 @@ public class TypeHolderDefault {
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
 
+  public String stringItem() {
+    return stringItem;
+  }
+
   public TypeHolderDefault stringItem(String stringItem) {
     
     this.stringItem = stringItem;
@@ -78,6 +82,10 @@ public class TypeHolderDefault {
     this.stringItem = stringItem;
   }
 
+
+  public BigDecimal numberItem() {
+    return numberItem;
+  }
 
   public TypeHolderDefault numberItem(BigDecimal numberItem) {
     
@@ -104,6 +112,10 @@ public class TypeHolderDefault {
   }
 
 
+  public Integer integerItem() {
+    return integerItem;
+  }
+
   public TypeHolderDefault integerItem(Integer integerItem) {
     
     this.integerItem = integerItem;
@@ -129,6 +141,10 @@ public class TypeHolderDefault {
   }
 
 
+  public Boolean boolItem() {
+    return boolItem;
+  }
+
   public TypeHolderDefault boolItem(Boolean boolItem) {
     
     this.boolItem = boolItem;
@@ -153,6 +169,10 @@ public class TypeHolderDefault {
     this.boolItem = boolItem;
   }
 
+
+  public List<Integer> arrayItem() {
+    return arrayItem;
+  }
 
   public TypeHolderDefault arrayItem(List<Integer> arrayItem) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/TypeHolderExample.java
@@ -58,6 +58,10 @@ public class TypeHolderExample {
   private List<Integer> arrayItem = new ArrayList<Integer>();
 
 
+  public String stringItem() {
+    return stringItem;
+  }
+
   public TypeHolderExample stringItem(String stringItem) {
     
     this.stringItem = stringItem;
@@ -82,6 +86,10 @@ public class TypeHolderExample {
     this.stringItem = stringItem;
   }
 
+
+  public BigDecimal numberItem() {
+    return numberItem;
+  }
 
   public TypeHolderExample numberItem(BigDecimal numberItem) {
     
@@ -108,6 +116,10 @@ public class TypeHolderExample {
   }
 
 
+  public Float floatItem() {
+    return floatItem;
+  }
+
   public TypeHolderExample floatItem(Float floatItem) {
     
     this.floatItem = floatItem;
@@ -132,6 +144,10 @@ public class TypeHolderExample {
     this.floatItem = floatItem;
   }
 
+
+  public Integer integerItem() {
+    return integerItem;
+  }
 
   public TypeHolderExample integerItem(Integer integerItem) {
     
@@ -158,6 +174,10 @@ public class TypeHolderExample {
   }
 
 
+  public Boolean boolItem() {
+    return boolItem;
+  }
+
   public TypeHolderExample boolItem(Boolean boolItem) {
     
     this.boolItem = boolItem;
@@ -182,6 +202,10 @@ public class TypeHolderExample {
     this.boolItem = boolItem;
   }
 
+
+  public List<Integer> arrayItem() {
+    return arrayItem;
+  }
 
   public TypeHolderExample arrayItem(List<Integer> arrayItem) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/User.java
@@ -63,6 +63,10 @@ public class User {
   private Integer userStatus;
 
 
+  public Long id() {
+    return id;
+  }
+
   public User id(Long id) {
     
     this.id = id;
@@ -88,6 +92,10 @@ public class User {
     this.id = id;
   }
 
+
+  public String username() {
+    return username;
+  }
 
   public User username(String username) {
     
@@ -115,6 +123,10 @@ public class User {
   }
 
 
+  public String firstName() {
+    return firstName;
+  }
+
   public User firstName(String firstName) {
     
     this.firstName = firstName;
@@ -140,6 +152,10 @@ public class User {
     this.firstName = firstName;
   }
 
+
+  public String lastName() {
+    return lastName;
+  }
 
   public User lastName(String lastName) {
     
@@ -167,6 +183,10 @@ public class User {
   }
 
 
+  public String email() {
+    return email;
+  }
+
   public User email(String email) {
     
     this.email = email;
@@ -192,6 +212,10 @@ public class User {
     this.email = email;
   }
 
+
+  public String password() {
+    return password;
+  }
 
   public User password(String password) {
     
@@ -219,6 +243,10 @@ public class User {
   }
 
 
+  public String phone() {
+    return phone;
+  }
+
   public User phone(String phone) {
     
     this.phone = phone;
@@ -244,6 +272,10 @@ public class User {
     this.phone = phone;
   }
 
+
+  public Integer userStatus() {
+    return userStatus;
+  }
 
   public User userStatus(Integer userStatus) {
     

--- a/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
+++ b/samples/client/petstore/java/jersey1/src/main/java/org/openapitools/client/model/XmlItem.java
@@ -150,6 +150,10 @@ public class XmlItem {
   private List<Integer> prefixNsWrappedArray = null;
 
 
+  public String attributeString() {
+    return attributeString;
+  }
+
   public XmlItem attributeString(String attributeString) {
     
     this.attributeString = attributeString;
@@ -175,6 +179,10 @@ public class XmlItem {
     this.attributeString = attributeString;
   }
 
+
+  public BigDecimal attributeNumber() {
+    return attributeNumber;
+  }
 
   public XmlItem attributeNumber(BigDecimal attributeNumber) {
     
@@ -202,6 +210,10 @@ public class XmlItem {
   }
 
 
+  public Integer attributeInteger() {
+    return attributeInteger;
+  }
+
   public XmlItem attributeInteger(Integer attributeInteger) {
     
     this.attributeInteger = attributeInteger;
@@ -228,6 +240,10 @@ public class XmlItem {
   }
 
 
+  public Boolean attributeBoolean() {
+    return attributeBoolean;
+  }
+
   public XmlItem attributeBoolean(Boolean attributeBoolean) {
     
     this.attributeBoolean = attributeBoolean;
@@ -253,6 +269,10 @@ public class XmlItem {
     this.attributeBoolean = attributeBoolean;
   }
 
+
+  public List<Integer> wrappedArray() {
+    return wrappedArray;
+  }
 
   public XmlItem wrappedArray(List<Integer> wrappedArray) {
     
@@ -288,6 +308,10 @@ public class XmlItem {
   }
 
 
+  public String nameString() {
+    return nameString;
+  }
+
   public XmlItem nameString(String nameString) {
     
     this.nameString = nameString;
@@ -313,6 +337,10 @@ public class XmlItem {
     this.nameString = nameString;
   }
 
+
+  public BigDecimal nameNumber() {
+    return nameNumber;
+  }
 
   public XmlItem nameNumber(BigDecimal nameNumber) {
     
@@ -340,6 +368,10 @@ public class XmlItem {
   }
 
 
+  public Integer nameInteger() {
+    return nameInteger;
+  }
+
   public XmlItem nameInteger(Integer nameInteger) {
     
     this.nameInteger = nameInteger;
@@ -366,6 +398,10 @@ public class XmlItem {
   }
 
 
+  public Boolean nameBoolean() {
+    return nameBoolean;
+  }
+
   public XmlItem nameBoolean(Boolean nameBoolean) {
     
     this.nameBoolean = nameBoolean;
@@ -391,6 +427,10 @@ public class XmlItem {
     this.nameBoolean = nameBoolean;
   }
 
+
+  public List<Integer> nameArray() {
+    return nameArray;
+  }
 
   public XmlItem nameArray(List<Integer> nameArray) {
     
@@ -426,6 +466,10 @@ public class XmlItem {
   }
 
 
+  public List<Integer> nameWrappedArray() {
+    return nameWrappedArray;
+  }
+
   public XmlItem nameWrappedArray(List<Integer> nameWrappedArray) {
     
     this.nameWrappedArray = nameWrappedArray;
@@ -460,6 +504,10 @@ public class XmlItem {
   }
 
 
+  public String prefixString() {
+    return prefixString;
+  }
+
   public XmlItem prefixString(String prefixString) {
     
     this.prefixString = prefixString;
@@ -485,6 +533,10 @@ public class XmlItem {
     this.prefixString = prefixString;
   }
 
+
+  public BigDecimal prefixNumber() {
+    return prefixNumber;
+  }
 
   public XmlItem prefixNumber(BigDecimal prefixNumber) {
     
@@ -512,6 +564,10 @@ public class XmlItem {
   }
 
 
+  public Integer prefixInteger() {
+    return prefixInteger;
+  }
+
   public XmlItem prefixInteger(Integer prefixInteger) {
     
     this.prefixInteger = prefixInteger;
@@ -538,6 +594,10 @@ public class XmlItem {
   }
 
 
+  public Boolean prefixBoolean() {
+    return prefixBoolean;
+  }
+
   public XmlItem prefixBoolean(Boolean prefixBoolean) {
     
     this.prefixBoolean = prefixBoolean;
@@ -563,6 +623,10 @@ public class XmlItem {
     this.prefixBoolean = prefixBoolean;
   }
 
+
+  public List<Integer> prefixArray() {
+    return prefixArray;
+  }
 
   public XmlItem prefixArray(List<Integer> prefixArray) {
     
@@ -598,6 +662,10 @@ public class XmlItem {
   }
 
 
+  public List<Integer> prefixWrappedArray() {
+    return prefixWrappedArray;
+  }
+
   public XmlItem prefixWrappedArray(List<Integer> prefixWrappedArray) {
     
     this.prefixWrappedArray = prefixWrappedArray;
@@ -632,6 +700,10 @@ public class XmlItem {
   }
 
 
+  public String namespaceString() {
+    return namespaceString;
+  }
+
   public XmlItem namespaceString(String namespaceString) {
     
     this.namespaceString = namespaceString;
@@ -657,6 +729,10 @@ public class XmlItem {
     this.namespaceString = namespaceString;
   }
 
+
+  public BigDecimal namespaceNumber() {
+    return namespaceNumber;
+  }
 
   public XmlItem namespaceNumber(BigDecimal namespaceNumber) {
     
@@ -684,6 +760,10 @@ public class XmlItem {
   }
 
 
+  public Integer namespaceInteger() {
+    return namespaceInteger;
+  }
+
   public XmlItem namespaceInteger(Integer namespaceInteger) {
     
     this.namespaceInteger = namespaceInteger;
@@ -710,6 +790,10 @@ public class XmlItem {
   }
 
 
+  public Boolean namespaceBoolean() {
+    return namespaceBoolean;
+  }
+
   public XmlItem namespaceBoolean(Boolean namespaceBoolean) {
     
     this.namespaceBoolean = namespaceBoolean;
@@ -735,6 +819,10 @@ public class XmlItem {
     this.namespaceBoolean = namespaceBoolean;
   }
 
+
+  public List<Integer> namespaceArray() {
+    return namespaceArray;
+  }
 
   public XmlItem namespaceArray(List<Integer> namespaceArray) {
     
@@ -770,6 +858,10 @@ public class XmlItem {
   }
 
 
+  public List<Integer> namespaceWrappedArray() {
+    return namespaceWrappedArray;
+  }
+
   public XmlItem namespaceWrappedArray(List<Integer> namespaceWrappedArray) {
     
     this.namespaceWrappedArray = namespaceWrappedArray;
@@ -804,6 +896,10 @@ public class XmlItem {
   }
 
 
+  public String prefixNsString() {
+    return prefixNsString;
+  }
+
   public XmlItem prefixNsString(String prefixNsString) {
     
     this.prefixNsString = prefixNsString;
@@ -829,6 +925,10 @@ public class XmlItem {
     this.prefixNsString = prefixNsString;
   }
 
+
+  public BigDecimal prefixNsNumber() {
+    return prefixNsNumber;
+  }
 
   public XmlItem prefixNsNumber(BigDecimal prefixNsNumber) {
     
@@ -856,6 +956,10 @@ public class XmlItem {
   }
 
 
+  public Integer prefixNsInteger() {
+    return prefixNsInteger;
+  }
+
   public XmlItem prefixNsInteger(Integer prefixNsInteger) {
     
     this.prefixNsInteger = prefixNsInteger;
@@ -882,6 +986,10 @@ public class XmlItem {
   }
 
 
+  public Boolean prefixNsBoolean() {
+    return prefixNsBoolean;
+  }
+
   public XmlItem prefixNsBoolean(Boolean prefixNsBoolean) {
     
     this.prefixNsBoolean = prefixNsBoolean;
@@ -907,6 +1015,10 @@ public class XmlItem {
     this.prefixNsBoolean = prefixNsBoolean;
   }
 
+
+  public List<Integer> prefixNsArray() {
+    return prefixNsArray;
+  }
 
   public XmlItem prefixNsArray(List<Integer> prefixNsArray) {
     
@@ -941,6 +1053,10 @@ public class XmlItem {
     this.prefixNsArray = prefixNsArray;
   }
 
+
+  public List<Integer> prefixNsWrappedArray() {
+    return prefixNsWrappedArray;
+  }
 
   public XmlItem prefixNsWrappedArray(List<Integer> prefixNsWrappedArray) {
     


### PR DESCRIPTION
All Java generators except JavaVertXServer already produce fluent setters,
so this adds fluent getters to those as well.

Motivation: I like having fluent accessors, but the OpenAPI code in my
project is inconsistent with the rest, as I have to resort to `getWhatever()`
accessors instead of `whatever()`.

FYI @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger
@karismann @Zomzog 
