### PR TITLE
Make Resttemplate thread safe by using the withHttpInfo pattern used …

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -99,9 +99,6 @@ public class ApiClient {
 
     private Map<String, Authentication> authentications;
 
-    private HttpStatus statusCode;
-    private MultiValueMap<String, String> responseHeaders;
-
     private DateFormat dateFormat;
 
     public ApiClient() {
@@ -152,22 +149,6 @@ public class ApiClient {
     public ApiClient setBasePath(String basePath) {
         this.basePath = basePath;
         return this;
-    }
-
-    /**
-     * Gets the status code of the previous request
-     * @return HttpStatus the status code
-     */
-    public HttpStatus getStatusCode() {
-        return statusCode;
-    }
-
-    /**
-     * Gets the response headers of the previous request
-     * @return MultiValueMap a map of response headers
-     */
-    public MultiValueMap<String, String> getResponseHeaders() {
-        return responseHeaders;
     }
 
     /**
@@ -580,9 +561,9 @@ public class ApiClient {
      * @param contentType The request's Content-Type header
      * @param authNames The authentications to apply
      * @param returnType The return type into which to deserialize the response
-     * @return The response body in chosen type
+     * @return ResponseEntity&lt;T&gt; The response of the chosen type
      */
-    public <T> T invokeAPI(String path, HttpMethod method, MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams, MultiValueMap<String, Object> formParams, List<MediaType> accept, MediaType contentType, String[] authNames, ParameterizedTypeReference<T> returnType) throws RestClientException {
+    public <T> ResponseEntity<T> invokeAPI(String path, HttpMethod method, MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams, MultiValueMap<String, Object> formParams, List<MediaType> accept, MediaType contentType, String[] authNames, ParameterizedTypeReference<T> returnType) throws RestClientException {
         updateParamsForAuth(authNames, queryParams, headerParams);
 
         final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
@@ -624,16 +605,11 @@ public class ApiClient {
 
         ResponseEntity<T> responseEntity = restTemplate.exchange(requestEntity, returnType);
 
-        statusCode = responseEntity.getStatusCode();
-        responseHeaders = responseEntity.getHeaders();
-
-        if (responseEntity.getStatusCode() == HttpStatus.NO_CONTENT) {
-            return null;
-        } else if (responseEntity.getStatusCode().is2xxSuccessful()) {
-            return responseEntity.getBody();
+        if (responseEntity.getStatusCode().is2xxSuccessful()) {
+            return responseEntity;
         } else {
             // The error handler built into the RestTemplate should handle 400 and 500 series errors.
-            throw new RestClientException("API returned " + statusCode + " and it wasn't handled by the RestTemplate error handler");
+            throw new RestClientException("API returned " + responseEntity.getStatusCode() + " and it wasn't handled by the RestTemplate error handler");
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/api.mustache
@@ -25,6 +25,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 {{>generatedAnnotation}}
 @Component("{{package}}.{{classname}}")
@@ -53,16 +54,53 @@ public class {{classname}} {
     /**
      * {{summary}}
      * {{notes}}
-{{#responses}}     * <p><b>{{code}}</b>{{#message}} - {{message}}{{/message}}
-{{/responses}}{{#allParams}}     * @param {{paramName}} {{description}}{{^description}}The {{paramName}} parameter{{/description}}
-{{/allParams}}{{#returnType}}     * @return {{returnType}}
-{{/returnType}}     * @throws RestClientException if an error occurs while attempting to invoke the API
-{{#externalDocs}}
-    * {{description}}
-    * @see <a href="{{url}}">{{summary}} Documentation</a>
-{{/externalDocs}}
+    {{#responses}}
+     * <p><b>{{code}}</b>{{#message}} - {{message}}{{/message}}
+     {{/responses}}
+     {{#allParams}}
+     * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+     {{/allParams}}
+     {{#returnType}}
+     * @return {{returnType}}
+     {{/returnType}}
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+     {{/externalDocs}}
      */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
     public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws RestClientException {
+        {{#returnType}}
+        return {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}).getBody();
+        {{/returnType}}
+        {{^returnType}}
+        {{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
+        {{/returnType}}
+    }
+
+    /**
+     * {{summary}}
+     * {{notes}}
+     {{#responses}}
+     * <p><b>{{code}}</b>{{#message}} - {{message}}{{/message}}
+     {{/responses}}
+     {{#allParams}}
+     * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+     {{/allParams}}
+     * @return ResponseEntity&lt;{{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}Void{{/returnType}}&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     {{#externalDocs}}
+     * {{description}}
+     * @see <a href="{{url}}">{{summary}} Documentation</a>
+     {{/externalDocs}}
+     */
+    {{#isDeprecated}}
+    @Deprecated
+    {{/isDeprecated}}
+    public ResponseEntity<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws RestClientException {
         Object postBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
         {{#allParams}}{{#required}}
         // verify the required parameter '{{paramName}}' is set
@@ -102,7 +140,7 @@ public class {{classname}} {
         String[] authNames = new String[] { {{#authMethods}}"{{name}}"{{#hasMore}}, {{/hasMore}}{{/authMethods}} };
 
         {{#returnType}}ParameterizedTypeReference<{{{returnType}}}> returnType = new ParameterizedTypeReference<{{{returnType}}}>() {};{{/returnType}}{{^returnType}}ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};{{/returnType}}
-        {{#returnType}}return {{/returnType}}apiClient.invokeAPI(path, HttpMethod.{{httpMethod}}, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.{{httpMethod}}, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     {{/operation}}
 }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -91,9 +91,6 @@ public class ApiClient {
 
     private Map<String, Authentication> authentications;
 
-    private HttpStatus statusCode;
-    private MultiValueMap<String, String> responseHeaders;
-
     private DateFormat dateFormat;
 
     public ApiClient() {
@@ -144,22 +141,6 @@ public class ApiClient {
     public ApiClient setBasePath(String basePath) {
         this.basePath = basePath;
         return this;
-    }
-
-    /**
-     * Gets the status code of the previous request
-     * @return HttpStatus the status code
-     */
-    public HttpStatus getStatusCode() {
-        return statusCode;
-    }
-
-    /**
-     * Gets the response headers of the previous request
-     * @return MultiValueMap a map of response headers
-     */
-    public MultiValueMap<String, String> getResponseHeaders() {
-        return responseHeaders;
     }
 
     /**
@@ -568,9 +549,9 @@ public class ApiClient {
      * @param contentType The request's Content-Type header
      * @param authNames The authentications to apply
      * @param returnType The return type into which to deserialize the response
-     * @return The response body in chosen type
+     * @return ResponseEntity&lt;T&gt; The response of the chosen type
      */
-    public <T> T invokeAPI(String path, HttpMethod method, MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams, MultiValueMap<String, Object> formParams, List<MediaType> accept, MediaType contentType, String[] authNames, ParameterizedTypeReference<T> returnType) throws RestClientException {
+    public <T> ResponseEntity<T> invokeAPI(String path, HttpMethod method, MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams, MultiValueMap<String, Object> formParams, List<MediaType> accept, MediaType contentType, String[] authNames, ParameterizedTypeReference<T> returnType) throws RestClientException {
         updateParamsForAuth(authNames, queryParams, headerParams);
 
         final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
@@ -612,16 +593,11 @@ public class ApiClient {
 
         ResponseEntity<T> responseEntity = restTemplate.exchange(requestEntity, returnType);
 
-        statusCode = responseEntity.getStatusCode();
-        responseHeaders = responseEntity.getHeaders();
-
-        if (responseEntity.getStatusCode() == HttpStatus.NO_CONTENT) {
-            return null;
-        } else if (responseEntity.getStatusCode().is2xxSuccessful()) {
-            return responseEntity.getBody();
+        if (responseEntity.getStatusCode().is2xxSuccessful()) {
+            return responseEntity;
         } else {
             // The error handler built into the RestTemplate should handle 400 and 500 series errors.
-            throw new RestClientException("API returned " + statusCode + " and it wasn't handled by the RestTemplate error handler");
+            throw new RestClientException("API returned " + responseEntity.getStatusCode() + " and it wasn't handled by the RestTemplate error handler");
         }
     }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.AnotherFakeApi")
@@ -51,11 +52,23 @@ public class AnotherFakeApi {
      * To test special tags
      * To test special tags and operation ID starting with number
      * <p><b>200</b> - successful operation
-     * @param body client model
+     * @param body client model (required)
      * @return Client
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Client call123testSpecialTags(Client body) throws RestClientException {
+        return call123testSpecialTagsWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * To test special tags
+     * To test special tags and operation ID starting with number
+     * <p><b>200</b> - successful operation
+     * @param body client model (required)
+     * @return ResponseEntity&lt;Client&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Client> call123testSpecialTagsWithHttpInfo(Client body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -32,6 +32,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.FakeApi")
@@ -59,10 +60,22 @@ public class FakeApi {
      * creates an XmlItem
      * this route creates an XmlItem
      * <p><b>200</b> - successful operation
-     * @param xmlItem XmlItem Body
+     * @param xmlItem XmlItem Body (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void createXmlItem(XmlItem xmlItem) throws RestClientException {
+        createXmlItemWithHttpInfo(xmlItem);
+    }
+
+    /**
+     * creates an XmlItem
+     * this route creates an XmlItem
+     * <p><b>200</b> - successful operation
+     * @param xmlItem XmlItem Body (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws RestClientException {
         Object postBody = xmlItem;
         
         // verify the required parameter 'xmlItem' is set
@@ -86,17 +99,29 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * 
      * Test serialization of outer boolean types
      * <p><b>200</b> - Output boolean
-     * @param body Input boolean as post body
+     * @param body Input boolean as post body (optional)
      * @return Boolean
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Boolean fakeOuterBooleanSerialize(Boolean body) throws RestClientException {
+        return fakeOuterBooleanSerializeWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * 
+     * Test serialization of outer boolean types
+     * <p><b>200</b> - Output boolean
+     * @param body Input boolean as post body (optional)
+     * @return ResponseEntity&lt;Boolean&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws RestClientException {
         Object postBody = body;
         
         String path = apiClient.expandPath("/fake/outer/boolean", Collections.<String, Object>emptyMap());
@@ -121,11 +146,23 @@ public class FakeApi {
      * 
      * Test serialization of object with outer number type
      * <p><b>200</b> - Output composite
-     * @param body Input composite as post body
+     * @param body Input composite as post body (optional)
      * @return OuterComposite
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public OuterComposite fakeOuterCompositeSerialize(OuterComposite body) throws RestClientException {
+        return fakeOuterCompositeSerializeWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * 
+     * Test serialization of object with outer number type
+     * <p><b>200</b> - Output composite
+     * @param body Input composite as post body (optional)
+     * @return ResponseEntity&lt;OuterComposite&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws RestClientException {
         Object postBody = body;
         
         String path = apiClient.expandPath("/fake/outer/composite", Collections.<String, Object>emptyMap());
@@ -150,11 +187,23 @@ public class FakeApi {
      * 
      * Test serialization of outer number types
      * <p><b>200</b> - Output number
-     * @param body Input number as post body
+     * @param body Input number as post body (optional)
      * @return BigDecimal
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public BigDecimal fakeOuterNumberSerialize(BigDecimal body) throws RestClientException {
+        return fakeOuterNumberSerializeWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * 
+     * Test serialization of outer number types
+     * <p><b>200</b> - Output number
+     * @param body Input number as post body (optional)
+     * @return ResponseEntity&lt;BigDecimal&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws RestClientException {
         Object postBody = body;
         
         String path = apiClient.expandPath("/fake/outer/number", Collections.<String, Object>emptyMap());
@@ -179,11 +228,23 @@ public class FakeApi {
      * 
      * Test serialization of outer string types
      * <p><b>200</b> - Output string
-     * @param body Input string as post body
+     * @param body Input string as post body (optional)
      * @return String
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public String fakeOuterStringSerialize(String body) throws RestClientException {
+        return fakeOuterStringSerializeWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * 
+     * Test serialization of outer string types
+     * <p><b>200</b> - Output string
+     * @param body Input string as post body (optional)
+     * @return ResponseEntity&lt;String&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<String> fakeOuterStringSerializeWithHttpInfo(String body) throws RestClientException {
         Object postBody = body;
         
         String path = apiClient.expandPath("/fake/outer/string", Collections.<String, Object>emptyMap());
@@ -208,10 +269,22 @@ public class FakeApi {
      * 
      * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
      * <p><b>200</b> - Success
-     * @param body The body parameter
+     * @param body  (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testBodyWithFileSchema(FileSchemaTestClass body) throws RestClientException {
+        testBodyWithFileSchemaWithHttpInfo(body);
+    }
+
+    /**
+     * 
+     * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+     * <p><b>200</b> - Success
+     * @param body  (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -235,17 +308,30 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * 
      * 
      * <p><b>200</b> - Success
-     * @param query The query parameter
-     * @param body The body parameter
+     * @param query  (required)
+     * @param body  (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testBodyWithQueryParams(String query, User body) throws RestClientException {
+        testBodyWithQueryParamsWithHttpInfo(query, body);
+    }
+
+    /**
+     * 
+     * 
+     * <p><b>200</b> - Success
+     * @param query  (required)
+     * @param body  (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'query' is set
@@ -276,17 +362,29 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * To test \&quot;client\&quot; model
      * To test \&quot;client\&quot; model
      * <p><b>200</b> - successful operation
-     * @param body client model
+     * @param body client model (required)
      * @return Client
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Client testClientModel(Client body) throws RestClientException {
+        return testClientModelWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * To test \&quot;client\&quot; model
+     * To test \&quot;client\&quot; model
+     * <p><b>200</b> - successful operation
+     * @param body client model (required)
+     * @return ResponseEntity&lt;Client&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Client> testClientModelWithHttpInfo(Client body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -319,23 +417,49 @@ public class FakeApi {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param number None
-     * @param _double None
-     * @param patternWithoutDelimiter None
-     * @param _byte None
-     * @param integer None
-     * @param int32 None
-     * @param int64 None
-     * @param _float None
-     * @param string None
-     * @param binary None
-     * @param date None
-     * @param dateTime None
-     * @param password None
-     * @param paramCallback None
+     * @param number None (required)
+     * @param _double None (required)
+     * @param patternWithoutDelimiter None (required)
+     * @param _byte None (required)
+     * @param integer None (optional)
+     * @param int32 None (optional)
+     * @param int64 None (optional)
+     * @param _float None (optional)
+     * @param string None (optional)
+     * @param binary None (optional)
+     * @param date None (optional)
+     * @param dateTime None (optional)
+     * @param password None (optional)
+     * @param paramCallback None (optional)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws RestClientException {
+        testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+    }
+
+    /**
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param number None (required)
+     * @param _double None (required)
+     * @param patternWithoutDelimiter None (required)
+     * @param _byte None (required)
+     * @param integer None (optional)
+     * @param int32 None (optional)
+     * @param int64 None (optional)
+     * @param _float None (optional)
+     * @param string None (optional)
+     * @param binary None (optional)
+     * @param date None (optional)
+     * @param dateTime None (optional)
+     * @param password None (optional)
+     * @param paramCallback None (optional)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'number' is set
@@ -403,24 +527,44 @@ public class FakeApi {
         String[] authNames = new String[] { "http_basic_test" };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * To test enum parameters
      * To test enum parameters
      * <p><b>400</b> - Invalid request
      * <p><b>404</b> - Not found
-     * @param enumHeaderStringArray Header parameter enum test (string array)
-     * @param enumHeaderString Header parameter enum test (string)
-     * @param enumQueryStringArray Query parameter enum test (string array)
-     * @param enumQueryString Query parameter enum test (string)
-     * @param enumQueryInteger Query parameter enum test (double)
-     * @param enumQueryDouble Query parameter enum test (double)
-     * @param enumFormStringArray Form parameter enum test (string array)
-     * @param enumFormString Form parameter enum test (string)
+     * @param enumHeaderStringArray Header parameter enum test (string array) (optional, default to new ArrayList&lt;String&gt;())
+     * @param enumHeaderString Header parameter enum test (string) (optional, default to -efg)
+     * @param enumQueryStringArray Query parameter enum test (string array) (optional, default to new ArrayList&lt;String&gt;())
+     * @param enumQueryString Query parameter enum test (string) (optional, default to -efg)
+     * @param enumQueryInteger Query parameter enum test (double) (optional)
+     * @param enumQueryDouble Query parameter enum test (double) (optional)
+     * @param enumFormStringArray Form parameter enum test (string array) (optional, default to $)
+     * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws RestClientException {
+        testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    }
+
+    /**
+     * To test enum parameters
+     * To test enum parameters
+     * <p><b>400</b> - Invalid request
+     * <p><b>404</b> - Not found
+     * @param enumHeaderStringArray Header parameter enum test (string array) (optional, default to new ArrayList&lt;String&gt;())
+     * @param enumHeaderString Header parameter enum test (string) (optional, default to -efg)
+     * @param enumQueryStringArray Query parameter enum test (string array) (optional, default to new ArrayList&lt;String&gt;())
+     * @param enumQueryString Query parameter enum test (string) (optional, default to -efg)
+     * @param enumQueryInteger Query parameter enum test (double) (optional)
+     * @param enumQueryDouble Query parameter enum test (double) (optional)
+     * @param enumFormStringArray Form parameter enum test (string array) (optional, default to $)
+     * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws RestClientException {
         Object postBody = null;
         
         String path = apiClient.expandPath("/fake", Collections.<String, Object>emptyMap());
@@ -454,21 +598,38 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Fake endpoint to test group parameters (optional)
      * Fake endpoint to test group parameters (optional)
      * <p><b>400</b> - Someting wrong
-     * @param requiredStringGroup Required String in group parameters
-     * @param requiredBooleanGroup Required Boolean in group parameters
-     * @param requiredInt64Group Required Integer in group parameters
-     * @param stringGroup String in group parameters
-     * @param booleanGroup Boolean in group parameters
-     * @param int64Group Integer in group parameters
+     * @param requiredStringGroup Required String in group parameters (required)
+     * @param requiredBooleanGroup Required Boolean in group parameters (required)
+     * @param requiredInt64Group Required Integer in group parameters (required)
+     * @param stringGroup String in group parameters (optional)
+     * @param booleanGroup Boolean in group parameters (optional)
+     * @param int64Group Integer in group parameters (optional)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testGroupParameters(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws RestClientException {
+        testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    }
+
+    /**
+     * Fake endpoint to test group parameters (optional)
+     * Fake endpoint to test group parameters (optional)
+     * <p><b>400</b> - Someting wrong
+     * @param requiredStringGroup Required String in group parameters (required)
+     * @param requiredBooleanGroup Required Boolean in group parameters (required)
+     * @param requiredInt64Group Required Integer in group parameters (required)
+     * @param stringGroup String in group parameters (optional)
+     * @param booleanGroup Boolean in group parameters (optional)
+     * @param int64Group Integer in group parameters (optional)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'requiredStringGroup' is set
@@ -510,16 +671,28 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * test inline additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param param request body
+     * @param param request body (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testInlineAdditionalProperties(Map<String, String> param) throws RestClientException {
+        testInlineAdditionalPropertiesWithHttpInfo(param);
+    }
+
+    /**
+     * test inline additionalProperties
+     * 
+     * <p><b>200</b> - successful operation
+     * @param param request body (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws RestClientException {
         Object postBody = param;
         
         // verify the required parameter 'param' is set
@@ -543,17 +716,30 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * test json serialization of form data
      * 
      * <p><b>200</b> - successful operation
-     * @param param field1
-     * @param param2 field2
+     * @param param field1 (required)
+     * @param param2 field2 (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testJsonFormData(String param, String param2) throws RestClientException {
+        testJsonFormDataWithHttpInfo(param, param2);
+    }
+
+    /**
+     * test json serialization of form data
+     * 
+     * <p><b>200</b> - successful operation
+     * @param param field1 (required)
+     * @param param2 field2 (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'param' is set
@@ -587,20 +773,36 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * 
      * To test the collection format in query parameters
      * <p><b>200</b> - Success
-     * @param pipe The pipe parameter
-     * @param ioutil The ioutil parameter
-     * @param http The http parameter
-     * @param url The url parameter
-     * @param context The context parameter
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws RestClientException {
+        testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+    }
+
+    /**
+     * 
+     * To test the collection format in query parameters
+     * <p><b>200</b> - Success
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'pipe' is set
@@ -648,6 +850,6 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
 }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.FakeClassnameTags123Api")
@@ -51,11 +52,23 @@ public class FakeClassnameTags123Api {
      * To test class name in snake case
      * To test class name in snake case
      * <p><b>200</b> - successful operation
-     * @param body client model
+     * @param body client model (required)
      * @return Client
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Client testClassname(Client body) throws RestClientException {
+        return testClassnameWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * To test class name in snake case
+     * To test class name in snake case
+     * <p><b>200</b> - successful operation
+     * @param body client model (required)
+     * @return ResponseEntity&lt;Client&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Client> testClassnameWithHttpInfo(Client body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/PetApi.java
@@ -26,6 +26,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.PetApi")
@@ -54,10 +55,23 @@ public class PetApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>405</b> - Invalid input
-     * @param body Pet object that needs to be added to the store
+     * @param body Pet object that needs to be added to the store (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void addPet(Pet body) throws RestClientException {
+        addPetWithHttpInfo(body);
+    }
+
+    /**
+     * Add a new pet to the store
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>405</b> - Invalid input
+     * @param body Pet object that needs to be added to the store (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> addPetWithHttpInfo(Pet body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -81,18 +95,32 @@ public class PetApi {
         String[] authNames = new String[] { "petstore_auth" };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Deletes a pet
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid pet value
-     * @param petId Pet id to delete
-     * @param apiKey The apiKey parameter
+     * @param petId Pet id to delete (required)
+     * @param apiKey  (optional)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deletePet(Long petId, String apiKey) throws RestClientException {
+        deletePetWithHttpInfo(petId, apiKey);
+    }
+
+    /**
+     * Deletes a pet
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid pet value
+     * @param petId Pet id to delete (required)
+     * @param apiKey  (optional)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'petId' is set
@@ -120,18 +148,31 @@ public class PetApi {
         String[] authNames = new String[] { "petstore_auth" };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid status value
-     * @param status Status values that need to be considered for filter
+     * @param status Status values that need to be considered for filter (required)
      * @return List&lt;Pet&gt;
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public List<Pet> findPetsByStatus(List<String> status) throws RestClientException {
+        return findPetsByStatusWithHttpInfo(status).getBody();
+    }
+
+    /**
+     * Finds Pets by status
+     * Multiple status values can be provided with comma separated strings
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid status value
+     * @param status Status values that need to be considered for filter (required)
+     * @return ResponseEntity&lt;List&lt;Pet&gt;&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'status' is set
@@ -164,11 +205,26 @@ public class PetApi {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid tag value
-     * @param tags Tags to filter by
+     * @param tags Tags to filter by (required)
      * @return List&lt;Pet&gt;
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
+    @Deprecated
     public List<Pet> findPetsByTags(List<String> tags) throws RestClientException {
+        return findPetsByTagsWithHttpInfo(tags).getBody();
+    }
+
+    /**
+     * Finds Pets by tags
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid tag value
+     * @param tags Tags to filter by (required)
+     * @return ResponseEntity&lt;List&lt;Pet&gt;&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    @Deprecated
+    public ResponseEntity<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'tags' is set
@@ -202,11 +258,25 @@ public class PetApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
-     * @param petId ID of pet to return
+     * @param petId ID of pet to return (required)
      * @return Pet
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Pet getPetById(Long petId) throws RestClientException {
+        return getPetByIdWithHttpInfo(petId).getBody();
+    }
+
+    /**
+     * Find pet by ID
+     * Returns a single pet
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Pet not found
+     * @param petId ID of pet to return (required)
+     * @return ResponseEntity&lt;Pet&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Pet> getPetByIdWithHttpInfo(Long petId) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'petId' is set
@@ -242,10 +312,25 @@ public class PetApi {
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
      * <p><b>405</b> - Validation exception
-     * @param body Pet object that needs to be added to the store
+     * @param body Pet object that needs to be added to the store (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void updatePet(Pet body) throws RestClientException {
+        updatePetWithHttpInfo(body);
+    }
+
+    /**
+     * Update an existing pet
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Pet not found
+     * <p><b>405</b> - Validation exception
+     * @param body Pet object that needs to be added to the store (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> updatePetWithHttpInfo(Pet body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -269,18 +354,32 @@ public class PetApi {
         String[] authNames = new String[] { "petstore_auth" };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Updates a pet in the store with form data
      * 
      * <p><b>405</b> - Invalid input
-     * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param petId ID of pet that needs to be updated (required)
+     * @param name Updated name of the pet (optional)
+     * @param status Updated status of the pet (optional)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void updatePetWithForm(Long petId, String name, String status) throws RestClientException {
+        updatePetWithFormWithHttpInfo(petId, name, status);
+    }
+
+    /**
+     * Updates a pet in the store with form data
+     * 
+     * <p><b>405</b> - Invalid input
+     * @param petId ID of pet that needs to be updated (required)
+     * @param name Updated name of the pet (optional)
+     * @param status Updated status of the pet (optional)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'petId' is set
@@ -312,19 +411,33 @@ public class PetApi {
         String[] authNames = new String[] { "petstore_auth" };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * uploads an image
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param petId ID of pet to update (required)
+     * @param additionalMetadata Additional data to pass to server (optional)
+     * @param file file to upload (optional)
      * @return ModelApiResponse
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file) throws RestClientException {
+        return uploadFileWithHttpInfo(petId, additionalMetadata, file).getBody();
+    }
+
+    /**
+     * uploads an image
+     * 
+     * <p><b>200</b> - successful operation
+     * @param petId ID of pet to update (required)
+     * @param additionalMetadata Additional data to pass to server (optional)
+     * @param file file to upload (optional)
+     * @return ResponseEntity&lt;ModelApiResponse&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'petId' is set
@@ -364,13 +477,27 @@ public class PetApi {
      * uploads an image (required)
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param requiredFile file to upload
-     * @param additionalMetadata Additional data to pass to server
+     * @param petId ID of pet to update (required)
+     * @param requiredFile file to upload (required)
+     * @param additionalMetadata Additional data to pass to server (optional)
      * @return ModelApiResponse
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata) throws RestClientException {
+        return uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata).getBody();
+    }
+
+    /**
+     * uploads an image (required)
+     * 
+     * <p><b>200</b> - successful operation
+     * @param petId ID of pet to update (required)
+     * @param requiredFile file to upload (required)
+     * @param additionalMetadata Additional data to pass to server (optional)
+     * @return ResponseEntity&lt;ModelApiResponse&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'petId' is set

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.StoreApi")
@@ -52,10 +53,23 @@ public class StoreApi {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of the order that needs to be deleted
+     * @param orderId ID of the order that needs to be deleted (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deleteOrder(String orderId) throws RestClientException {
+        deleteOrderWithHttpInfo(orderId);
+    }
+
+    /**
+     * Delete purchase order by ID
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Order not found
+     * @param orderId ID of the order that needs to be deleted (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> deleteOrderWithHttpInfo(String orderId) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'orderId' is set
@@ -80,7 +94,7 @@ public class StoreApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Returns pet inventories by status
@@ -90,6 +104,17 @@ public class StoreApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Map<String, Integer> getInventory() throws RestClientException {
+        return getInventoryWithHttpInfo().getBody();
+    }
+
+    /**
+     * Returns pet inventories by status
+     * Returns a map of status codes to quantities
+     * <p><b>200</b> - successful operation
+     * @return ResponseEntity&lt;Map&lt;String, Integer&gt;&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Map<String, Integer>> getInventoryWithHttpInfo() throws RestClientException {
         Object postBody = null;
         
         String path = apiClient.expandPath("/store/inventory", Collections.<String, Object>emptyMap());
@@ -116,11 +141,25 @@ public class StoreApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of pet that needs to be fetched
+     * @param orderId ID of pet that needs to be fetched (required)
      * @return Order
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Order getOrderById(Long orderId) throws RestClientException {
+        return getOrderByIdWithHttpInfo(orderId).getBody();
+    }
+
+    /**
+     * Find purchase order by ID
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Order not found
+     * @param orderId ID of pet that needs to be fetched (required)
+     * @return ResponseEntity&lt;Order&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Order> getOrderByIdWithHttpInfo(Long orderId) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'orderId' is set
@@ -154,11 +193,24 @@ public class StoreApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid Order
-     * @param body order placed for purchasing the pet
+     * @param body order placed for purchasing the pet (required)
      * @return Order
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Order placeOrder(Order body) throws RestClientException {
+        return placeOrderWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * Place an order for a pet
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid Order
+     * @param body order placed for purchasing the pet (required)
+     * @return ResponseEntity&lt;Order&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Order> placeOrderWithHttpInfo(Order body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/api/UserApi.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.UserApi")
@@ -51,10 +52,22 @@ public class UserApi {
      * Create user
      * This can only be done by the logged in user.
      * <p><b>0</b> - successful operation
-     * @param body Created user object
+     * @param body Created user object (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void createUser(User body) throws RestClientException {
+        createUserWithHttpInfo(body);
+    }
+
+    /**
+     * Create user
+     * This can only be done by the logged in user.
+     * <p><b>0</b> - successful operation
+     * @param body Created user object (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> createUserWithHttpInfo(User body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -76,16 +89,28 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param body List of user object
+     * @param body List of user object (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void createUsersWithArrayInput(List<User> body) throws RestClientException {
+        createUsersWithArrayInputWithHttpInfo(body);
+    }
+
+    /**
+     * Creates list of users with given input array
+     * 
+     * <p><b>0</b> - successful operation
+     * @param body List of user object (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -107,16 +132,28 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param body List of user object
+     * @param body List of user object (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void createUsersWithListInput(List<User> body) throws RestClientException {
+        createUsersWithListInputWithHttpInfo(body);
+    }
+
+    /**
+     * Creates list of users with given input array
+     * 
+     * <p><b>0</b> - successful operation
+     * @param body List of user object (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -138,17 +175,30 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Delete user
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be deleted
+     * @param username The name that needs to be deleted (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deleteUser(String username) throws RestClientException {
+        deleteUserWithHttpInfo(username);
+    }
+
+    /**
+     * Delete user
+     * This can only be done by the logged in user.
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param username The name that needs to be deleted (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> deleteUserWithHttpInfo(String username) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'username' is set
@@ -173,7 +223,7 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Get user by user name
@@ -181,11 +231,25 @@ public class UserApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @param username The name that needs to be fetched. Use user1 for testing. (required)
      * @return User
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public User getUserByName(String username) throws RestClientException {
+        return getUserByNameWithHttpInfo(username).getBody();
+    }
+
+    /**
+     * Get user by user name
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param username The name that needs to be fetched. Use user1 for testing. (required)
+     * @return ResponseEntity&lt;User&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<User> getUserByNameWithHttpInfo(String username) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'username' is set
@@ -219,12 +283,26 @@ public class UserApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username/password supplied
-     * @param username The user name for login
-     * @param password The password for login in clear text
+     * @param username The user name for login (required)
+     * @param password The password for login in clear text (required)
      * @return String
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public String loginUser(String username, String password) throws RestClientException {
+        return loginUserWithHttpInfo(username, password).getBody();
+    }
+
+    /**
+     * Logs user into the system
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid username/password supplied
+     * @param username The user name for login (required)
+     * @param password The password for login in clear text (required)
+     * @return ResponseEntity&lt;String&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<String> loginUserWithHttpInfo(String username, String password) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'username' is set
@@ -265,6 +343,17 @@ public class UserApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void logoutUser() throws RestClientException {
+        logoutUserWithHttpInfo();
+    }
+
+    /**
+     * Logs out current logged in user session
+     * 
+     * <p><b>0</b> - successful operation
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> logoutUserWithHttpInfo() throws RestClientException {
         Object postBody = null;
         
         String path = apiClient.expandPath("/user/logout", Collections.<String, Object>emptyMap());
@@ -281,18 +370,32 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Updated user
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid user supplied
      * <p><b>404</b> - User not found
-     * @param username name that need to be deleted
-     * @param body Updated user object
+     * @param username name that need to be deleted (required)
+     * @param body Updated user object (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void updateUser(String username, User body) throws RestClientException {
+        updateUserWithHttpInfo(username, body);
+    }
+
+    /**
+     * Updated user
+     * This can only be done by the logged in user.
+     * <p><b>400</b> - Invalid user supplied
+     * <p><b>404</b> - User not found
+     * @param username name that need to be deleted (required)
+     * @param body Updated user object (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> updateUserWithHttpInfo(String username, User body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'username' is set
@@ -322,6 +425,6 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
 }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -86,9 +86,6 @@ public class ApiClient {
 
     private Map<String, Authentication> authentications;
 
-    private HttpStatus statusCode;
-    private MultiValueMap<String, String> responseHeaders;
-
     private DateFormat dateFormat;
 
     public ApiClient() {
@@ -139,22 +136,6 @@ public class ApiClient {
     public ApiClient setBasePath(String basePath) {
         this.basePath = basePath;
         return this;
-    }
-
-    /**
-     * Gets the status code of the previous request
-     * @return HttpStatus the status code
-     */
-    public HttpStatus getStatusCode() {
-        return statusCode;
-    }
-
-    /**
-     * Gets the response headers of the previous request
-     * @return MultiValueMap a map of response headers
-     */
-    public MultiValueMap<String, String> getResponseHeaders() {
-        return responseHeaders;
     }
 
     /**
@@ -563,9 +544,9 @@ public class ApiClient {
      * @param contentType The request's Content-Type header
      * @param authNames The authentications to apply
      * @param returnType The return type into which to deserialize the response
-     * @return The response body in chosen type
+     * @return ResponseEntity&lt;T&gt; The response of the chosen type
      */
-    public <T> T invokeAPI(String path, HttpMethod method, MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams, MultiValueMap<String, Object> formParams, List<MediaType> accept, MediaType contentType, String[] authNames, ParameterizedTypeReference<T> returnType) throws RestClientException {
+    public <T> ResponseEntity<T> invokeAPI(String path, HttpMethod method, MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams, MultiValueMap<String, Object> formParams, List<MediaType> accept, MediaType contentType, String[] authNames, ParameterizedTypeReference<T> returnType) throws RestClientException {
         updateParamsForAuth(authNames, queryParams, headerParams);
 
         final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
@@ -607,16 +588,11 @@ public class ApiClient {
 
         ResponseEntity<T> responseEntity = restTemplate.exchange(requestEntity, returnType);
 
-        statusCode = responseEntity.getStatusCode();
-        responseHeaders = responseEntity.getHeaders();
-
-        if (responseEntity.getStatusCode() == HttpStatus.NO_CONTENT) {
-            return null;
-        } else if (responseEntity.getStatusCode().is2xxSuccessful()) {
-            return responseEntity.getBody();
+        if (responseEntity.getStatusCode().is2xxSuccessful()) {
+            return responseEntity;
         } else {
             // The error handler built into the RestTemplate should handle 400 and 500 series errors.
-            throw new RestClientException("API returned " + statusCode + " and it wasn't handled by the RestTemplate error handler");
+            throw new RestClientException("API returned " + responseEntity.getStatusCode() + " and it wasn't handled by the RestTemplate error handler");
         }
     }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.AnotherFakeApi")
@@ -51,11 +52,23 @@ public class AnotherFakeApi {
      * To test special tags
      * To test special tags and operation ID starting with number
      * <p><b>200</b> - successful operation
-     * @param body client model
+     * @param body client model (required)
      * @return Client
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Client call123testSpecialTags(Client body) throws RestClientException {
+        return call123testSpecialTagsWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * To test special tags
+     * To test special tags and operation ID starting with number
+     * <p><b>200</b> - successful operation
+     * @param body client model (required)
+     * @return ResponseEntity&lt;Client&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Client> call123testSpecialTagsWithHttpInfo(Client body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -32,6 +32,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.FakeApi")
@@ -59,10 +60,22 @@ public class FakeApi {
      * creates an XmlItem
      * this route creates an XmlItem
      * <p><b>200</b> - successful operation
-     * @param xmlItem XmlItem Body
+     * @param xmlItem XmlItem Body (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void createXmlItem(XmlItem xmlItem) throws RestClientException {
+        createXmlItemWithHttpInfo(xmlItem);
+    }
+
+    /**
+     * creates an XmlItem
+     * this route creates an XmlItem
+     * <p><b>200</b> - successful operation
+     * @param xmlItem XmlItem Body (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> createXmlItemWithHttpInfo(XmlItem xmlItem) throws RestClientException {
         Object postBody = xmlItem;
         
         // verify the required parameter 'xmlItem' is set
@@ -86,17 +99,29 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * 
      * Test serialization of outer boolean types
      * <p><b>200</b> - Output boolean
-     * @param body Input boolean as post body
+     * @param body Input boolean as post body (optional)
      * @return Boolean
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Boolean fakeOuterBooleanSerialize(Boolean body) throws RestClientException {
+        return fakeOuterBooleanSerializeWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * 
+     * Test serialization of outer boolean types
+     * <p><b>200</b> - Output boolean
+     * @param body Input boolean as post body (optional)
+     * @return ResponseEntity&lt;Boolean&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Boolean> fakeOuterBooleanSerializeWithHttpInfo(Boolean body) throws RestClientException {
         Object postBody = body;
         
         String path = apiClient.expandPath("/fake/outer/boolean", Collections.<String, Object>emptyMap());
@@ -121,11 +146,23 @@ public class FakeApi {
      * 
      * Test serialization of object with outer number type
      * <p><b>200</b> - Output composite
-     * @param body Input composite as post body
+     * @param body Input composite as post body (optional)
      * @return OuterComposite
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public OuterComposite fakeOuterCompositeSerialize(OuterComposite body) throws RestClientException {
+        return fakeOuterCompositeSerializeWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * 
+     * Test serialization of object with outer number type
+     * <p><b>200</b> - Output composite
+     * @param body Input composite as post body (optional)
+     * @return ResponseEntity&lt;OuterComposite&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<OuterComposite> fakeOuterCompositeSerializeWithHttpInfo(OuterComposite body) throws RestClientException {
         Object postBody = body;
         
         String path = apiClient.expandPath("/fake/outer/composite", Collections.<String, Object>emptyMap());
@@ -150,11 +187,23 @@ public class FakeApi {
      * 
      * Test serialization of outer number types
      * <p><b>200</b> - Output number
-     * @param body Input number as post body
+     * @param body Input number as post body (optional)
      * @return BigDecimal
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public BigDecimal fakeOuterNumberSerialize(BigDecimal body) throws RestClientException {
+        return fakeOuterNumberSerializeWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * 
+     * Test serialization of outer number types
+     * <p><b>200</b> - Output number
+     * @param body Input number as post body (optional)
+     * @return ResponseEntity&lt;BigDecimal&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<BigDecimal> fakeOuterNumberSerializeWithHttpInfo(BigDecimal body) throws RestClientException {
         Object postBody = body;
         
         String path = apiClient.expandPath("/fake/outer/number", Collections.<String, Object>emptyMap());
@@ -179,11 +228,23 @@ public class FakeApi {
      * 
      * Test serialization of outer string types
      * <p><b>200</b> - Output string
-     * @param body Input string as post body
+     * @param body Input string as post body (optional)
      * @return String
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public String fakeOuterStringSerialize(String body) throws RestClientException {
+        return fakeOuterStringSerializeWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * 
+     * Test serialization of outer string types
+     * <p><b>200</b> - Output string
+     * @param body Input string as post body (optional)
+     * @return ResponseEntity&lt;String&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<String> fakeOuterStringSerializeWithHttpInfo(String body) throws RestClientException {
         Object postBody = body;
         
         String path = apiClient.expandPath("/fake/outer/string", Collections.<String, Object>emptyMap());
@@ -208,10 +269,22 @@ public class FakeApi {
      * 
      * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
      * <p><b>200</b> - Success
-     * @param body The body parameter
+     * @param body  (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testBodyWithFileSchema(FileSchemaTestClass body) throws RestClientException {
+        testBodyWithFileSchemaWithHttpInfo(body);
+    }
+
+    /**
+     * 
+     * For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+     * <p><b>200</b> - Success
+     * @param body  (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -235,17 +308,30 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * 
      * 
      * <p><b>200</b> - Success
-     * @param query The query parameter
-     * @param body The body parameter
+     * @param query  (required)
+     * @param body  (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testBodyWithQueryParams(String query, User body) throws RestClientException {
+        testBodyWithQueryParamsWithHttpInfo(query, body);
+    }
+
+    /**
+     * 
+     * 
+     * <p><b>200</b> - Success
+     * @param query  (required)
+     * @param body  (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testBodyWithQueryParamsWithHttpInfo(String query, User body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'query' is set
@@ -276,17 +362,29 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * To test \&quot;client\&quot; model
      * To test \&quot;client\&quot; model
      * <p><b>200</b> - successful operation
-     * @param body client model
+     * @param body client model (required)
      * @return Client
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Client testClientModel(Client body) throws RestClientException {
+        return testClientModelWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * To test \&quot;client\&quot; model
+     * To test \&quot;client\&quot; model
+     * <p><b>200</b> - successful operation
+     * @param body client model (required)
+     * @return ResponseEntity&lt;Client&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Client> testClientModelWithHttpInfo(Client body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -319,23 +417,49 @@ public class FakeApi {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param number None
-     * @param _double None
-     * @param patternWithoutDelimiter None
-     * @param _byte None
-     * @param integer None
-     * @param int32 None
-     * @param int64 None
-     * @param _float None
-     * @param string None
-     * @param binary None
-     * @param date None
-     * @param dateTime None
-     * @param password None
-     * @param paramCallback None
+     * @param number None (required)
+     * @param _double None (required)
+     * @param patternWithoutDelimiter None (required)
+     * @param _byte None (required)
+     * @param integer None (optional)
+     * @param int32 None (optional)
+     * @param int64 None (optional)
+     * @param _float None (optional)
+     * @param string None (optional)
+     * @param binary None (optional)
+     * @param date None (optional)
+     * @param dateTime None (optional)
+     * @param password None (optional)
+     * @param paramCallback None (optional)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testEndpointParameters(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws RestClientException {
+        testEndpointParametersWithHttpInfo(number, _double, patternWithoutDelimiter, _byte, integer, int32, int64, _float, string, binary, date, dateTime, password, paramCallback);
+    }
+
+    /**
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param number None (required)
+     * @param _double None (required)
+     * @param patternWithoutDelimiter None (required)
+     * @param _byte None (required)
+     * @param integer None (optional)
+     * @param int32 None (optional)
+     * @param int64 None (optional)
+     * @param _float None (optional)
+     * @param string None (optional)
+     * @param binary None (optional)
+     * @param date None (optional)
+     * @param dateTime None (optional)
+     * @param password None (optional)
+     * @param paramCallback None (optional)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testEndpointParametersWithHttpInfo(BigDecimal number, Double _double, String patternWithoutDelimiter, byte[] _byte, Integer integer, Integer int32, Long int64, Float _float, String string, File binary, LocalDate date, OffsetDateTime dateTime, String password, String paramCallback) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'number' is set
@@ -403,24 +527,44 @@ public class FakeApi {
         String[] authNames = new String[] { "http_basic_test" };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * To test enum parameters
      * To test enum parameters
      * <p><b>400</b> - Invalid request
      * <p><b>404</b> - Not found
-     * @param enumHeaderStringArray Header parameter enum test (string array)
-     * @param enumHeaderString Header parameter enum test (string)
-     * @param enumQueryStringArray Query parameter enum test (string array)
-     * @param enumQueryString Query parameter enum test (string)
-     * @param enumQueryInteger Query parameter enum test (double)
-     * @param enumQueryDouble Query parameter enum test (double)
-     * @param enumFormStringArray Form parameter enum test (string array)
-     * @param enumFormString Form parameter enum test (string)
+     * @param enumHeaderStringArray Header parameter enum test (string array) (optional, default to new ArrayList&lt;String&gt;())
+     * @param enumHeaderString Header parameter enum test (string) (optional, default to -efg)
+     * @param enumQueryStringArray Query parameter enum test (string array) (optional, default to new ArrayList&lt;String&gt;())
+     * @param enumQueryString Query parameter enum test (string) (optional, default to -efg)
+     * @param enumQueryInteger Query parameter enum test (double) (optional)
+     * @param enumQueryDouble Query parameter enum test (double) (optional)
+     * @param enumFormStringArray Form parameter enum test (string array) (optional, default to $)
+     * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testEnumParameters(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws RestClientException {
+        testEnumParametersWithHttpInfo(enumHeaderStringArray, enumHeaderString, enumQueryStringArray, enumQueryString, enumQueryInteger, enumQueryDouble, enumFormStringArray, enumFormString);
+    }
+
+    /**
+     * To test enum parameters
+     * To test enum parameters
+     * <p><b>400</b> - Invalid request
+     * <p><b>404</b> - Not found
+     * @param enumHeaderStringArray Header parameter enum test (string array) (optional, default to new ArrayList&lt;String&gt;())
+     * @param enumHeaderString Header parameter enum test (string) (optional, default to -efg)
+     * @param enumQueryStringArray Query parameter enum test (string array) (optional, default to new ArrayList&lt;String&gt;())
+     * @param enumQueryString Query parameter enum test (string) (optional, default to -efg)
+     * @param enumQueryInteger Query parameter enum test (double) (optional)
+     * @param enumQueryDouble Query parameter enum test (double) (optional)
+     * @param enumFormStringArray Form parameter enum test (string array) (optional, default to $)
+     * @param enumFormString Form parameter enum test (string) (optional, default to -efg)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testEnumParametersWithHttpInfo(List<String> enumHeaderStringArray, String enumHeaderString, List<String> enumQueryStringArray, String enumQueryString, Integer enumQueryInteger, Double enumQueryDouble, List<String> enumFormStringArray, String enumFormString) throws RestClientException {
         Object postBody = null;
         
         String path = apiClient.expandPath("/fake", Collections.<String, Object>emptyMap());
@@ -454,21 +598,38 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Fake endpoint to test group parameters (optional)
      * Fake endpoint to test group parameters (optional)
      * <p><b>400</b> - Someting wrong
-     * @param requiredStringGroup Required String in group parameters
-     * @param requiredBooleanGroup Required Boolean in group parameters
-     * @param requiredInt64Group Required Integer in group parameters
-     * @param stringGroup String in group parameters
-     * @param booleanGroup Boolean in group parameters
-     * @param int64Group Integer in group parameters
+     * @param requiredStringGroup Required String in group parameters (required)
+     * @param requiredBooleanGroup Required Boolean in group parameters (required)
+     * @param requiredInt64Group Required Integer in group parameters (required)
+     * @param stringGroup String in group parameters (optional)
+     * @param booleanGroup Boolean in group parameters (optional)
+     * @param int64Group Integer in group parameters (optional)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testGroupParameters(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws RestClientException {
+        testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group, stringGroup, booleanGroup, int64Group);
+    }
+
+    /**
+     * Fake endpoint to test group parameters (optional)
+     * Fake endpoint to test group parameters (optional)
+     * <p><b>400</b> - Someting wrong
+     * @param requiredStringGroup Required String in group parameters (required)
+     * @param requiredBooleanGroup Required Boolean in group parameters (required)
+     * @param requiredInt64Group Required Integer in group parameters (required)
+     * @param stringGroup String in group parameters (optional)
+     * @param booleanGroup Boolean in group parameters (optional)
+     * @param int64Group Integer in group parameters (optional)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testGroupParametersWithHttpInfo(Integer requiredStringGroup, Boolean requiredBooleanGroup, Long requiredInt64Group, Integer stringGroup, Boolean booleanGroup, Long int64Group) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'requiredStringGroup' is set
@@ -510,16 +671,28 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * test inline additionalProperties
      * 
      * <p><b>200</b> - successful operation
-     * @param param request body
+     * @param param request body (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testInlineAdditionalProperties(Map<String, String> param) throws RestClientException {
+        testInlineAdditionalPropertiesWithHttpInfo(param);
+    }
+
+    /**
+     * test inline additionalProperties
+     * 
+     * <p><b>200</b> - successful operation
+     * @param param request body (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> param) throws RestClientException {
         Object postBody = param;
         
         // verify the required parameter 'param' is set
@@ -543,17 +716,30 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * test json serialization of form data
      * 
      * <p><b>200</b> - successful operation
-     * @param param field1
-     * @param param2 field2
+     * @param param field1 (required)
+     * @param param2 field2 (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testJsonFormData(String param, String param2) throws RestClientException {
+        testJsonFormDataWithHttpInfo(param, param2);
+    }
+
+    /**
+     * test json serialization of form data
+     * 
+     * <p><b>200</b> - successful operation
+     * @param param field1 (required)
+     * @param param2 field2 (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testJsonFormDataWithHttpInfo(String param, String param2) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'param' is set
@@ -587,20 +773,36 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * 
      * To test the collection format in query parameters
      * <p><b>200</b> - Success
-     * @param pipe The pipe parameter
-     * @param ioutil The ioutil parameter
-     * @param http The http parameter
-     * @param url The url parameter
-     * @param context The context parameter
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws RestClientException {
+        testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context);
+    }
+
+    /**
+     * 
+     * To test the collection format in query parameters
+     * <p><b>200</b> - Success
+     * @param pipe  (required)
+     * @param ioutil  (required)
+     * @param http  (required)
+     * @param url  (required)
+     * @param context  (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'pipe' is set
@@ -648,6 +850,6 @@ public class FakeApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
 }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.FakeClassnameTags123Api")
@@ -51,11 +52,23 @@ public class FakeClassnameTags123Api {
      * To test class name in snake case
      * To test class name in snake case
      * <p><b>200</b> - successful operation
-     * @param body client model
+     * @param body client model (required)
      * @return Client
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Client testClassname(Client body) throws RestClientException {
+        return testClassnameWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * To test class name in snake case
+     * To test class name in snake case
+     * <p><b>200</b> - successful operation
+     * @param body client model (required)
+     * @return ResponseEntity&lt;Client&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Client> testClassnameWithHttpInfo(Client body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/PetApi.java
@@ -26,6 +26,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.PetApi")
@@ -54,10 +55,23 @@ public class PetApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>405</b> - Invalid input
-     * @param body Pet object that needs to be added to the store
+     * @param body Pet object that needs to be added to the store (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void addPet(Pet body) throws RestClientException {
+        addPetWithHttpInfo(body);
+    }
+
+    /**
+     * Add a new pet to the store
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>405</b> - Invalid input
+     * @param body Pet object that needs to be added to the store (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> addPetWithHttpInfo(Pet body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -81,18 +95,32 @@ public class PetApi {
         String[] authNames = new String[] { "petstore_auth" };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Deletes a pet
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid pet value
-     * @param petId Pet id to delete
-     * @param apiKey The apiKey parameter
+     * @param petId Pet id to delete (required)
+     * @param apiKey  (optional)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deletePet(Long petId, String apiKey) throws RestClientException {
+        deletePetWithHttpInfo(petId, apiKey);
+    }
+
+    /**
+     * Deletes a pet
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid pet value
+     * @param petId Pet id to delete (required)
+     * @param apiKey  (optional)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> deletePetWithHttpInfo(Long petId, String apiKey) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'petId' is set
@@ -120,18 +148,31 @@ public class PetApi {
         String[] authNames = new String[] { "petstore_auth" };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid status value
-     * @param status Status values that need to be considered for filter
+     * @param status Status values that need to be considered for filter (required)
      * @return List&lt;Pet&gt;
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public List<Pet> findPetsByStatus(List<String> status) throws RestClientException {
+        return findPetsByStatusWithHttpInfo(status).getBody();
+    }
+
+    /**
+     * Finds Pets by status
+     * Multiple status values can be provided with comma separated strings
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid status value
+     * @param status Status values that need to be considered for filter (required)
+     * @return ResponseEntity&lt;List&lt;Pet&gt;&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<List<Pet>> findPetsByStatusWithHttpInfo(List<String> status) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'status' is set
@@ -164,11 +205,26 @@ public class PetApi {
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid tag value
-     * @param tags Tags to filter by
+     * @param tags Tags to filter by (required)
      * @return List&lt;Pet&gt;
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
+    @Deprecated
     public List<Pet> findPetsByTags(List<String> tags) throws RestClientException {
+        return findPetsByTagsWithHttpInfo(tags).getBody();
+    }
+
+    /**
+     * Finds Pets by tags
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid tag value
+     * @param tags Tags to filter by (required)
+     * @return ResponseEntity&lt;List&lt;Pet&gt;&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    @Deprecated
+    public ResponseEntity<List<Pet>> findPetsByTagsWithHttpInfo(List<String> tags) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'tags' is set
@@ -202,11 +258,25 @@ public class PetApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
-     * @param petId ID of pet to return
+     * @param petId ID of pet to return (required)
      * @return Pet
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Pet getPetById(Long petId) throws RestClientException {
+        return getPetByIdWithHttpInfo(petId).getBody();
+    }
+
+    /**
+     * Find pet by ID
+     * Returns a single pet
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Pet not found
+     * @param petId ID of pet to return (required)
+     * @return ResponseEntity&lt;Pet&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Pet> getPetByIdWithHttpInfo(Long petId) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'petId' is set
@@ -242,10 +312,25 @@ public class PetApi {
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Pet not found
      * <p><b>405</b> - Validation exception
-     * @param body Pet object that needs to be added to the store
+     * @param body Pet object that needs to be added to the store (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void updatePet(Pet body) throws RestClientException {
+        updatePetWithHttpInfo(body);
+    }
+
+    /**
+     * Update an existing pet
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Pet not found
+     * <p><b>405</b> - Validation exception
+     * @param body Pet object that needs to be added to the store (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> updatePetWithHttpInfo(Pet body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -269,18 +354,32 @@ public class PetApi {
         String[] authNames = new String[] { "petstore_auth" };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Updates a pet in the store with form data
      * 
      * <p><b>405</b> - Invalid input
-     * @param petId ID of pet that needs to be updated
-     * @param name Updated name of the pet
-     * @param status Updated status of the pet
+     * @param petId ID of pet that needs to be updated (required)
+     * @param name Updated name of the pet (optional)
+     * @param status Updated status of the pet (optional)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void updatePetWithForm(Long petId, String name, String status) throws RestClientException {
+        updatePetWithFormWithHttpInfo(petId, name, status);
+    }
+
+    /**
+     * Updates a pet in the store with form data
+     * 
+     * <p><b>405</b> - Invalid input
+     * @param petId ID of pet that needs to be updated (required)
+     * @param name Updated name of the pet (optional)
+     * @param status Updated status of the pet (optional)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> updatePetWithFormWithHttpInfo(Long petId, String name, String status) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'petId' is set
@@ -312,19 +411,33 @@ public class PetApi {
         String[] authNames = new String[] { "petstore_auth" };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * uploads an image
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param additionalMetadata Additional data to pass to server
-     * @param file file to upload
+     * @param petId ID of pet to update (required)
+     * @param additionalMetadata Additional data to pass to server (optional)
+     * @param file file to upload (optional)
      * @return ModelApiResponse
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public ModelApiResponse uploadFile(Long petId, String additionalMetadata, File file) throws RestClientException {
+        return uploadFileWithHttpInfo(petId, additionalMetadata, file).getBody();
+    }
+
+    /**
+     * uploads an image
+     * 
+     * <p><b>200</b> - successful operation
+     * @param petId ID of pet to update (required)
+     * @param additionalMetadata Additional data to pass to server (optional)
+     * @param file file to upload (optional)
+     * @return ResponseEntity&lt;ModelApiResponse&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<ModelApiResponse> uploadFileWithHttpInfo(Long petId, String additionalMetadata, File file) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'petId' is set
@@ -364,13 +477,27 @@ public class PetApi {
      * uploads an image (required)
      * 
      * <p><b>200</b> - successful operation
-     * @param petId ID of pet to update
-     * @param requiredFile file to upload
-     * @param additionalMetadata Additional data to pass to server
+     * @param petId ID of pet to update (required)
+     * @param requiredFile file to upload (required)
+     * @param additionalMetadata Additional data to pass to server (optional)
      * @return ModelApiResponse
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public ModelApiResponse uploadFileWithRequiredFile(Long petId, File requiredFile, String additionalMetadata) throws RestClientException {
+        return uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata).getBody();
+    }
+
+    /**
+     * uploads an image (required)
+     * 
+     * <p><b>200</b> - successful operation
+     * @param petId ID of pet to update (required)
+     * @param requiredFile file to upload (required)
+     * @param additionalMetadata Additional data to pass to server (optional)
+     * @return ResponseEntity&lt;ModelApiResponse&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<ModelApiResponse> uploadFileWithRequiredFileWithHttpInfo(Long petId, File requiredFile, String additionalMetadata) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'petId' is set

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.StoreApi")
@@ -52,10 +53,23 @@ public class StoreApi {
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of the order that needs to be deleted
+     * @param orderId ID of the order that needs to be deleted (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deleteOrder(String orderId) throws RestClientException {
+        deleteOrderWithHttpInfo(orderId);
+    }
+
+    /**
+     * Delete purchase order by ID
+     * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Order not found
+     * @param orderId ID of the order that needs to be deleted (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> deleteOrderWithHttpInfo(String orderId) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'orderId' is set
@@ -80,7 +94,7 @@ public class StoreApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Returns pet inventories by status
@@ -90,6 +104,17 @@ public class StoreApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Map<String, Integer> getInventory() throws RestClientException {
+        return getInventoryWithHttpInfo().getBody();
+    }
+
+    /**
+     * Returns pet inventories by status
+     * Returns a map of status codes to quantities
+     * <p><b>200</b> - successful operation
+     * @return ResponseEntity&lt;Map&lt;String, Integer&gt;&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Map<String, Integer>> getInventoryWithHttpInfo() throws RestClientException {
         Object postBody = null;
         
         String path = apiClient.expandPath("/store/inventory", Collections.<String, Object>emptyMap());
@@ -116,11 +141,25 @@ public class StoreApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid ID supplied
      * <p><b>404</b> - Order not found
-     * @param orderId ID of pet that needs to be fetched
+     * @param orderId ID of pet that needs to be fetched (required)
      * @return Order
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Order getOrderById(Long orderId) throws RestClientException {
+        return getOrderByIdWithHttpInfo(orderId).getBody();
+    }
+
+    /**
+     * Find purchase order by ID
+     * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid ID supplied
+     * <p><b>404</b> - Order not found
+     * @param orderId ID of pet that needs to be fetched (required)
+     * @return ResponseEntity&lt;Order&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Order> getOrderByIdWithHttpInfo(Long orderId) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'orderId' is set
@@ -154,11 +193,24 @@ public class StoreApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid Order
-     * @param body order placed for purchasing the pet
+     * @param body order placed for purchasing the pet (required)
      * @return Order
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public Order placeOrder(Order body) throws RestClientException {
+        return placeOrderWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * Place an order for a pet
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid Order
+     * @param body order placed for purchasing the pet (required)
+     * @return ResponseEntity&lt;Order&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Order> placeOrderWithHttpInfo(Order body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/api/UserApi.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 
 
 @Component("org.openapitools.client.api.UserApi")
@@ -51,10 +52,22 @@ public class UserApi {
      * Create user
      * This can only be done by the logged in user.
      * <p><b>0</b> - successful operation
-     * @param body Created user object
+     * @param body Created user object (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void createUser(User body) throws RestClientException {
+        createUserWithHttpInfo(body);
+    }
+
+    /**
+     * Create user
+     * This can only be done by the logged in user.
+     * <p><b>0</b> - successful operation
+     * @param body Created user object (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> createUserWithHttpInfo(User body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -76,16 +89,28 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param body List of user object
+     * @param body List of user object (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void createUsersWithArrayInput(List<User> body) throws RestClientException {
+        createUsersWithArrayInputWithHttpInfo(body);
+    }
+
+    /**
+     * Creates list of users with given input array
+     * 
+     * <p><b>0</b> - successful operation
+     * @param body List of user object (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> createUsersWithArrayInputWithHttpInfo(List<User> body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -107,16 +132,28 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Creates list of users with given input array
      * 
      * <p><b>0</b> - successful operation
-     * @param body List of user object
+     * @param body List of user object (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void createUsersWithListInput(List<User> body) throws RestClientException {
+        createUsersWithListInputWithHttpInfo(body);
+    }
+
+    /**
+     * Creates list of users with given input array
+     * 
+     * <p><b>0</b> - successful operation
+     * @param body List of user object (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> createUsersWithListInputWithHttpInfo(List<User> body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'body' is set
@@ -138,17 +175,30 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.POST, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Delete user
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be deleted
+     * @param username The name that needs to be deleted (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void deleteUser(String username) throws RestClientException {
+        deleteUserWithHttpInfo(username);
+    }
+
+    /**
+     * Delete user
+     * This can only be done by the logged in user.
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param username The name that needs to be deleted (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> deleteUserWithHttpInfo(String username) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'username' is set
@@ -173,7 +223,7 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.DELETE, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Get user by user name
@@ -181,11 +231,25 @@ public class UserApi {
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username supplied
      * <p><b>404</b> - User not found
-     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @param username The name that needs to be fetched. Use user1 for testing. (required)
      * @return User
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public User getUserByName(String username) throws RestClientException {
+        return getUserByNameWithHttpInfo(username).getBody();
+    }
+
+    /**
+     * Get user by user name
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid username supplied
+     * <p><b>404</b> - User not found
+     * @param username The name that needs to be fetched. Use user1 for testing. (required)
+     * @return ResponseEntity&lt;User&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<User> getUserByNameWithHttpInfo(String username) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'username' is set
@@ -219,12 +283,26 @@ public class UserApi {
      * 
      * <p><b>200</b> - successful operation
      * <p><b>400</b> - Invalid username/password supplied
-     * @param username The user name for login
-     * @param password The password for login in clear text
+     * @param username The user name for login (required)
+     * @param password The password for login in clear text (required)
      * @return String
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public String loginUser(String username, String password) throws RestClientException {
+        return loginUserWithHttpInfo(username, password).getBody();
+    }
+
+    /**
+     * Logs user into the system
+     * 
+     * <p><b>200</b> - successful operation
+     * <p><b>400</b> - Invalid username/password supplied
+     * @param username The user name for login (required)
+     * @param password The password for login in clear text (required)
+     * @return ResponseEntity&lt;String&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<String> loginUserWithHttpInfo(String username, String password) throws RestClientException {
         Object postBody = null;
         
         // verify the required parameter 'username' is set
@@ -265,6 +343,17 @@ public class UserApi {
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void logoutUser() throws RestClientException {
+        logoutUserWithHttpInfo();
+    }
+
+    /**
+     * Logs out current logged in user session
+     * 
+     * <p><b>0</b> - successful operation
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> logoutUserWithHttpInfo() throws RestClientException {
         Object postBody = null;
         
         String path = apiClient.expandPath("/user/logout", Collections.<String, Object>emptyMap());
@@ -281,18 +370,32 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.GET, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
     /**
      * Updated user
      * This can only be done by the logged in user.
      * <p><b>400</b> - Invalid user supplied
      * <p><b>404</b> - User not found
-     * @param username name that need to be deleted
-     * @param body Updated user object
+     * @param username name that need to be deleted (required)
+     * @param body Updated user object (required)
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
     public void updateUser(String username, User body) throws RestClientException {
+        updateUserWithHttpInfo(username, body);
+    }
+
+    /**
+     * Updated user
+     * This can only be done by the logged in user.
+     * <p><b>400</b> - Invalid user supplied
+     * <p><b>404</b> - User not found
+     * @param username name that need to be deleted (required)
+     * @param body Updated user object (required)
+     * @return ResponseEntity&lt;Void&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<Void> updateUserWithHttpInfo(String username, User body) throws RestClientException {
         Object postBody = body;
         
         // verify the required parameter 'username' is set
@@ -322,6 +425,6 @@ public class UserApi {
         String[] authNames = new String[] {  };
 
         ParameterizedTypeReference<Void> returnType = new ParameterizedTypeReference<Void>() {};
-        apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
+        return apiClient.invokeAPI(path, HttpMethod.PUT, queryParams, postBody, headerParams, formParams, accept, contentType, authNames, returnType);
     }
 }


### PR DESCRIPTION
…by many other generated clients

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


### Description of the PR
This PR is just a copy of the one I just merged in the old `swagger-api/swagger-codegen` repo 
https://github.com/swagger-api/swagger-codegen/pull/9737

This PR is to make the generated RestTemplate client thread safe. Currently, we don't have any way of retrieving the response headers except by using getResponseHeaders() method which returns the latest response headers, in the case multiple threads use the ApiClient we might end up getting the headers of the response sent to another thread.

This PR purpose is to add an additional method which not only return the expected DTO but also the ResponseEntity wrapping it, so user can easily retrieve headers by inspecting the ResponseEntity. The usual methods to directly get the DTO are conserved.

This change breaks backward compatibility since (thread unsafe) attributes, statusCode and responseHeaders, are removed from ApiClient class.

Java technical committee: 
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)
