### PR TITLE
[haskell-http-client] Bump deps to LTS 14.7

### DIFF
--- a/modules/openapi-generator/src/main/resources/haskell-http-client/stack.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/stack.mustache
@@ -1,8 +1,7 @@
-resolver: lts-14.3
+resolver: lts-14.7
 build:
   haddock-arguments:
     haddock-args:
     - "--odir=./docs"
-extra-deps: [ katip-0.8.3.0 ]
 packages:
 - '.'

--- a/samples/client/petstore/haskell-http-client/stack.yaml
+++ b/samples/client/petstore/haskell-http-client/stack.yaml
@@ -1,8 +1,7 @@
-resolver: lts-14.3
+resolver: lts-14.7
 build:
   haddock-arguments:
     haddock-args:
     - "--odir=./docs"
-extra-deps: [ katip-0.8.3.0 ]
 packages:
 - '.'


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Nobody is listed in the technical committee, but last few PRs were merged by @jonschoning, so cc'ing them.

### Description of the PR

As the title says, bumped stack.yaml to use lts-14.7. `katip` is already in the snapshot, so no need for `extra-deps`.
I re-generated the `petstore` example and ran the tests, they all passed.