### PR TITLE
[Python] Run all test cases against petstore server

### DIFF
--- a/samples/client/petstore/python/tests/test_api_client.py
+++ b/samples/client/petstore/python/tests/test_api_client.py
@@ -27,7 +27,6 @@ class ApiClientTests(unittest.TestCase):
 
     def test_configuration(self):
         config = petstore_api.Configuration()
-        config.host = 'http://localhost/'
 
         config.api_key['api_key'] = '123456'
         config.api_key_prefix['api_key'] = 'PREFIX'

--- a/samples/client/petstore/python/tests/test_pet_api.py
+++ b/samples/client/petstore/python/tests/test_pet_api.py
@@ -24,7 +24,7 @@ import json
 
 import urllib3
 
-HOST = 'http://localhost/v2'
+HOST = 'http://petstore.swagger.io/v2'
 
 
 class TimeoutWithEqual(urllib3.Timeout):
@@ -104,13 +104,13 @@ class PetApiTests(unittest.TestCase):
         mock_pool = MockPoolManager(self)
         self.api_client.rest_client.pool_manager = mock_pool
 
-        mock_pool.expect_request('POST', 'http://localhost/v2/pet',
+        mock_pool.expect_request('POST', HOST + '/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
                                           'Authorization': 'Bearer ',
                                           'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=TimeoutWithEqual(total=5))
-        mock_pool.expect_request('POST', 'http://localhost/v2/pet',
+        mock_pool.expect_request('POST', HOST + '/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
                                           'Authorization': 'Bearer ',


### PR DESCRIPTION
Few test cases now run against localhost which causes the test cases to fail and we have to run petstore locally for that to pass

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before .
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
