### PR TITLE
Add newline between function signature of operation and summary of operation

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/api_doc.mustache
@@ -15,6 +15,7 @@ Method | HTTP request | Description
 ## {{{operationId}}}
 
 > {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationId}}}(ctx, {{#allParams}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}optional{{/hasOptionalParams}})
+
 {{{summary}}}{{#notes}}
 
 {{{notes}}}{{/notes}}

--- a/modules/openapi-generator/src/main/resources/go/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api_doc.mustache
@@ -15,6 +15,7 @@ Method | HTTP request | Description
 ## {{{operationId}}}
 
 > {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationId}}}(ctx, {{#allParams}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}optional{{/hasOptionalParams}})
+
 {{{summary}}}{{#notes}}
 
 {{{notes}}}{{/notes}}

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AnotherFakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 ## Call123TestSpecialTags
 
 > Client Call123TestSpecialTags(ctx, body)
+
 To test special tags
 
 To test special tags and operation ID starting with number

--- a/samples/client/petstore/go-experimental/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/FakeApi.md
@@ -24,6 +24,7 @@ Method | HTTP request | Description
 ## CreateXmlItem
 
 > CreateXmlItem(ctx, xmlItem)
+
 creates an XmlItem
 
 this route creates an XmlItem
@@ -57,6 +58,7 @@ No authorization required
 ## FakeOuterBooleanSerialize
 
 > bool FakeOuterBooleanSerialize(ctx, optional)
+
 
 
 Test serialization of outer boolean types
@@ -101,6 +103,7 @@ No authorization required
 > OuterComposite FakeOuterCompositeSerialize(ctx, optional)
 
 
+
 Test serialization of object with outer number type
 
 ### Required Parameters
@@ -141,6 +144,7 @@ No authorization required
 ## FakeOuterNumberSerialize
 
 > float32 FakeOuterNumberSerialize(ctx, optional)
+
 
 
 Test serialization of outer number types
@@ -185,6 +189,7 @@ No authorization required
 > string FakeOuterStringSerialize(ctx, optional)
 
 
+
 Test serialization of outer string types
 
 ### Required Parameters
@@ -227,6 +232,7 @@ No authorization required
 > TestBodyWithFileSchema(ctx, body)
 
 
+
 For this test, the body for this request much reference a schema named `File`.
 
 ### Required Parameters
@@ -260,6 +266,7 @@ No authorization required
 > TestBodyWithQueryParams(ctx, query, body)
 
 
+
 ### Required Parameters
 
 
@@ -290,6 +297,7 @@ No authorization required
 ## TestClientModel
 
 > Client TestClientModel(ctx, body)
+
 To test \"client\" model
 
 To test \"client\" model
@@ -323,6 +331,7 @@ No authorization required
 ## TestEndpointParameters
 
 > TestEndpointParameters(ctx, number, double, patternWithoutDelimiter, byte_, optional)
+
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -382,6 +391,7 @@ Name | Type | Description  | Notes
 ## TestEnumParameters
 
 > TestEnumParameters(ctx, optional)
+
 To test enum parameters
 
 To test enum parameters
@@ -431,6 +441,7 @@ No authorization required
 ## TestGroupParameters
 
 > TestGroupParameters(ctx, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, optional)
+
 Fake endpoint to test group parameters (optional)
 
 Fake endpoint to test group parameters (optional)
@@ -481,6 +492,7 @@ No authorization required
 ## TestInlineAdditionalProperties
 
 > TestInlineAdditionalProperties(ctx, param)
+
 test inline additionalProperties
 
 ### Required Parameters
@@ -512,6 +524,7 @@ No authorization required
 ## TestJsonFormData
 
 > TestJsonFormData(ctx, param, param2)
+
 test json serialization of form data
 
 ### Required Parameters
@@ -544,6 +557,7 @@ No authorization required
 ## TestQueryParameterCollectionFormat
 
 > TestQueryParameterCollectionFormat(ctx, pipe, ioutil, http, url, context)
+
 
 
 To test the collection format in query parameters

--- a/samples/client/petstore/go-experimental/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/FakeClassnameTags123Api.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 ## TestClassname
 
 > Client TestClassname(ctx, body)
+
 To test class name in snake case
 
 To test class name in snake case

--- a/samples/client/petstore/go-experimental/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/PetApi.md
@@ -19,6 +19,7 @@ Method | HTTP request | Description
 ## AddPet
 
 > AddPet(ctx, body)
+
 Add a new pet to the store
 
 ### Required Parameters
@@ -50,6 +51,7 @@ Name | Type | Description  | Notes
 ## DeletePet
 
 > DeletePet(ctx, petId, optional)
+
 Deletes a pet
 
 ### Required Parameters
@@ -92,6 +94,7 @@ Name | Type | Description  | Notes
 ## FindPetsByStatus
 
 > []Pet FindPetsByStatus(ctx, status)
+
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
@@ -125,6 +128,7 @@ Name | Type | Description  | Notes
 ## FindPetsByTags
 
 > []Pet FindPetsByTags(ctx, tags)
+
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -158,6 +162,7 @@ Name | Type | Description  | Notes
 ## GetPetById
 
 > Pet GetPetById(ctx, petId)
+
 Find pet by ID
 
 Returns a single pet
@@ -191,6 +196,7 @@ Name | Type | Description  | Notes
 ## UpdatePet
 
 > UpdatePet(ctx, body)
+
 Update an existing pet
 
 ### Required Parameters
@@ -222,6 +228,7 @@ Name | Type | Description  | Notes
 ## UpdatePetWithForm
 
 > UpdatePetWithForm(ctx, petId, optional)
+
 Updates a pet in the store with form data
 
 ### Required Parameters
@@ -265,6 +272,7 @@ Name | Type | Description  | Notes
 ## UploadFile
 
 > ApiResponse UploadFile(ctx, petId, optional)
+
 uploads an image
 
 ### Required Parameters
@@ -308,6 +316,7 @@ Name | Type | Description  | Notes
 ## UploadFileWithRequiredFile
 
 > ApiResponse UploadFileWithRequiredFile(ctx, petId, requiredFile, optional)
+
 uploads an image (required)
 
 ### Required Parameters

--- a/samples/client/petstore/go-experimental/go-petstore/docs/StoreApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/StoreApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 ## DeleteOrder
 
 > DeleteOrder(ctx, orderId)
+
 Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -47,6 +48,7 @@ No authorization required
 ## GetInventory
 
 > map[string]int32 GetInventory(ctx, )
+
 Returns pet inventories by status
 
 Returns a map of status codes to quantities
@@ -76,6 +78,7 @@ This endpoint does not need any parameter.
 ## GetOrderById
 
 > Order GetOrderById(ctx, orderId)
+
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -109,6 +112,7 @@ No authorization required
 ## PlaceOrder
 
 > Order PlaceOrder(ctx, body)
+
 Place an order for a pet
 
 ### Required Parameters

--- a/samples/client/petstore/go-experimental/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/UserApi.md
@@ -18,6 +18,7 @@ Method | HTTP request | Description
 ## CreateUser
 
 > CreateUser(ctx, body)
+
 Create user
 
 This can only be done by the logged in user.
@@ -51,6 +52,7 @@ No authorization required
 ## CreateUsersWithArrayInput
 
 > CreateUsersWithArrayInput(ctx, body)
+
 Creates list of users with given input array
 
 ### Required Parameters
@@ -82,6 +84,7 @@ No authorization required
 ## CreateUsersWithListInput
 
 > CreateUsersWithListInput(ctx, body)
+
 Creates list of users with given input array
 
 ### Required Parameters
@@ -113,6 +116,7 @@ No authorization required
 ## DeleteUser
 
 > DeleteUser(ctx, username)
+
 Delete user
 
 This can only be done by the logged in user.
@@ -146,6 +150,7 @@ No authorization required
 ## GetUserByName
 
 > User GetUserByName(ctx, username)
+
 Get user by user name
 
 ### Required Parameters
@@ -177,6 +182,7 @@ No authorization required
 ## LoginUser
 
 > string LoginUser(ctx, username, password)
+
 Logs user into the system
 
 ### Required Parameters
@@ -209,6 +215,7 @@ No authorization required
 ## LogoutUser
 
 > LogoutUser(ctx, )
+
 Logs out current logged in user session
 
 ### Required Parameters
@@ -236,6 +243,7 @@ No authorization required
 ## UpdateUser
 
 > UpdateUser(ctx, username, body)
+
 Updated user
 
 This can only be done by the logged in user.

--- a/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 ## Call123TestSpecialTags
 
 > Client Call123TestSpecialTags(ctx, body)
+
 To test special tags
 
 To test special tags and operation ID starting with number

--- a/samples/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -24,6 +24,7 @@ Method | HTTP request | Description
 ## CreateXmlItem
 
 > CreateXmlItem(ctx, xmlItem)
+
 creates an XmlItem
 
 this route creates an XmlItem
@@ -57,6 +58,7 @@ No authorization required
 ## FakeOuterBooleanSerialize
 
 > bool FakeOuterBooleanSerialize(ctx, optional)
+
 
 
 Test serialization of outer boolean types
@@ -101,6 +103,7 @@ No authorization required
 > OuterComposite FakeOuterCompositeSerialize(ctx, optional)
 
 
+
 Test serialization of object with outer number type
 
 ### Required Parameters
@@ -141,6 +144,7 @@ No authorization required
 ## FakeOuterNumberSerialize
 
 > float32 FakeOuterNumberSerialize(ctx, optional)
+
 
 
 Test serialization of outer number types
@@ -185,6 +189,7 @@ No authorization required
 > string FakeOuterStringSerialize(ctx, optional)
 
 
+
 Test serialization of outer string types
 
 ### Required Parameters
@@ -227,6 +232,7 @@ No authorization required
 > TestBodyWithFileSchema(ctx, body)
 
 
+
 For this test, the body for this request much reference a schema named `File`.
 
 ### Required Parameters
@@ -260,6 +266,7 @@ No authorization required
 > TestBodyWithQueryParams(ctx, query, body)
 
 
+
 ### Required Parameters
 
 
@@ -290,6 +297,7 @@ No authorization required
 ## TestClientModel
 
 > Client TestClientModel(ctx, body)
+
 To test \"client\" model
 
 To test \"client\" model
@@ -323,6 +331,7 @@ No authorization required
 ## TestEndpointParameters
 
 > TestEndpointParameters(ctx, number, double, patternWithoutDelimiter, byte_, optional)
+
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -382,6 +391,7 @@ Name | Type | Description  | Notes
 ## TestEnumParameters
 
 > TestEnumParameters(ctx, optional)
+
 To test enum parameters
 
 To test enum parameters
@@ -431,6 +441,7 @@ No authorization required
 ## TestGroupParameters
 
 > TestGroupParameters(ctx, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, optional)
+
 Fake endpoint to test group parameters (optional)
 
 Fake endpoint to test group parameters (optional)
@@ -481,6 +492,7 @@ No authorization required
 ## TestInlineAdditionalProperties
 
 > TestInlineAdditionalProperties(ctx, param)
+
 test inline additionalProperties
 
 ### Required Parameters
@@ -512,6 +524,7 @@ No authorization required
 ## TestJsonFormData
 
 > TestJsonFormData(ctx, param, param2)
+
 test json serialization of form data
 
 ### Required Parameters
@@ -544,6 +557,7 @@ No authorization required
 ## TestQueryParameterCollectionFormat
 
 > TestQueryParameterCollectionFormat(ctx, pipe, ioutil, http, url, context)
+
 
 
 To test the collection format in query parameters

--- a/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 ## TestClassname
 
 > Client TestClassname(ctx, body)
+
 To test class name in snake case
 
 To test class name in snake case

--- a/samples/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/PetApi.md
@@ -19,6 +19,7 @@ Method | HTTP request | Description
 ## AddPet
 
 > AddPet(ctx, body)
+
 Add a new pet to the store
 
 ### Required Parameters
@@ -50,6 +51,7 @@ Name | Type | Description  | Notes
 ## DeletePet
 
 > DeletePet(ctx, petId, optional)
+
 Deletes a pet
 
 ### Required Parameters
@@ -92,6 +94,7 @@ Name | Type | Description  | Notes
 ## FindPetsByStatus
 
 > []Pet FindPetsByStatus(ctx, status)
+
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
@@ -125,6 +128,7 @@ Name | Type | Description  | Notes
 ## FindPetsByTags
 
 > []Pet FindPetsByTags(ctx, tags)
+
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -158,6 +162,7 @@ Name | Type | Description  | Notes
 ## GetPetById
 
 > Pet GetPetById(ctx, petId)
+
 Find pet by ID
 
 Returns a single pet
@@ -191,6 +196,7 @@ Name | Type | Description  | Notes
 ## UpdatePet
 
 > UpdatePet(ctx, body)
+
 Update an existing pet
 
 ### Required Parameters
@@ -222,6 +228,7 @@ Name | Type | Description  | Notes
 ## UpdatePetWithForm
 
 > UpdatePetWithForm(ctx, petId, optional)
+
 Updates a pet in the store with form data
 
 ### Required Parameters
@@ -265,6 +272,7 @@ Name | Type | Description  | Notes
 ## UploadFile
 
 > ApiResponse UploadFile(ctx, petId, optional)
+
 uploads an image
 
 ### Required Parameters
@@ -308,6 +316,7 @@ Name | Type | Description  | Notes
 ## UploadFileWithRequiredFile
 
 > ApiResponse UploadFileWithRequiredFile(ctx, petId, requiredFile, optional)
+
 uploads an image (required)
 
 ### Required Parameters

--- a/samples/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 ## DeleteOrder
 
 > DeleteOrder(ctx, orderId)
+
 Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -47,6 +48,7 @@ No authorization required
 ## GetInventory
 
 > map[string]int32 GetInventory(ctx, )
+
 Returns pet inventories by status
 
 Returns a map of status codes to quantities
@@ -76,6 +78,7 @@ This endpoint does not need any parameter.
 ## GetOrderById
 
 > Order GetOrderById(ctx, orderId)
+
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -109,6 +112,7 @@ No authorization required
 ## PlaceOrder
 
 > Order PlaceOrder(ctx, body)
+
 Place an order for a pet
 
 ### Required Parameters

--- a/samples/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go/go-petstore/docs/UserApi.md
@@ -18,6 +18,7 @@ Method | HTTP request | Description
 ## CreateUser
 
 > CreateUser(ctx, body)
+
 Create user
 
 This can only be done by the logged in user.
@@ -51,6 +52,7 @@ No authorization required
 ## CreateUsersWithArrayInput
 
 > CreateUsersWithArrayInput(ctx, body)
+
 Creates list of users with given input array
 
 ### Required Parameters
@@ -82,6 +84,7 @@ No authorization required
 ## CreateUsersWithListInput
 
 > CreateUsersWithListInput(ctx, body)
+
 Creates list of users with given input array
 
 ### Required Parameters
@@ -113,6 +116,7 @@ No authorization required
 ## DeleteUser
 
 > DeleteUser(ctx, username)
+
 Delete user
 
 This can only be done by the logged in user.
@@ -146,6 +150,7 @@ No authorization required
 ## GetUserByName
 
 > User GetUserByName(ctx, username)
+
 Get user by user name
 
 ### Required Parameters
@@ -177,6 +182,7 @@ No authorization required
 ## LoginUser
 
 > string LoginUser(ctx, username, password)
+
 Logs user into the system
 
 ### Required Parameters
@@ -209,6 +215,7 @@ No authorization required
 ## LogoutUser
 
 > LogoutUser(ctx, )
+
 Logs out current logged in user session
 
 ### Required Parameters
@@ -236,6 +243,7 @@ No authorization required
 ## UpdateUser
 
 > UpdateUser(ctx, username, body)
+
 Updated user
 
 This can only be done by the logged in user.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/AnotherFakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 ## Call123TestSpecialTags
 
 > Client Call123TestSpecialTags(ctx, client)
+
 To test special tags
 
 To test special tags and operation ID starting with number

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/DefaultApi.md
@@ -13,6 +13,7 @@ Method | HTTP request | Description
 > InlineResponseDefault FooGet(ctx, )
 
 
+
 ### Required Parameters
 
 This endpoint does not need any parameter.

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FakeApi.md
@@ -24,6 +24,7 @@ Method | HTTP request | Description
 ## FakeHealthGet
 
 > HealthCheckResult FakeHealthGet(ctx, )
+
 Health check endpoint
 
 ### Required Parameters
@@ -51,6 +52,7 @@ No authorization required
 ## FakeOuterBooleanSerialize
 
 > bool FakeOuterBooleanSerialize(ctx, optional)
+
 
 
 Test serialization of outer boolean types
@@ -95,6 +97,7 @@ No authorization required
 > OuterComposite FakeOuterCompositeSerialize(ctx, optional)
 
 
+
 Test serialization of object with outer number type
 
 ### Required Parameters
@@ -135,6 +138,7 @@ No authorization required
 ## FakeOuterNumberSerialize
 
 > float32 FakeOuterNumberSerialize(ctx, optional)
+
 
 
 Test serialization of outer number types
@@ -179,6 +183,7 @@ No authorization required
 > string FakeOuterStringSerialize(ctx, optional)
 
 
+
 Test serialization of outer string types
 
 ### Required Parameters
@@ -221,6 +226,7 @@ No authorization required
 > TestBodyWithFileSchema(ctx, fileSchemaTestClass)
 
 
+
 For this test, the body for this request much reference a schema named `File`.
 
 ### Required Parameters
@@ -254,6 +260,7 @@ No authorization required
 > TestBodyWithQueryParams(ctx, query, user)
 
 
+
 ### Required Parameters
 
 
@@ -284,6 +291,7 @@ No authorization required
 ## TestClientModel
 
 > Client TestClientModel(ctx, client)
+
 To test \"client\" model
 
 To test \"client\" model
@@ -317,6 +325,7 @@ No authorization required
 ## TestEndpointParameters
 
 > TestEndpointParameters(ctx, number, double, patternWithoutDelimiter, byte_, optional)
+
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -376,6 +385,7 @@ Name | Type | Description  | Notes
 ## TestEnumParameters
 
 > TestEnumParameters(ctx, optional)
+
 To test enum parameters
 
 To test enum parameters
@@ -425,6 +435,7 @@ No authorization required
 ## TestGroupParameters
 
 > TestGroupParameters(ctx, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, optional)
+
 Fake endpoint to test group parameters (optional)
 
 Fake endpoint to test group parameters (optional)
@@ -475,6 +486,7 @@ Name | Type | Description  | Notes
 ## TestInlineAdditionalProperties
 
 > TestInlineAdditionalProperties(ctx, requestBody)
+
 test inline additionalProperties
 
 ### Required Parameters
@@ -506,6 +518,7 @@ No authorization required
 ## TestJsonFormData
 
 > TestJsonFormData(ctx, param, param2)
+
 test json serialization of form data
 
 ### Required Parameters
@@ -538,6 +551,7 @@ No authorization required
 ## TestQueryParameterCollectionFormat
 
 > TestQueryParameterCollectionFormat(ctx, pipe, ioutil, http, url, context)
+
 
 
 To test the collection format in query parameters

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FakeClassnameTags123Api.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 ## TestClassname
 
 > Client TestClassname(ctx, client)
+
 To test class name in snake case
 
 To test class name in snake case

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | Pointer to **string** |  | [optional] 
-**Foo** | Pointer to **string** |  | [optional] 
+**Bar** | Pointer to **string** |  | [optional] [readonly] 
+**Foo** | Pointer to **string** |  | [optional] [readonly] 
 
 ## Methods
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Name.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/Name.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | Pointer to **int32** |  | 
-**SnakeCase** | Pointer to **int32** |  | [optional] 
+**SnakeCase** | Pointer to **int32** |  | [optional] [readonly] 
 **Property** | Pointer to **string** |  | [optional] 
-**Var123Number** | Pointer to **int32** |  | [optional] 
+**Var123Number** | Pointer to **int32** |  | [optional] [readonly] 
 
 ## Methods
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/PetApi.md
@@ -19,6 +19,7 @@ Method | HTTP request | Description
 ## AddPet
 
 > AddPet(ctx, pet)
+
 Add a new pet to the store
 
 ### Required Parameters
@@ -50,6 +51,7 @@ Name | Type | Description  | Notes
 ## DeletePet
 
 > DeletePet(ctx, petId, optional)
+
 Deletes a pet
 
 ### Required Parameters
@@ -92,6 +94,7 @@ Name | Type | Description  | Notes
 ## FindPetsByStatus
 
 > []Pet FindPetsByStatus(ctx, status)
+
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
@@ -125,6 +128,7 @@ Name | Type | Description  | Notes
 ## FindPetsByTags
 
 > []Pet FindPetsByTags(ctx, tags)
+
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -158,6 +162,7 @@ Name | Type | Description  | Notes
 ## GetPetById
 
 > Pet GetPetById(ctx, petId)
+
 Find pet by ID
 
 Returns a single pet
@@ -191,6 +196,7 @@ Name | Type | Description  | Notes
 ## UpdatePet
 
 > UpdatePet(ctx, pet)
+
 Update an existing pet
 
 ### Required Parameters
@@ -222,6 +228,7 @@ Name | Type | Description  | Notes
 ## UpdatePetWithForm
 
 > UpdatePetWithForm(ctx, petId, optional)
+
 Updates a pet in the store with form data
 
 ### Required Parameters
@@ -265,6 +272,7 @@ Name | Type | Description  | Notes
 ## UploadFile
 
 > ApiResponse UploadFile(ctx, petId, optional)
+
 uploads an image
 
 ### Required Parameters
@@ -308,6 +316,7 @@ Name | Type | Description  | Notes
 ## UploadFileWithRequiredFile
 
 > ApiResponse UploadFileWithRequiredFile(ctx, petId, requiredFile, optional)
+
 uploads an image (required)
 
 ### Required Parameters

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/ReadOnlyFirst.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | Pointer to **string** |  | [optional] 
+**Bar** | Pointer to **string** |  | [optional] [readonly] 
 **Baz** | Pointer to **string** |  | [optional] 
 
 ## Methods

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/StoreApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 ## DeleteOrder
 
 > DeleteOrder(ctx, orderId)
+
 Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -47,6 +48,7 @@ No authorization required
 ## GetInventory
 
 > map[string]int32 GetInventory(ctx, )
+
 Returns pet inventories by status
 
 Returns a map of status codes to quantities
@@ -76,6 +78,7 @@ This endpoint does not need any parameter.
 ## GetOrderById
 
 > Order GetOrderById(ctx, orderId)
+
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -109,6 +112,7 @@ No authorization required
 ## PlaceOrder
 
 > Order PlaceOrder(ctx, order)
+
 Place an order for a pet
 
 ### Required Parameters

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/UserApi.md
@@ -18,6 +18,7 @@ Method | HTTP request | Description
 ## CreateUser
 
 > CreateUser(ctx, user)
+
 Create user
 
 This can only be done by the logged in user.
@@ -51,6 +52,7 @@ No authorization required
 ## CreateUsersWithArrayInput
 
 > CreateUsersWithArrayInput(ctx, user)
+
 Creates list of users with given input array
 
 ### Required Parameters
@@ -82,6 +84,7 @@ No authorization required
 ## CreateUsersWithListInput
 
 > CreateUsersWithListInput(ctx, user)
+
 Creates list of users with given input array
 
 ### Required Parameters
@@ -113,6 +116,7 @@ No authorization required
 ## DeleteUser
 
 > DeleteUser(ctx, username)
+
 Delete user
 
 This can only be done by the logged in user.
@@ -146,6 +150,7 @@ No authorization required
 ## GetUserByName
 
 > User GetUserByName(ctx, username)
+
 Get user by user name
 
 ### Required Parameters
@@ -177,6 +182,7 @@ No authorization required
 ## LoginUser
 
 > string LoginUser(ctx, username, password)
+
 Logs user into the system
 
 ### Required Parameters
@@ -209,6 +215,7 @@ No authorization required
 ## LogoutUser
 
 > LogoutUser(ctx, )
+
 Logs out current logged in user session
 
 ### Required Parameters
@@ -236,6 +243,7 @@ No authorization required
 ## UpdateUser
 
 > UpdateUser(ctx, username, user)
+
 Updated user
 
 This can only be done by the logged in user.

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/AnotherFakeApi.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 ## Call123TestSpecialTags
 
 > Client Call123TestSpecialTags(ctx, client)
+
 To test special tags
 
 To test special tags and operation ID starting with number

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/DefaultApi.md
@@ -13,6 +13,7 @@ Method | HTTP request | Description
 > InlineResponseDefault FooGet(ctx, )
 
 
+
 ### Required Parameters
 
 This endpoint does not need any parameter.

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeApi.md
@@ -24,6 +24,7 @@ Method | HTTP request | Description
 ## FakeHealthGet
 
 > HealthCheckResult FakeHealthGet(ctx, )
+
 Health check endpoint
 
 ### Required Parameters
@@ -51,6 +52,7 @@ No authorization required
 ## FakeOuterBooleanSerialize
 
 > bool FakeOuterBooleanSerialize(ctx, optional)
+
 
 
 Test serialization of outer boolean types
@@ -95,6 +97,7 @@ No authorization required
 > OuterComposite FakeOuterCompositeSerialize(ctx, optional)
 
 
+
 Test serialization of object with outer number type
 
 ### Required Parameters
@@ -135,6 +138,7 @@ No authorization required
 ## FakeOuterNumberSerialize
 
 > float32 FakeOuterNumberSerialize(ctx, optional)
+
 
 
 Test serialization of outer number types
@@ -179,6 +183,7 @@ No authorization required
 > string FakeOuterStringSerialize(ctx, optional)
 
 
+
 Test serialization of outer string types
 
 ### Required Parameters
@@ -221,6 +226,7 @@ No authorization required
 > TestBodyWithFileSchema(ctx, fileSchemaTestClass)
 
 
+
 For this test, the body for this request much reference a schema named `File`.
 
 ### Required Parameters
@@ -254,6 +260,7 @@ No authorization required
 > TestBodyWithQueryParams(ctx, query, user)
 
 
+
 ### Required Parameters
 
 
@@ -284,6 +291,7 @@ No authorization required
 ## TestClientModel
 
 > Client TestClientModel(ctx, client)
+
 To test \"client\" model
 
 To test \"client\" model
@@ -317,6 +325,7 @@ No authorization required
 ## TestEndpointParameters
 
 > TestEndpointParameters(ctx, number, double, patternWithoutDelimiter, byte_, optional)
+
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
@@ -376,6 +385,7 @@ Name | Type | Description  | Notes
 ## TestEnumParameters
 
 > TestEnumParameters(ctx, optional)
+
 To test enum parameters
 
 To test enum parameters
@@ -425,6 +435,7 @@ No authorization required
 ## TestGroupParameters
 
 > TestGroupParameters(ctx, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, optional)
+
 Fake endpoint to test group parameters (optional)
 
 Fake endpoint to test group parameters (optional)
@@ -475,6 +486,7 @@ Name | Type | Description  | Notes
 ## TestInlineAdditionalProperties
 
 > TestInlineAdditionalProperties(ctx, requestBody)
+
 test inline additionalProperties
 
 ### Required Parameters
@@ -506,6 +518,7 @@ No authorization required
 ## TestJsonFormData
 
 > TestJsonFormData(ctx, param, param2)
+
 test json serialization of form data
 
 ### Required Parameters
@@ -538,6 +551,7 @@ No authorization required
 ## TestQueryParameterCollectionFormat
 
 > TestQueryParameterCollectionFormat(ctx, pipe, ioutil, http, url, context)
+
 
 
 To test the collection format in query parameters

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/FakeClassnameTags123Api.md
@@ -11,6 +11,7 @@ Method | HTTP request | Description
 ## TestClassname
 
 > Client TestClassname(ctx, client)
+
 To test class name in snake case
 
 To test class name in snake case

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/PetApi.md
@@ -19,6 +19,7 @@ Method | HTTP request | Description
 ## AddPet
 
 > AddPet(ctx, pet)
+
 Add a new pet to the store
 
 ### Required Parameters
@@ -50,6 +51,7 @@ Name | Type | Description  | Notes
 ## DeletePet
 
 > DeletePet(ctx, petId, optional)
+
 Deletes a pet
 
 ### Required Parameters
@@ -92,6 +94,7 @@ Name | Type | Description  | Notes
 ## FindPetsByStatus
 
 > []Pet FindPetsByStatus(ctx, status)
+
 Finds Pets by status
 
 Multiple status values can be provided with comma separated strings
@@ -125,6 +128,7 @@ Name | Type | Description  | Notes
 ## FindPetsByTags
 
 > []Pet FindPetsByTags(ctx, tags)
+
 Finds Pets by tags
 
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -158,6 +162,7 @@ Name | Type | Description  | Notes
 ## GetPetById
 
 > Pet GetPetById(ctx, petId)
+
 Find pet by ID
 
 Returns a single pet
@@ -191,6 +196,7 @@ Name | Type | Description  | Notes
 ## UpdatePet
 
 > UpdatePet(ctx, pet)
+
 Update an existing pet
 
 ### Required Parameters
@@ -222,6 +228,7 @@ Name | Type | Description  | Notes
 ## UpdatePetWithForm
 
 > UpdatePetWithForm(ctx, petId, optional)
+
 Updates a pet in the store with form data
 
 ### Required Parameters
@@ -265,6 +272,7 @@ Name | Type | Description  | Notes
 ## UploadFile
 
 > ApiResponse UploadFile(ctx, petId, optional)
+
 uploads an image
 
 ### Required Parameters
@@ -308,6 +316,7 @@ Name | Type | Description  | Notes
 ## UploadFileWithRequiredFile
 
 > ApiResponse UploadFileWithRequiredFile(ctx, petId, requiredFile, optional)
+
 uploads an image (required)
 
 ### Required Parameters

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/StoreApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 ## DeleteOrder
 
 > DeleteOrder(ctx, orderId)
+
 Delete purchase order by ID
 
 For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
@@ -47,6 +48,7 @@ No authorization required
 ## GetInventory
 
 > map[string]int32 GetInventory(ctx, )
+
 Returns pet inventories by status
 
 Returns a map of status codes to quantities
@@ -76,6 +78,7 @@ This endpoint does not need any parameter.
 ## GetOrderById
 
 > Order GetOrderById(ctx, orderId)
+
 Find purchase order by ID
 
 For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
@@ -109,6 +112,7 @@ No authorization required
 ## PlaceOrder
 
 > Order PlaceOrder(ctx, order)
+
 Place an order for a pet
 
 ### Required Parameters

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/UserApi.md
@@ -18,6 +18,7 @@ Method | HTTP request | Description
 ## CreateUser
 
 > CreateUser(ctx, user)
+
 Create user
 
 This can only be done by the logged in user.
@@ -51,6 +52,7 @@ No authorization required
 ## CreateUsersWithArrayInput
 
 > CreateUsersWithArrayInput(ctx, user)
+
 Creates list of users with given input array
 
 ### Required Parameters
@@ -82,6 +84,7 @@ No authorization required
 ## CreateUsersWithListInput
 
 > CreateUsersWithListInput(ctx, user)
+
 Creates list of users with given input array
 
 ### Required Parameters
@@ -113,6 +116,7 @@ No authorization required
 ## DeleteUser
 
 > DeleteUser(ctx, username)
+
 Delete user
 
 This can only be done by the logged in user.
@@ -146,6 +150,7 @@ No authorization required
 ## GetUserByName
 
 > User GetUserByName(ctx, username)
+
 Get user by user name
 
 ### Required Parameters
@@ -177,6 +182,7 @@ No authorization required
 ## LoginUser
 
 > string LoginUser(ctx, username, password)
+
 Logs user into the system
 
 ### Required Parameters
@@ -209,6 +215,7 @@ No authorization required
 ## LogoutUser
 
 > LogoutUser(ctx, )
+
 Logs out current logged in user session
 
 ### Required Parameters
@@ -236,6 +243,7 @@ No authorization required
 ## UpdateUser
 
 > UpdateUser(ctx, username, user)
+
 Updated user
 
 This can only be done by the logged in user.


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Added newline so that the summary doesn't appear at the same line as the function signature.

