### PR TITLE
[docs] Add step in contributing.md to run petstore server

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -93,7 +93,7 @@ To test the templates, please perform the following:
 - Run the Petstore server using
 ```bash
 docker pull swaggerapi/petstore
-docker run -d -e SWAGGER_HOST=http://petstore.swagger.io  -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
+docker run -d -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
 ```
 - Run the tests in the sample folder using maven `mvn integration-test -rf :<artifactId>`, e.g. open a shell in `samples/client/petstore/python`, run `mvn integration-test -rf :PythonPetstoreClientTests`. The artifactId of the project can be found in the pom.xml file. (some languages may not contain unit testing for Petstore and we're looking for contribution from the community to implement those tests)
 - Finally, git commit the updated samples files: `git commit -a`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -90,6 +90,11 @@ To add test cases (optional) covering the change in the code generator, please r
 
 To test the templates, please perform the following:
 - Update the Petstore sample by running the shell scripts under `bin` and `bin/openapi3` folder. For example, run `./bin/python-client-petstore.sh` and `./bin/openapi3/python-client-petstore.sh` to update the Python PetStore API client under [`samples/client/petstore/python`](https://github.com/openapitools/openapi-generator/tree/master/samples/client/petstore/python) and [`samples/openapi3/client/petstore/python`](https://github.com/openapitools/openapi-generator/tree/master/samples/openapi3/client/petstore/python). For Windows, the batch files can be found under `bin\windows` folder. (If you find that there are new files generated or unexpected changes as a result of the update, that's not unusual as the test cases are added to the OpenAPI spec from time to time. If you've questions or concerns, please open a ticket to start a discussion)
+- Run the Petstore server using
+```bash
+docker pull swaggerapi/petstore
+docker run -d -e SWAGGER_HOST=http://petstore.swagger.io  -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
+```
 - Run the tests in the sample folder using maven `mvn integration-test -rf :<artifactId>`, e.g. open a shell in `samples/client/petstore/python`, run `mvn integration-test -rf :PythonPetstoreClientTests`. The artifactId of the project can be found in the pom.xml file. (some languages may not contain unit testing for Petstore and we're looking for contribution from the community to implement those tests)
 - Finally, git commit the updated samples files: `git commit -a`
   (`git add -A` if added files with new test cases)


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

The step to run Petstore server before running tests is missing, which leads to the below exception
```bash
MaxRetryError: HTTPConnectionPool(host='localhost', port=80): Max retries exceeded with url: /v2/pet (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10c064bd0>: Failed to establish a new connection: [Errno 61] Connection refused',))
```
