### PR TITLE
[python] Add ability to get allowed values

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model.mustache
@@ -77,8 +77,7 @@ class {{classname}}(object):
 {{#allowableValues}}
     @staticmethod
     def get_allowed_values():
-        allowed_values = [{{#enumVars}}{{classname}}.{{name}}{{^-last}}, {{/-last}}{{/enumVars}}]  # noqa: E501
-        return allowed_values
+        return [{{#enumVars}}{{classname}}.{{name}}{{^-last}}, {{/-last}}{{/enumVars}}]  # noqa: E501
 
 {{/allowableValues}}
 {{#vars}}

--- a/modules/openapi-generator/src/main/resources/python/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model.mustache
@@ -74,6 +74,13 @@ class {{classname}}(object):
 {{/required}}
 {{/vars}}
 
+{{#allowableValues}}
+    @staticmethod
+    def get_allowed_values():
+        allowed_values = [{{#enumVars}}{{classname}}.{{name}}{{^-last}}, {{/-last}}{{/enumVars}}]  # noqa: E501
+        return allowed_values
+
+{{/allowableValues}}
 {{#vars}}
     @property
     def {{name}}(self):

--- a/modules/openapi-generator/src/main/resources/python/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model.mustache
@@ -25,6 +25,10 @@ class {{classname}}(object):
 {{/-last}}
 {{/enumVars}}{{/allowableValues}}
 
+{{#allowableValues}}
+    allowable_values = [{{#enumVars}}{{classname}}.{{name}}{{^-last}}, {{/-last}}{{/enumVars}}]  # noqa: E501
+
+{{/allowableValues}}
     """
     Attributes:
       openapi_types (dict): The key is attribute name
@@ -74,12 +78,6 @@ class {{classname}}(object):
 {{/required}}
 {{/vars}}
 
-{{#allowableValues}}
-    @staticmethod
-    def get_allowed_values():
-        return [{{#enumVars}}{{classname}}.{{name}}{{^-last}}, {{/-last}}{{/enumVars}}]  # noqa: E501
-
-{{/allowableValues}}
 {{#vars}}
     @property
     def {{name}}(self):

--- a/modules/openapi-generator/src/main/resources/python/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model.mustache
@@ -26,7 +26,7 @@ class {{classname}}(object):
 {{/enumVars}}{{/allowableValues}}
 
 {{#allowableValues}}
-    allowable_values = [{{#enumVars}}{{classname}}.{{name}}{{^-last}}, {{/-last}}{{/enumVars}}]  # noqa: E501
+    allowable_values = [{{#enumVars}}{{name}}{{^-last}}, {{/-last}}{{/enumVars}}]  # noqa: E501
 
 {{/allowableValues}}
     """

--- a/samples/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/client/petstore/python/petstore_api/models/enum_class.py
@@ -30,7 +30,7 @@ class EnumClass(object):
     _EFG = "-efg"
     _XYZ_ = "(xyz)"
 
-    allowable_values = [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
+    allowable_values = [_ABC, _EFG, _XYZ_]  # noqa: E501
 
     """
     Attributes:

--- a/samples/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/client/petstore/python/petstore_api/models/enum_class.py
@@ -47,6 +47,11 @@ class EnumClass(object):
         """EnumClass - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
 
+    @staticmethod
+    def get_allowed_values():
+        allowed_values = [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
+        return allowed_values
+
     def to_dict(self):
         """Returns the model properties as a dict"""
         result = {}

--- a/samples/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/client/petstore/python/petstore_api/models/enum_class.py
@@ -49,8 +49,7 @@ class EnumClass(object):
 
     @staticmethod
     def get_allowed_values():
-        allowed_values = [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
-        return allowed_values
+        return [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/client/petstore/python/petstore_api/models/enum_class.py
@@ -30,6 +30,8 @@ class EnumClass(object):
     _EFG = "-efg"
     _XYZ_ = "(xyz)"
 
+    allowable_values = [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
+
     """
     Attributes:
       openapi_types (dict): The key is attribute name
@@ -46,10 +48,6 @@ class EnumClass(object):
     def __init__(self):  # noqa: E501
         """EnumClass - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
-
-    @staticmethod
-    def get_allowed_values():
-        return [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/client/petstore/python/petstore_api/models/outer_enum.py
@@ -47,6 +47,11 @@ class OuterEnum(object):
         """OuterEnum - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
 
+    @staticmethod
+    def get_allowed_values():
+        allowed_values = [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
+        return allowed_values
+
     def to_dict(self):
         """Returns the model properties as a dict"""
         result = {}

--- a/samples/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/client/petstore/python/petstore_api/models/outer_enum.py
@@ -30,6 +30,8 @@ class OuterEnum(object):
     APPROVED = "approved"
     DELIVERED = "delivered"
 
+    allowable_values = [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
+
     """
     Attributes:
       openapi_types (dict): The key is attribute name
@@ -46,10 +48,6 @@ class OuterEnum(object):
     def __init__(self):  # noqa: E501
         """OuterEnum - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
-
-    @staticmethod
-    def get_allowed_values():
-        return [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/client/petstore/python/petstore_api/models/outer_enum.py
@@ -30,7 +30,7 @@ class OuterEnum(object):
     APPROVED = "approved"
     DELIVERED = "delivered"
 
-    allowable_values = [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
+    allowable_values = [PLACED, APPROVED, DELIVERED]  # noqa: E501
 
     """
     Attributes:

--- a/samples/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/client/petstore/python/petstore_api/models/outer_enum.py
@@ -49,8 +49,7 @@ class OuterEnum(object):
 
     @staticmethod
     def get_allowed_values():
-        allowed_values = [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
-        return allowed_values
+        return [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
@@ -30,7 +30,7 @@ class EnumClass(object):
     _EFG = "-efg"
     _XYZ_ = "(xyz)"
 
-    allowable_values = [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
+    allowable_values = [_ABC, _EFG, _XYZ_]  # noqa: E501
 
     """
     Attributes:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
@@ -47,6 +47,11 @@ class EnumClass(object):
         """EnumClass - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
 
+    @staticmethod
+    def get_allowed_values():
+        allowed_values = [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
+        return allowed_values
+
     def to_dict(self):
         """Returns the model properties as a dict"""
         result = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
@@ -49,8 +49,7 @@ class EnumClass(object):
 
     @staticmethod
     def get_allowed_values():
-        allowed_values = [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
-        return allowed_values
+        return [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
@@ -30,6 +30,8 @@ class EnumClass(object):
     _EFG = "-efg"
     _XYZ_ = "(xyz)"
 
+    allowable_values = [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
+
     """
     Attributes:
       openapi_types (dict): The key is attribute name
@@ -46,10 +48,6 @@ class EnumClass(object):
     def __init__(self):  # noqa: E501
         """EnumClass - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
-
-    @staticmethod
-    def get_allowed_values():
-        return [EnumClass._ABC, EnumClass._EFG, EnumClass._XYZ_]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
@@ -47,6 +47,11 @@ class OuterEnum(object):
         """OuterEnum - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
 
+    @staticmethod
+    def get_allowed_values():
+        allowed_values = [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
+        return allowed_values
+
     def to_dict(self):
         """Returns the model properties as a dict"""
         result = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
@@ -30,6 +30,8 @@ class OuterEnum(object):
     APPROVED = "approved"
     DELIVERED = "delivered"
 
+    allowable_values = [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
+
     """
     Attributes:
       openapi_types (dict): The key is attribute name
@@ -46,10 +48,6 @@ class OuterEnum(object):
     def __init__(self):  # noqa: E501
         """OuterEnum - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
-
-    @staticmethod
-    def get_allowed_values():
-        return [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
@@ -30,7 +30,7 @@ class OuterEnum(object):
     APPROVED = "approved"
     DELIVERED = "delivered"
 
-    allowable_values = [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
+    allowable_values = [PLACED, APPROVED, DELIVERED]  # noqa: E501
 
     """
     Attributes:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
@@ -49,8 +49,7 @@ class OuterEnum(object):
 
     @staticmethod
     def get_allowed_values():
-        allowed_values = [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
-        return allowed_values
+        return [OuterEnum.PLACED, OuterEnum.APPROVED, OuterEnum.DELIVERED]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
@@ -47,6 +47,11 @@ class OuterEnumDefaultValue(object):
         """OuterEnumDefaultValue - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
 
+    @staticmethod
+    def get_allowed_values():
+        allowed_values = [OuterEnumDefaultValue.PLACED, OuterEnumDefaultValue.APPROVED, OuterEnumDefaultValue.DELIVERED]  # noqa: E501
+        return allowed_values
+
     def to_dict(self):
         """Returns the model properties as a dict"""
         result = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
@@ -30,6 +30,8 @@ class OuterEnumDefaultValue(object):
     APPROVED = "approved"
     DELIVERED = "delivered"
 
+    allowable_values = [OuterEnumDefaultValue.PLACED, OuterEnumDefaultValue.APPROVED, OuterEnumDefaultValue.DELIVERED]  # noqa: E501
+
     """
     Attributes:
       openapi_types (dict): The key is attribute name
@@ -46,10 +48,6 @@ class OuterEnumDefaultValue(object):
     def __init__(self):  # noqa: E501
         """OuterEnumDefaultValue - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
-
-    @staticmethod
-    def get_allowed_values():
-        return [OuterEnumDefaultValue.PLACED, OuterEnumDefaultValue.APPROVED, OuterEnumDefaultValue.DELIVERED]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
@@ -49,8 +49,7 @@ class OuterEnumDefaultValue(object):
 
     @staticmethod
     def get_allowed_values():
-        allowed_values = [OuterEnumDefaultValue.PLACED, OuterEnumDefaultValue.APPROVED, OuterEnumDefaultValue.DELIVERED]  # noqa: E501
-        return allowed_values
+        return [OuterEnumDefaultValue.PLACED, OuterEnumDefaultValue.APPROVED, OuterEnumDefaultValue.DELIVERED]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
@@ -30,7 +30,7 @@ class OuterEnumDefaultValue(object):
     APPROVED = "approved"
     DELIVERED = "delivered"
 
-    allowable_values = [OuterEnumDefaultValue.PLACED, OuterEnumDefaultValue.APPROVED, OuterEnumDefaultValue.DELIVERED]  # noqa: E501
+    allowable_values = [PLACED, APPROVED, DELIVERED]  # noqa: E501
 
     """
     Attributes:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
@@ -30,7 +30,7 @@ class OuterEnumInteger(object):
     _1 = "1"
     _2 = "2"
 
-    allowable_values = [OuterEnumInteger._0, OuterEnumInteger._1, OuterEnumInteger._2]  # noqa: E501
+    allowable_values = [_0, _1, _2]  # noqa: E501
 
     """
     Attributes:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
@@ -30,6 +30,8 @@ class OuterEnumInteger(object):
     _1 = "1"
     _2 = "2"
 
+    allowable_values = [OuterEnumInteger._0, OuterEnumInteger._1, OuterEnumInteger._2]  # noqa: E501
+
     """
     Attributes:
       openapi_types (dict): The key is attribute name
@@ -46,10 +48,6 @@ class OuterEnumInteger(object):
     def __init__(self):  # noqa: E501
         """OuterEnumInteger - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
-
-    @staticmethod
-    def get_allowed_values():
-        return [OuterEnumInteger._0, OuterEnumInteger._1, OuterEnumInteger._2]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
@@ -47,6 +47,11 @@ class OuterEnumInteger(object):
         """OuterEnumInteger - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
 
+    @staticmethod
+    def get_allowed_values():
+        allowed_values = [OuterEnumInteger._0, OuterEnumInteger._1, OuterEnumInteger._2]  # noqa: E501
+        return allowed_values
+
     def to_dict(self):
         """Returns the model properties as a dict"""
         result = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
@@ -49,8 +49,7 @@ class OuterEnumInteger(object):
 
     @staticmethod
     def get_allowed_values():
-        allowed_values = [OuterEnumInteger._0, OuterEnumInteger._1, OuterEnumInteger._2]  # noqa: E501
-        return allowed_values
+        return [OuterEnumInteger._0, OuterEnumInteger._1, OuterEnumInteger._2]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
@@ -47,6 +47,11 @@ class OuterEnumIntegerDefaultValue(object):
         """OuterEnumIntegerDefaultValue - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
 
+    @staticmethod
+    def get_allowed_values():
+        allowed_values = [OuterEnumIntegerDefaultValue._0, OuterEnumIntegerDefaultValue._1, OuterEnumIntegerDefaultValue._2]  # noqa: E501
+        return allowed_values
+
     def to_dict(self):
         """Returns the model properties as a dict"""
         result = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
@@ -30,7 +30,7 @@ class OuterEnumIntegerDefaultValue(object):
     _1 = "1"
     _2 = "2"
 
-    allowable_values = [OuterEnumIntegerDefaultValue._0, OuterEnumIntegerDefaultValue._1, OuterEnumIntegerDefaultValue._2]  # noqa: E501
+    allowable_values = [_0, _1, _2]  # noqa: E501
 
     """
     Attributes:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
@@ -30,6 +30,8 @@ class OuterEnumIntegerDefaultValue(object):
     _1 = "1"
     _2 = "2"
 
+    allowable_values = [OuterEnumIntegerDefaultValue._0, OuterEnumIntegerDefaultValue._1, OuterEnumIntegerDefaultValue._2]  # noqa: E501
+
     """
     Attributes:
       openapi_types (dict): The key is attribute name
@@ -46,10 +48,6 @@ class OuterEnumIntegerDefaultValue(object):
     def __init__(self):  # noqa: E501
         """OuterEnumIntegerDefaultValue - a model defined in OpenAPI"""  # noqa: E501
         self.discriminator = None
-
-    @staticmethod
-    def get_allowed_values():
-        return [OuterEnumIntegerDefaultValue._0, OuterEnumIntegerDefaultValue._1, OuterEnumIntegerDefaultValue._2]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
@@ -49,8 +49,7 @@ class OuterEnumIntegerDefaultValue(object):
 
     @staticmethod
     def get_allowed_values():
-        allowed_values = [OuterEnumIntegerDefaultValue._0, OuterEnumIntegerDefaultValue._1, OuterEnumIntegerDefaultValue._2]  # noqa: E501
-        return allowed_values
+        return [OuterEnumIntegerDefaultValue._0, OuterEnumIntegerDefaultValue._1, OuterEnumIntegerDefaultValue._2]  # noqa: E501
 
     def to_dict(self):
         """Returns the model properties as a dict"""


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Currently, there is no way to get the list of allowed values for an enum. This PR adds a class variable to get all the allowed values

Why this is needed?
fixes https://github.com/OpenAPITools/openapi-generator/issues/4139