### PR TITLE
serializer object mapper setting fix

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/SerializerUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/SerializerUtils.java
@@ -19,6 +19,7 @@ public class SerializerUtils {
         SimpleModule module = createModule();
         try {
             return Yaml.mapper()
+                    .copy()
                     .registerModule(module)
                     .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
                     .writeValueAsString(openAPI)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR
- same as object mapper in `toJsonString`, we should copy object mapper when serializing the yaml, in order to avoid setting affects other serialization.

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

@wing328 