### PR TITLE
[C] Update build-and-test.bash

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/README.md.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/README.md.mustache
@@ -64,6 +64,8 @@ once compile, you can run it with ``` ./main ```
 
 Note: You dont need to specify includes for models and include folder seperately as they are path linked. You just have to import the api.h file in your code, the include linking will work.
 
+## Test petstore sample
+In CMakeLists.txt, uncomment line 67 to 90 inorder to compile and generate the executables for manual tests. Once the tests are generated, execute then with ./{testname}
 ## Author
 
 {{#apiInfo}}{{#apis}}{{^hasMore}}{{infoEmail}}

--- a/samples/client/petstore/c/build-and-test.bash
+++ b/samples/client/petstore/c/build-and-test.bash
@@ -16,6 +16,7 @@ cmake .
 
 make 
 
-./unit-manual-PetAPI
-./unit-manual-UserAPI
-./unit-manual-StoreAPI
+if [ -f unit-manual-PetAPI ]; then ./unit-manual-PetAPI; fi
+if [ -f unit-manual-UserAPI ]; then ./unit-manual-UserAPI; fi
+if [ -f unit-manual-StoreAPI ]; then ./unit-manual-StoreAPI; fi
+


### PR DESCRIPTION
add check for non autogenerated test file

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Due to build of manual test files is commented out in CMakeLists.txt, they are not generated hence build fails.

@Fjolnir-Dvorak 