### PR TITLE
Comment out qt5 installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,11 +97,12 @@ before_install:
   # install valgrind for C++ memory test
   - sudo apt-get install valgrind
   # install Qt 5.10
-  - sudo add-apt-repository --yes ppa:beineri/opt-qt-5.10.1-trusty
-  - sudo apt-get update -qq
-  - sudo apt-get install qt510-meta-minimal
-  - source /opt/qt510/bin/qt510-env.sh
-  - qmake -v
+  # comment out the following due to failure in downloading http://ppa.launchpad.net/beineri/opt-qt-5.10.1-trusty/ubuntu/dists/xenial/main/binary-amd64/Packages
+  #- sudo add-apt-repository --yes ppa:beineri/opt-qt-5.10.1-trusty
+  #- sudo apt-get update -qq
+  #- sudo apt-get install qt510-meta-minimal
+  #- source /opt/qt510/bin/qt510-env.sh
+  #- qmake -v
 
   # show host table to confirm petstore.swagger.io is mapped to localhost
   - cat /etc/hosts


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [ ] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Comment out qt5 installation to avoid build failure
```
8.02s$ sudo apt-get install valgrind
before_install.14
1.63s$ sudo add-apt-repository --yes ppa:beineri/opt-qt-5.10.1-trusty
13.70s$ sudo apt-get update -qq
W: The repository 'http://ppa.launchpad.net/beineri/opt-qt-5.10.1-trusty/ubuntu xenial Release' does not have a Release file.
E: Failed to fetch http://ppa.launchpad.net/beineri/opt-qt-5.10.1-trusty/ubuntu/dists/xenial/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
The command "sudo apt-get update -qq" failed and exited with 100 during .
```
