### PR TITLE
Fix boolean operators precedence

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -505,7 +505,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 CodegenModel model = (CodegenModel) v;
                 for (CodegenProperty param : model.vars) {
                     if (!addedTimeImport
-                        && "time.Time".equals(param.dataType) || ("[]time.Time".equals(param.dataType))) {
+                        && ("time.Time".equals(param.dataType) || ("[]time.Time".equals(param.dataType)))) {
                         imports.add(createMapping("import", "time"));
                         addedTimeImport = true;
                     }


### PR DESCRIPTION
This is a fix for a bug I've introduced with #3973 

Due to operator precedence, even if `addedTimeImport` is `true`, the if branch is executed and it results in duplicated `import time` statements in the generated code.

### Steps to reproduce

Use this definition (notice `User` has 2 date-time related fields, `joined` and `times`):

```
openapi: 3.0.0

info:
  title: Sample OpenAPI Specification
  version: 0.0.1

servers:
  - url: http://localhost:8080/
    description: Example API Service

components:
  schemas:
    'User':
      type: object
      required:
        - display_name
        - email
      properties:
        name:
          type: string
          readOnly: true
        display_name:
          type: string
          maxLength: 20
          minLength: 1
        email:
          type: string
          format: email
        joined:
          type: string
          format: date-time
        times:
          type: array
          items:
            type: string
            format: date-time
            #        from_date:
            #type: string
            #format: date-time

    'ErrorMessage':
      type: object
      required:
        - error_code
        - error_message
      properties:
        error_code:
          type: string
        error_message:
          type: string

paths:
  /users/{user_id}:
    parameters:
      - name: user_id
        in: path
        description: ID of a user
        required: true
        schema:
          type: string
    get:
      description: Gets a user
      operationId: get_user
      responses:
        '200':
          description: User found
          content:
            'application/json':
              schema:
                $ref: '#/components/schemas/User'
        'default':
          description: Unexpected error
          content:
            'application/json':
              schema:
                $ref: '#/components/schemas/ErrorMessage'

```

With the latest version (4.1.3), run:

```
openapi-generator generate -g go -i api.yaml -o go/
```

Notice the wrong import statement in `go/model_user.go`:

```
import (
        "time"
        "time"
)

```

cc: @antihax @bvwells @grokify @kemokemo @bkabrda

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before .
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
