### PR TITLE
Fix example docker command line

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,7 +68,7 @@ Here's an example generating a Go client:
 ```bash
 docker run --rm \
   -v ${PWD}:/local openapitools/openapi-generator-cli generate \
-  -i petstore.yaml \
+  -i /local/petstore.yaml \
   -g go \
   -o /local/out/go
 ```

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -158,7 +158,7 @@ class Index extends React.Component {
     | \`\`\`bash
     | docker run --rm \\
     | -v \${PWD}:/local openapitools/openapi-generator-cli generate \\
-    | -i petstore.yaml \\
+    | -i /local/petstore.yaml \\
     | -g go \\
     | -o /local/out/go
     | \`\`\`


### PR DESCRIPTION
Problem:

```bash
cd ./modules/openapi-generator/src/test/resources/3_0/
docker run --rm \
> -v ${PWD}:/local openapitools/openapi-generator-cli generate \
> -i petstore.yaml \
> -g go \
> -o /local/out/go
[error] The spec file is not found: petstore.yaml
[error] Check the path of the OpenAPI spec and try again.
```

Solution: specify absolute path to input file