### PR TITLE
typescript-fetch: fix empty URLSearchParams request body

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -49,7 +49,7 @@ export class BaseAPI {
             // do not handle correctly sometimes.
             url += '?' + this.configuration.queryParamsStringify(context.query);
         }
-        const body = (context.body instanceof FormData || isBlob(context.body))
+        const body = (context.body instanceof FormData || context.body instanceof URLSearchParams || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
 

--- a/samples/client/petstore/typescript-fetch/builds/default/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/src/runtime.ts
@@ -60,7 +60,7 @@ export class BaseAPI {
             // do not handle correctly sometimes.
             url += '?' + this.configuration.queryParamsStringify(context.query);
         }
-        const body = (context.body instanceof FormData || isBlob(context.body))
+        const body = (context.body instanceof FormData || context.body instanceof URLSearchParams || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -60,7 +60,7 @@ export class BaseAPI {
             // do not handle correctly sometimes.
             url += '?' + this.configuration.queryParamsStringify(context.query);
         }
-        const body = (context.body instanceof FormData || isBlob(context.body))
+        const body = (context.body instanceof FormData || context.body instanceof URLSearchParams || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/runtime.ts
@@ -60,7 +60,7 @@ export class BaseAPI {
             // do not handle correctly sometimes.
             url += '?' + this.configuration.queryParamsStringify(context.query);
         }
-        const body = (context.body instanceof FormData || isBlob(context.body))
+        const body = (context.body instanceof FormData || context.body instanceof URLSearchParams || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -60,7 +60,7 @@ export class BaseAPI {
             // do not handle correctly sometimes.
             url += '?' + this.configuration.queryParamsStringify(context.query);
         }
-        const body = (context.body instanceof FormData || isBlob(context.body))
+        const body = (context.body instanceof FormData || context.body instanceof URLSearchParams || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
 

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/runtime.ts
@@ -60,7 +60,7 @@ export class BaseAPI {
             // do not handle correctly sometimes.
             url += '?' + this.configuration.queryParamsStringify(context.query);
         }
-        const body = (context.body instanceof FormData || isBlob(context.body))
+        const body = (context.body instanceof FormData || context.body instanceof URLSearchParams || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/runtime.ts
@@ -60,7 +60,7 @@ export class BaseAPI {
             // do not handle correctly sometimes.
             url += '?' + this.configuration.queryParamsStringify(context.query);
         }
-        const body = (context.body instanceof FormData || isBlob(context.body))
+        const body = (context.body instanceof FormData || context.body instanceof URLSearchParams || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -60,7 +60,7 @@ export class BaseAPI {
             // do not handle correctly sometimes.
             url += '?' + this.configuration.queryParamsStringify(context.query);
         }
-        const body = (context.body instanceof FormData || isBlob(context.body))
+        const body = (context.body instanceof FormData || context.body instanceof URLSearchParams || isBlob(context.body))
 	    ? context.body
 	    : JSON.stringify(context.body);
 

--- a/samples/client/petstore/typescript-fetch/tests/default/mocks.ts
+++ b/samples/client/petstore/typescript-fetch/tests/default/mocks.ts
@@ -1,5 +1,7 @@
 import * as FormData from 'form-data';
+import { URLSearchParams } from 'url';
 
 const globals = global as any;
 
 globals.FormData = FormData;
+globals.URLSearchParams = URLSearchParams;


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

This pull-request is correction patch for https://github.com/OpenAPITools/openapi-generator/pull/3934 . (related to https://github.com/OpenAPITools/openapi-generator/issues/3920 )
URLSearchParams body is converted empty JSON Object by `JSON.stringify` since missing check.

### Technical Committee
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07)