### PR TITLE
Fix readonly with isReadOnly

### DIFF
--- a/modules/openapi-generator/src/main/resources/Eiffel/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Eiffel/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/Java/pojo_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo_doc.mustache
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isEnum}}[**{{datatypeWithEnum}}**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#readOnly}} [readonly]{{/readOnly}}
+{{#vars}}**{{name}}** | {{#isEnum}}[**{{datatypeWithEnum}}**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#isReadOnly}} [readonly]{{/isReadOnly}}
 {{/vars}}
 {{#vars}}{{#isEnum}}
 

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/model_doc.mustache
@@ -11,7 +11,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
 {{/vars}}
 {{#vars}}{{#isEnum}}
 

--- a/modules/openapi-generator/src/main/resources/Javascript/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/model_doc.mustache
@@ -11,7 +11,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
 {{/vars}}
 {{#vars}}{{#isEnum}}
 

--- a/modules/openapi-generator/src/main/resources/android/pojo_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/android/pojo_doc.mustache
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isEnum}}[**{{datatypeWithEnum}}**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#readOnly}} [readonly]{{/readOnly}}
+{{#vars}}**{{name}}** | {{#isEnum}}[**{{datatypeWithEnum}}**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#isReadOnly}} [readonly]{{/isReadOnly}}
 {{/vars}}
 {{#vars}}{{#isEnum}}
 

--- a/modules/openapi-generator/src/main/resources/apex/pojo_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/apex/pojo_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isEnum}}[**{{datatypeWithEnum}}**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{datatype}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{datatype}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#readOnly}} [readonly]{{/readOnly}}
+{{#vars}}**{{name}}** | {{#isEnum}}[**{{datatypeWithEnum}}**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{datatype}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{datatype}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#isReadOnly}} [readonly]{{/isReadOnly}}
 {{/vars}}
 {{#vars}}{{#isEnum}}
 

--- a/modules/openapi-generator/src/main/resources/bash/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/bash/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{title}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{title}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/csharp-dotnet2/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-dotnet2/model_doc.mustache
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/model_doc.mustache
@@ -7,10 +7,10 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 {{#parent}}
 {{#parentVars}}
-**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/parentVars}}
 {{/parent}}
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/csharp/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/model_doc.mustache
@@ -9,10 +9,10 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 {{#parent}}
 {{#parentVars}}
-**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/parentVars}}
 {{/parent}}
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models)

--- a/modules/openapi-generator/src/main/resources/dart-jaguar/object_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-jaguar/object_doc.mustache
@@ -8,7 +8,7 @@ import 'package:{{pubName}}/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{datatype}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{datatype}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{datatype}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{datatype}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/dart/object_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/object_doc.mustache
@@ -8,7 +8,7 @@ import 'package:{{pubName}}/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/dart2/object_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/object_doc.mustache
@@ -8,7 +8,7 @@ import 'package:{{pubName}}/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/go-experimental/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model_doc.mustache
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | Pointer to {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | Pointer to {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 {{^isEnum}}

--- a/modules/openapi-generator/src/main/resources/go/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_doc.mustache
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isNullable}}Pointer to {{/isNullable}}{{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isNullable}}Pointer to {{/isNullable}}{{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/graphql-nodejs-express-server/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/graphql-nodejs-express-server/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/graphql-schema/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/graphql-schema/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/haskell-http-client/Model.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-http-client/Model.mustache
@@ -74,7 +74,7 @@ newtype {{classname}} = {{classname}}
   { un{{classname}} :: {{{vendorExtensions.x-dataType}}}
   } deriving (P.Eq, P.Show, P.Typeable, A.ToJSON, A.FromJSON{{#modelDeriving}}, {{modelDeriving}}{{/modelDeriving}}){{/isAlias}}{{^isAlias}}
 data {{classname}} = {{classname}}
-  { {{#vars}}{{name}} :: {{#x-strictFields}}!({{/x-strictFields}}{{^required}}Maybe {{/required}}{{{vendorExtensions.x-dataType}}}{{#x-strictFields}}){{/x-strictFields}} -- ^ {{#required}}/Required/ {{/required}}{{#readOnly}}/ReadOnly/ {{/readOnly}}"{{baseName}}"{{#description}} - {{description}}{{/description}}{{#hasMore}}
+  { {{#vars}}{{name}} :: {{#x-strictFields}}!({{/x-strictFields}}{{^required}}Maybe {{/required}}{{{vendorExtensions.x-dataType}}}{{#x-strictFields}}){{/x-strictFields}} -- ^ {{#required}}/Required/ {{/required}}{{#isReadOnly}}/ReadOnly/ {{/isReadOnly}}"{{baseName}}"{{#description}} - {{description}}{{/description}}{{#hasMore}}
   , {{/hasMore}}{{/vars}}
   } deriving (P.Show, P.Eq, P.Typeable{{#modelDeriving}}, {{modelDeriving}}{{/modelDeriving}}){{/isAlias}}
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/class_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/class_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isEnum}}[**inline**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#readOnly}} [readonly]{{/readOnly}}
+{{#vars}}**{{name}}** | {{#isEnum}}[**inline**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#isReadOnly}} [readonly]{{/isReadOnly}}
 {{/vars}}
 {{#vars}}{{#isEnum}}
 

--- a/modules/openapi-generator/src/main/resources/kotlin-server/class_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/class_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isEnum}}[**inline**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#readOnly}} [readonly]{{/readOnly}}
+{{#vars}}**{{name}}** | {{#isEnum}}[**inline**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#isReadOnly}} [readonly]{{/isReadOnly}}
 {{/vars}}
 {{#vars}}{{#isEnum}}
 

--- a/modules/openapi-generator/src/main/resources/kotlin-vertx-server/class_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-vertx-server/class_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isEnum}}[**inline**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#readOnly}} [readonly]{{/readOnly}}
+{{#vars}}**{{name}}** | {{#isEnum}}[**inline**](#{{datatypeWithEnum}}){{/isEnum}}{{^isEnum}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}}{{/isEnum}} | {{description}} | {{^required}} [optional]{{/required}}{{#isReadOnly}} [readonly]{{/isReadOnly}}
 {{/vars}}
 {{#vars}}{{#isEnum}}
 

--- a/modules/openapi-generator/src/main/resources/lua/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/lua/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{dataType}}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/objc/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/objc/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/perl/object_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/object_doc.mustache
@@ -8,7 +8,7 @@ use {{moduleName}}::Object::{{classname}};
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/php-symfony/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/php/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_doc.mustache
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)

--- a/modules/openapi-generator/src/main/resources/powershell/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/model_doc.mustache
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/model_doc.mustache
@@ -3,9 +3,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#requiredVars}}{{^defaultValue}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{#readOnly}}[readonly] {{/readOnly}}
-{{/defaultValue}}{{/requiredVars}}{{#requiredVars}}{{#defaultValue}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}defaults to {{{.}}}{{/defaultValue}}
-{{/defaultValue}}{{/requiredVars}}{{#optionalVars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | [optional] {{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}} if omitted the server will use the default value of {{{.}}}{{/defaultValue}}
+{{#requiredVars}}{{^defaultValue}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{#isReadOnly}}[readonly] {{/isReadOnly}}
+{{/defaultValue}}{{/requiredVars}}{{#requiredVars}}{{#defaultValue}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}defaults to {{{.}}}{{/defaultValue}}
+{{/defaultValue}}{{/requiredVars}}{{#optionalVars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | [optional] {{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}} if omitted the server will use the default value of {{{.}}}{{/defaultValue}}
 {{/optionalVars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/r/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/r/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
 {{/vars}}
 
 {{/model}}{{/models}}

--- a/modules/openapi-generator/src/main/resources/ruby-client/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/model_doc.mustache
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}
 {{/vars}}
 
 ## Code Sample

--- a/modules/openapi-generator/src/main/resources/rust-server/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{{name}}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{dataType}}}**]({{{complexType}}}.md){{/isPrimitiveType}} | {{{description}}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{{name}}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{dataType}}}**]({{{complexType}}}.md){{/isPrimitiveType}} | {{{description}}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/rust/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model_doc.mustache
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{{name}}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{dataType}}}**]({{{complexType}}}.md){{/isPrimitiveType}} | {{{description}}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{{name}}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{^isContainer}}{{^isDateTime}}*{{/isDateTime}}{{/isContainer}}{{{dataType}}}**]({{{complexType}}}.md){{/isPrimitiveType}} | {{{description}}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/modules/openapi-generator/src/main/resources/swift4/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/swift4/model_doc.mustache
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isContainer}}[**{{dataType}}**]({{complexType}}.md){{/isContainer}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#readOnly}}[readonly] {{/readOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
+{{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{{dataType}}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isContainer}}[**{{dataType}}**]({{complexType}}.md){{/isContainer}}{{#isContainer}}{{{dataType}}}{{/isContainer}}{{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/HasOnlyReadOnly.md
@@ -3,8 +3,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
-**Foo** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
+**Foo** | **string** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/Name.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/Name.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **_Name** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] 
+**SnakeCase** | **int** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**_123Number** | **int** |  | [optional] 
+**_123Number** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/docs/ReadOnlyFirst.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
 **Baz** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/HasOnlyReadOnly.md
@@ -3,8 +3,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
-**Foo** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
+**Foo** | **string** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/Name.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/Name.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **_Name** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] 
+**SnakeCase** | **int** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**_123Number** | **int** |  | [optional] 
+**_123Number** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/docs/ReadOnlyFirst.md
@@ -3,7 +3,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
 **Baz** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/HasOnlyReadOnly.md
@@ -5,8 +5,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
-**Foo** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
+**Foo** | **string** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models)
 [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Name.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Name.md
@@ -6,9 +6,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **_Name** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] 
+**SnakeCase** | **int** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**_123Number** | **int** |  | [optional] 
+**_123Number** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models)
 [[Back to API list]](../README.md#documentation-for-api-endpoints)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/ReadOnlyFirst.md
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
 **Baz** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models)

--- a/samples/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | Pointer to **string** |  | [optional] 
-**Foo** | Pointer to **string** |  | [optional] 
+**Bar** | Pointer to **string** |  | [optional] [readonly] 
+**Foo** | Pointer to **string** |  | [optional] [readonly] 
 
 ## Methods
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/Name.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/Name.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | Pointer to **int32** |  | 
-**SnakeCase** | Pointer to **int32** |  | [optional] 
+**SnakeCase** | Pointer to **int32** |  | [optional] [readonly] 
 **Property** | Pointer to **string** |  | [optional] 
-**Var123Number** | Pointer to **int32** |  | [optional] 
+**Var123Number** | Pointer to **int32** |  | [optional] [readonly] 
 
 ## Methods
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | Pointer to **string** |  | [optional] 
+**Bar** | Pointer to **string** |  | [optional] [readonly] 
 **Baz** | Pointer to **string** |  | [optional] 
 
 ## Methods

--- a/samples/client/petstore/go/go-petstore-withXml/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
-**Foo** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
+**Foo** | **string** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore-withXml/docs/Name.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/Name.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **int32** |  | 
-**SnakeCase** | **int32** |  | [optional] 
+**SnakeCase** | **int32** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**Var123Number** | **int32** |  | [optional] 
+**Var123Number** | **int32** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore-withXml/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/go/go-petstore-withXml/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
 **Baz** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/go/go-petstore/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/go/go-petstore/docs/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
-**Foo** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
+**Foo** | **string** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore/docs/Name.md
+++ b/samples/client/petstore/go/go-petstore/docs/Name.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **int32** |  | 
-**SnakeCase** | **int32** |  | [optional] 
+**SnakeCase** | **int32** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**Var123Number** | **int32** |  | [optional] 
+**Var123Number** | **int32** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/go/go-petstore/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/go/go-petstore/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
 **Baz** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Model.hs
+++ b/samples/client/petstore/haskell-http-client/lib/OpenAPIPetstore/Model.hs
@@ -1146,8 +1146,8 @@ mkFormatTest formatTestNumber formatTestByte formatTestDate formatTestPassword =
 -- ** HasOnlyReadOnly
 -- | HasOnlyReadOnly
 data HasOnlyReadOnly = HasOnlyReadOnly
-  { hasOnlyReadOnlyBar :: !(Maybe Text) -- ^ "bar"
-  , hasOnlyReadOnlyFoo :: !(Maybe Text) -- ^ "foo"
+  { hasOnlyReadOnlyBar :: !(Maybe Text) -- ^ /ReadOnly/ "bar"
+  , hasOnlyReadOnlyFoo :: !(Maybe Text) -- ^ /ReadOnly/ "foo"
   } deriving (P.Show, P.Eq, P.Typeable)
 
 -- | FromJSON HasOnlyReadOnly
@@ -1346,9 +1346,9 @@ mkModelReturn =
 -- Model for testing model name same as property name
 data Name = Name
   { nameName :: !(Int) -- ^ /Required/ "name"
-  , nameSnakeCase :: !(Maybe Int) -- ^ "snake_case"
+  , nameSnakeCase :: !(Maybe Int) -- ^ /ReadOnly/ "snake_case"
   , nameProperty :: !(Maybe Text) -- ^ "property"
-  , name123number :: !(Maybe Int) -- ^ "123Number"
+  , name123number :: !(Maybe Int) -- ^ /ReadOnly/ "123Number"
   } deriving (P.Show, P.Eq, P.Typeable)
 
 -- | FromJSON Name
@@ -1548,7 +1548,7 @@ mkPet petName petPhotoUrls =
 -- ** ReadOnlyFirst
 -- | ReadOnlyFirst
 data ReadOnlyFirst = ReadOnlyFirst
-  { readOnlyFirstBar :: !(Maybe Text) -- ^ "bar"
+  { readOnlyFirstBar :: !(Maybe Text) -- ^ /ReadOnly/ "bar"
   , readOnlyFirstBaz :: !(Maybe Text) -- ^ "baz"
   } deriving (P.Show, P.Eq, P.Typeable)
 

--- a/samples/client/petstore/java/google-api-client/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/google-api-client/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/google-api-client/docs/Name.md
+++ b/samples/client/petstore/java/google-api-client/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/google-api-client/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/google-api-client/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/jersey1/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/jersey1/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/jersey1/docs/Name.md
+++ b/samples/client/petstore/java/jersey1/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/jersey1/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/jersey1/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/jersey2-java6/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/jersey2-java6/docs/Name.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/jersey2-java6/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/jersey2-java6/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/jersey2-java8/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/jersey2-java8/docs/Name.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/jersey2-java8/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/jersey2-java8/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/jersey2/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/jersey2/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/jersey2/docs/Name.md
+++ b/samples/client/petstore/java/jersey2/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/jersey2/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/jersey2/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/native/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/native/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/native/docs/Name.md
+++ b/samples/client/petstore/java/native/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/native/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/native/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/Name.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/okhttp-gson/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/okhttp-gson/docs/Name.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/okhttp-gson/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/okhttp-gson/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/rest-assured/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/rest-assured/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/rest-assured/docs/Name.md
+++ b/samples/client/petstore/java/rest-assured/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/rest-assured/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/rest-assured/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/resteasy/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/resteasy/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/resteasy/docs/Name.md
+++ b/samples/client/petstore/java/resteasy/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/resteasy/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/resteasy/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/Name.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/resttemplate/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/resttemplate/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/resttemplate/docs/Name.md
+++ b/samples/client/petstore/java/resttemplate/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/resttemplate/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/resttemplate/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/Name.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2-play24/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/retrofit2-play24/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/retrofit2-play25/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2-play25/docs/Name.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2-play25/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/retrofit2-play25/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/retrofit2-play26/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2-play26/docs/Name.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2-play26/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/retrofit2-play26/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/retrofit2/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/retrofit2/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2/docs/Name.md
+++ b/samples/client/petstore/java/retrofit2/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/retrofit2/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/retrofit2rx/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2rx/docs/Name.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2rx/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/retrofit2rx/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/Name.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/retrofit2rx2/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/retrofit2rx2/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/vertx/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/vertx/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/vertx/docs/Name.md
+++ b/samples/client/petstore/java/vertx/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/vertx/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/vertx/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/java/webclient/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/java/webclient/docs/HasOnlyReadOnly.md
@@ -6,8 +6,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
-**foo** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
+**foo** | **String** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/webclient/docs/Name.md
+++ b/samples/client/petstore/java/webclient/docs/Name.md
@@ -7,9 +7,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snakeCase** | **Integer** |  |  [optional]
+**snakeCase** | **Integer** |  |  [optional] [readonly]
 **property** | **String** |  |  [optional]
-**_123number** | **Integer** |  |  [optional]
+**_123number** | **Integer** |  |  [optional] [readonly]
 
 
 

--- a/samples/client/petstore/java/webclient/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/java/webclient/docs/ReadOnlyFirst.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  |  [optional]
+**bar** | **String** |  |  [optional] [readonly]
 **baz** | **String** |  |  [optional]
 
 

--- a/samples/client/petstore/javascript-es6/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/javascript-es6/docs/HasOnlyReadOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
-**foo** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
+**foo** | **String** |  | [optional] [readonly] 
 
 

--- a/samples/client/petstore/javascript-es6/docs/Name.md
+++ b/samples/client/petstore/javascript-es6/docs/Name.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Number** |  | 
-**snakeCase** | **Number** |  | [optional] 
+**snakeCase** | **Number** |  | [optional] [readonly] 
 **property** | **String** |  | [optional] 
-**_123number** | **Number** |  | [optional] 
+**_123number** | **Number** |  | [optional] [readonly] 
 
 

--- a/samples/client/petstore/javascript-es6/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/javascript-es6/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
 **baz** | **String** |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-promise-es6/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/HasOnlyReadOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
-**foo** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
+**foo** | **String** |  | [optional] [readonly] 
 
 

--- a/samples/client/petstore/javascript-promise-es6/docs/Name.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/Name.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Number** |  | 
-**snakeCase** | **Number** |  | [optional] 
+**snakeCase** | **Number** |  | [optional] [readonly] 
 **property** | **String** |  | [optional] 
-**_123number** | **Number** |  | [optional] 
+**_123number** | **Number** |  | [optional] [readonly] 
 
 

--- a/samples/client/petstore/javascript-promise-es6/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/javascript-promise-es6/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
 **baz** | **String** |  | [optional] 
 
 

--- a/samples/client/petstore/javascript-promise/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/javascript-promise/docs/HasOnlyReadOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
-**foo** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
+**foo** | **String** |  | [optional] [readonly] 
 
 

--- a/samples/client/petstore/javascript-promise/docs/Name.md
+++ b/samples/client/petstore/javascript-promise/docs/Name.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Number** |  | 
-**snakeCase** | **Number** |  | [optional] 
+**snakeCase** | **Number** |  | [optional] [readonly] 
 **property** | **String** |  | [optional] 
-**_123number** | **Number** |  | [optional] 
+**_123number** | **Number** |  | [optional] [readonly] 
 
 

--- a/samples/client/petstore/javascript-promise/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/javascript-promise/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
 **baz** | **String** |  | [optional] 
 
 

--- a/samples/client/petstore/javascript/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/javascript/docs/HasOnlyReadOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
-**foo** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
+**foo** | **String** |  | [optional] [readonly] 
 
 

--- a/samples/client/petstore/javascript/docs/Name.md
+++ b/samples/client/petstore/javascript/docs/Name.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Number** |  | 
-**snakeCase** | **Number** |  | [optional] 
+**snakeCase** | **Number** |  | [optional] [readonly] 
 **property** | **String** |  | [optional] 
-**_123number** | **Number** |  | [optional] 
+**_123number** | **Number** |  | [optional] [readonly] 
 
 

--- a/samples/client/petstore/javascript/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/javascript/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
 **baz** | **String** |  | [optional] 
 
 

--- a/samples/client/petstore/perl/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/perl/docs/HasOnlyReadOnly.md
@@ -8,8 +8,8 @@ use WWW::OpenAPIClient::Object::HasOnlyReadOnly;
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **string** |  | [optional] 
-**foo** | **string** |  | [optional] 
+**bar** | **string** |  | [optional] [readonly] 
+**foo** | **string** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/perl/docs/Name.md
+++ b/samples/client/petstore/perl/docs/Name.md
@@ -9,9 +9,9 @@ use WWW::OpenAPIClient::Object::Name;
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **int** |  | 
-**snake_case** | **int** |  | [optional] 
+**snake_case** | **int** |  | [optional] [readonly] 
 **property** | **string** |  | [optional] 
-**_123_number** | **int** |  | [optional] 
+**_123_number** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/perl/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/perl/docs/ReadOnlyFirst.md
@@ -8,7 +8,7 @@ use WWW::OpenAPIClient::Object::ReadOnlyFirst;
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **string** |  | [optional] 
+**bar** | **string** |  | [optional] [readonly] 
 **baz** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/HasOnlyReadOnly.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **string** |  | [optional] 
-**foo** | **string** |  | [optional] 
+**bar** | **string** |  | [optional] [readonly] 
+**foo** | **string** |  | [optional] [readonly] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/Name.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/Name.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **int** |  | 
-**snake_case** | **int** |  | [optional] 
+**snake_case** | **int** |  | [optional] [readonly] 
 **property** | **string** |  | [optional] 
-**_123_number** | **int** |  | [optional] 
+**_123_number** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/php/OpenAPIClient-php/docs/Model/ReadOnlyFirst.md
+++ b/samples/client/petstore/php/OpenAPIClient-php/docs/Model/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **string** |  | [optional] 
+**bar** | **string** |  | [optional] [readonly] 
 **baz** | **string** |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)

--- a/samples/client/petstore/python-asyncio/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/python-asyncio/docs/HasOnlyReadOnly.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **str** |  | [optional] 
-**foo** | **str** |  | [optional] 
+**bar** | **str** |  | [optional] [readonly] 
+**foo** | **str** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-asyncio/docs/Name.md
+++ b/samples/client/petstore/python-asyncio/docs/Name.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **int** |  | 
-**snake_case** | **int** |  | [optional] 
+**snake_case** | **int** |  | [optional] [readonly] 
 **_property** | **str** |  | [optional] 
-**_123_number** | **int** |  | [optional] 
+**_123_number** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-asyncio/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/python-asyncio/docs/ReadOnlyFirst.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **str** |  | [optional] 
+**bar** | **str** |  | [optional] [readonly] 
 **baz** | **str** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/python-tornado/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/python-tornado/docs/HasOnlyReadOnly.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **str** |  | [optional] 
-**foo** | **str** |  | [optional] 
+**bar** | **str** |  | [optional] [readonly] 
+**foo** | **str** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-tornado/docs/Name.md
+++ b/samples/client/petstore/python-tornado/docs/Name.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **int** |  | 
-**snake_case** | **int** |  | [optional] 
+**snake_case** | **int** |  | [optional] [readonly] 
 **_property** | **str** |  | [optional] 
-**_123_number** | **int** |  | [optional] 
+**_123_number** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python-tornado/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/python-tornado/docs/ReadOnlyFirst.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **str** |  | [optional] 
+**bar** | **str** |  | [optional] [readonly] 
 **baz** | **str** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/python/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/python/docs/HasOnlyReadOnly.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **str** |  | [optional] 
-**foo** | **str** |  | [optional] 
+**bar** | **str** |  | [optional] [readonly] 
+**foo** | **str** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/docs/Name.md
+++ b/samples/client/petstore/python/docs/Name.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **int** |  | 
-**snake_case** | **int** |  | [optional] 
+**snake_case** | **int** |  | [optional] [readonly] 
 **_property** | **str** |  | [optional] 
-**_123_number** | **int** |  | [optional] 
+**_123_number** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/python/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/python/docs/ReadOnlyFirst.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **str** |  | [optional] 
+**bar** | **str** |  | [optional] [readonly] 
 **baz** | **str** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/ruby/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/ruby/docs/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
-**foo** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
+**foo** | **String** |  | [optional] [readonly] 
 
 ## Code Sample
 

--- a/samples/client/petstore/ruby/docs/Name.md
+++ b/samples/client/petstore/ruby/docs/Name.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snake_case** | **Integer** |  | [optional] 
+**snake_case** | **Integer** |  | [optional] [readonly] 
 **property** | **String** |  | [optional] 
-**_123_number** | **Integer** |  | [optional] 
+**_123_number** | **Integer** |  | [optional] [readonly] 
 
 ## Code Sample
 

--- a/samples/client/petstore/ruby/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/ruby/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
 **baz** | **String** |  | [optional] 
 
 ## Code Sample

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/HasOnlyReadOnly.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
-**Foo** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
+**Foo** | **string** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/Name.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/Name.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **int32** |  | 
-**SnakeCase** | **int32** |  | [optional] 
+**SnakeCase** | **int32** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**Var123Number** | **int32** |  | [optional] 
+**Var123Number** | **int32** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/ReadOnlyFirst.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] 
+**Bar** | **string** |  | [optional] [readonly] 
 **Baz** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Model/HasOnlyReadOnly.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Model/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **string** |  | [optional] 
-**foo** | **string** |  | [optional] 
+**bar** | **string** |  | [optional] [readonly] 
+**foo** | **string** |  | [optional] [readonly] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Model/Name.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Model/Name.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **int** |  | 
-**snake_case** | **int** |  | [optional] 
+**snake_case** | **int** |  | [optional] [readonly] 
 **property** | **string** |  | [optional] 
-**_123_number** | **int** |  | [optional] 
+**_123_number** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
 

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Model/ReadOnlyFirst.md
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/docs/Model/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **string** |  | [optional] 
+**bar** | **string** |  | [optional] [readonly] 
 **baz** | **string** |  | [optional] 
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)

--- a/samples/openapi3/client/petstore/python/docs/HasOnlyReadOnly.md
+++ b/samples/openapi3/client/petstore/python/docs/HasOnlyReadOnly.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **str** |  | [optional] 
-**foo** | **str** |  | [optional] 
+**bar** | **str** |  | [optional] [readonly] 
+**foo** | **str** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/Name.md
+++ b/samples/openapi3/client/petstore/python/docs/Name.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **int** |  | 
-**snake_case** | **int** |  | [optional] 
+**snake_case** | **int** |  | [optional] [readonly] 
 **_property** | **str** |  | [optional] 
-**_123_number** | **int** |  | [optional] 
+**_123_number** | **int** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/python/docs/ReadOnlyFirst.md
+++ b/samples/openapi3/client/petstore/python/docs/ReadOnlyFirst.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **str** |  | [optional] 
+**bar** | **str** |  | [optional] [readonly] 
 **baz** | **str** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/ruby-faraday/docs/HasOnlyReadOnly.md
+++ b/samples/openapi3/client/petstore/ruby-faraday/docs/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
-**foo** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
+**foo** | **String** |  | [optional] [readonly] 
 
 ## Code Sample
 

--- a/samples/openapi3/client/petstore/ruby-faraday/docs/Name.md
+++ b/samples/openapi3/client/petstore/ruby-faraday/docs/Name.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snake_case** | **Integer** |  | [optional] 
+**snake_case** | **Integer** |  | [optional] [readonly] 
 **property** | **String** |  | [optional] 
-**_123_number** | **Integer** |  | [optional] 
+**_123_number** | **Integer** |  | [optional] [readonly] 
 
 ## Code Sample
 

--- a/samples/openapi3/client/petstore/ruby-faraday/docs/ReadOnlyFirst.md
+++ b/samples/openapi3/client/petstore/ruby-faraday/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
 **baz** | **String** |  | [optional] 
 
 ## Code Sample

--- a/samples/openapi3/client/petstore/ruby/docs/HasOnlyReadOnly.md
+++ b/samples/openapi3/client/petstore/ruby/docs/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
-**foo** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
+**foo** | **String** |  | [optional] [readonly] 
 
 ## Code Sample
 

--- a/samples/openapi3/client/petstore/ruby/docs/Name.md
+++ b/samples/openapi3/client/petstore/ruby/docs/Name.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **Integer** |  | 
-**snake_case** | **Integer** |  | [optional] 
+**snake_case** | **Integer** |  | [optional] [readonly] 
 **property** | **String** |  | [optional] 
-**_123_number** | **Integer** |  | [optional] 
+**_123_number** | **Integer** |  | [optional] [readonly] 
 
 ## Code Sample
 

--- a/samples/openapi3/client/petstore/ruby/docs/ReadOnlyFirst.md
+++ b/samples/openapi3/client/petstore/ruby/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] 
+**bar** | **String** |  | [optional] [readonly] 
 **baz** | **String** |  | [optional] 
 
 ## Code Sample

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/HasOnlyReadOnly.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/HasOnlyReadOnly.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [default to None]
-**foo** | **String** |  | [optional] [default to None]
+**bar** | **String** |  | [optional] [readonly] [default to None]
+**foo** | **String** |  | [optional] [readonly] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/Name.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/Name.md
@@ -4,9 +4,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **i32** |  | 
-**snake_case** | **i32** |  | [optional] [default to None]
+**snake_case** | **i32** |  | [optional] [readonly] [default to None]
 **property** | **String** |  | [optional] [default to None]
-**_123_number** | **isize** |  | [optional] [default to None]
+**_123_number** | **isize** |  | [optional] [readonly] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/ReadOnlyFirst.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/ReadOnlyFirst.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**bar** | **String** |  | [optional] [default to None]
+**bar** | **String** |  | [optional] [readonly] [default to None]
 **baz** | **String** |  | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

- Fix readonly with isReadOnly

cc @OpenAPITools/generator-core-team 