### PR TITLE
Remove unused property

### DIFF
--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/model/GeneratorInput.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/model/GeneratorInput.java
@@ -19,7 +19,6 @@ package org.openapitools.codegen.online.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.annotations.ApiModelProperty;
-import io.swagger.models.auth.SecuritySchemeDefinition;
 import io.swagger.v3.parser.core.models.AuthorizationValue;
 
 import java.util.Map;
@@ -28,7 +27,6 @@ public class GeneratorInput {
     private JsonNode spec;
     private Map<String, String> options;
     private String openAPIUrl;
-    private SecuritySchemeDefinition auth;
     private AuthorizationValue authorizationValue;
 
     public AuthorizationValue getAuthorizationValue() {
@@ -62,15 +60,5 @@ public class GeneratorInput {
 
     public void setOpenAPIUrl(String url) {
         this.openAPIUrl = url;
-    }
-
-    @Deprecated
-    public SecuritySchemeDefinition getSecurityDefinition() {
-        return auth;
-    }
-
-    @Deprecated
-    public void setSecurityDefinition(SecuritySchemeDefinition auth) {
-        this.auth = auth;
     }
 }


### PR DESCRIPTION
Fix #4066

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The field SecuritySchemeDefinition auth is deprecated and no more used in the generator.

I think we can just remove it.

@wing328 
@jimschubert 
@cbornet 
@ackintosh 
@jmini
@etherealjoy 