### PR TITLE
[python] Skip adding None value in query parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -182,7 +182,7 @@ class {{classname}}(object):
 
         query_params = []
 {{#queryParams}}
-        if '{{paramName}}' in local_var_params:
+        if '{{paramName}}' in local_var_params and local_var_params['{{paramName}}'] is not None:  # noqa: E501
             query_params.append(('{{baseName}}', local_var_params['{{paramName}}'])){{#isListContainer}}  # noqa: E501
             collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isListContainer}}  # noqa: E501
 {{/queryParams}}

--- a/samples/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/client/petstore/python/petstore_api/api/fake_api.py
@@ -748,7 +748,7 @@ class FakeApi(object):
         path_params = {}
 
         query_params = []
-        if 'query' in local_var_params:
+        if 'query' in local_var_params and local_var_params['query'] is not None:  # noqa: E501
             query_params.append(('query', local_var_params['query']))  # noqa: E501
 
         header_params = {}
@@ -1180,14 +1180,14 @@ class FakeApi(object):
         path_params = {}
 
         query_params = []
-        if 'enum_query_string_array' in local_var_params:
+        if 'enum_query_string_array' in local_var_params and local_var_params['enum_query_string_array'] is not None:  # noqa: E501
             query_params.append(('enum_query_string_array', local_var_params['enum_query_string_array']))  # noqa: E501
             collection_formats['enum_query_string_array'] = 'csv'  # noqa: E501
-        if 'enum_query_string' in local_var_params:
+        if 'enum_query_string' in local_var_params and local_var_params['enum_query_string'] is not None:  # noqa: E501
             query_params.append(('enum_query_string', local_var_params['enum_query_string']))  # noqa: E501
-        if 'enum_query_integer' in local_var_params:
+        if 'enum_query_integer' in local_var_params and local_var_params['enum_query_integer'] is not None:  # noqa: E501
             query_params.append(('enum_query_integer', local_var_params['enum_query_integer']))  # noqa: E501
-        if 'enum_query_double' in local_var_params:
+        if 'enum_query_double' in local_var_params and local_var_params['enum_query_double'] is not None:  # noqa: E501
             query_params.append(('enum_query_double', local_var_params['enum_query_double']))  # noqa: E501
 
         header_params = {}
@@ -1323,13 +1323,13 @@ class FakeApi(object):
         path_params = {}
 
         query_params = []
-        if 'required_string_group' in local_var_params:
+        if 'required_string_group' in local_var_params and local_var_params['required_string_group'] is not None:  # noqa: E501
             query_params.append(('required_string_group', local_var_params['required_string_group']))  # noqa: E501
-        if 'required_int64_group' in local_var_params:
+        if 'required_int64_group' in local_var_params and local_var_params['required_int64_group'] is not None:  # noqa: E501
             query_params.append(('required_int64_group', local_var_params['required_int64_group']))  # noqa: E501
-        if 'string_group' in local_var_params:
+        if 'string_group' in local_var_params and local_var_params['string_group'] is not None:  # noqa: E501
             query_params.append(('string_group', local_var_params['string_group']))  # noqa: E501
-        if 'int64_group' in local_var_params:
+        if 'int64_group' in local_var_params and local_var_params['int64_group'] is not None:  # noqa: E501
             query_params.append(('int64_group', local_var_params['int64_group']))  # noqa: E501
 
         header_params = {}
@@ -1681,19 +1681,19 @@ class FakeApi(object):
         path_params = {}
 
         query_params = []
-        if 'pipe' in local_var_params:
+        if 'pipe' in local_var_params and local_var_params['pipe'] is not None:  # noqa: E501
             query_params.append(('pipe', local_var_params['pipe']))  # noqa: E501
             collection_formats['pipe'] = 'csv'  # noqa: E501
-        if 'ioutil' in local_var_params:
+        if 'ioutil' in local_var_params and local_var_params['ioutil'] is not None:  # noqa: E501
             query_params.append(('ioutil', local_var_params['ioutil']))  # noqa: E501
             collection_formats['ioutil'] = 'csv'  # noqa: E501
-        if 'http' in local_var_params:
+        if 'http' in local_var_params and local_var_params['http'] is not None:  # noqa: E501
             query_params.append(('http', local_var_params['http']))  # noqa: E501
             collection_formats['http'] = 'space'  # noqa: E501
-        if 'url' in local_var_params:
+        if 'url' in local_var_params and local_var_params['url'] is not None:  # noqa: E501
             query_params.append(('url', local_var_params['url']))  # noqa: E501
             collection_formats['url'] = 'csv'  # noqa: E501
-        if 'context' in local_var_params:
+        if 'context' in local_var_params and local_var_params['context'] is not None:  # noqa: E501
             query_params.append(('context', local_var_params['context']))  # noqa: E501
             collection_formats['context'] = 'multi'  # noqa: E501
 

--- a/samples/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/client/petstore/python/petstore_api/api/pet_api.py
@@ -324,7 +324,7 @@ class PetApi(object):
         path_params = {}
 
         query_params = []
-        if 'status' in local_var_params:
+        if 'status' in local_var_params and local_var_params['status'] is not None:  # noqa: E501
             query_params.append(('status', local_var_params['status']))  # noqa: E501
             collection_formats['status'] = 'csv'  # noqa: E501
 
@@ -433,7 +433,7 @@ class PetApi(object):
         path_params = {}
 
         query_params = []
-        if 'tags' in local_var_params:
+        if 'tags' in local_var_params and local_var_params['tags'] is not None:  # noqa: E501
             query_params.append(('tags', local_var_params['tags']))  # noqa: E501
             collection_formats['tags'] = 'csv'  # noqa: E501
 

--- a/samples/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/client/petstore/python/petstore_api/api/user_api.py
@@ -634,9 +634,9 @@ class UserApi(object):
         path_params = {}
 
         query_params = []
-        if 'username' in local_var_params:
+        if 'username' in local_var_params and local_var_params['username'] is not None:  # noqa: E501
             query_params.append(('username', local_var_params['username']))  # noqa: E501
-        if 'password' in local_var_params:
+        if 'password' in local_var_params and local_var_params['password'] is not None:  # noqa: E501
             query_params.append(('password', local_var_params['password']))  # noqa: E501
 
         header_params = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -754,7 +754,7 @@ class FakeApi(object):
         path_params = {}
 
         query_params = []
-        if 'query' in local_var_params:
+        if 'query' in local_var_params and local_var_params['query'] is not None:  # noqa: E501
             query_params.append(('query', local_var_params['query']))  # noqa: E501
 
         header_params = {}
@@ -1186,14 +1186,14 @@ class FakeApi(object):
         path_params = {}
 
         query_params = []
-        if 'enum_query_string_array' in local_var_params:
+        if 'enum_query_string_array' in local_var_params and local_var_params['enum_query_string_array'] is not None:  # noqa: E501
             query_params.append(('enum_query_string_array', local_var_params['enum_query_string_array']))  # noqa: E501
             collection_formats['enum_query_string_array'] = 'multi'  # noqa: E501
-        if 'enum_query_string' in local_var_params:
+        if 'enum_query_string' in local_var_params and local_var_params['enum_query_string'] is not None:  # noqa: E501
             query_params.append(('enum_query_string', local_var_params['enum_query_string']))  # noqa: E501
-        if 'enum_query_integer' in local_var_params:
+        if 'enum_query_integer' in local_var_params and local_var_params['enum_query_integer'] is not None:  # noqa: E501
             query_params.append(('enum_query_integer', local_var_params['enum_query_integer']))  # noqa: E501
-        if 'enum_query_double' in local_var_params:
+        if 'enum_query_double' in local_var_params and local_var_params['enum_query_double'] is not None:  # noqa: E501
             query_params.append(('enum_query_double', local_var_params['enum_query_double']))  # noqa: E501
 
         header_params = {}
@@ -1329,13 +1329,13 @@ class FakeApi(object):
         path_params = {}
 
         query_params = []
-        if 'required_string_group' in local_var_params:
+        if 'required_string_group' in local_var_params and local_var_params['required_string_group'] is not None:  # noqa: E501
             query_params.append(('required_string_group', local_var_params['required_string_group']))  # noqa: E501
-        if 'required_int64_group' in local_var_params:
+        if 'required_int64_group' in local_var_params and local_var_params['required_int64_group'] is not None:  # noqa: E501
             query_params.append(('required_int64_group', local_var_params['required_int64_group']))  # noqa: E501
-        if 'string_group' in local_var_params:
+        if 'string_group' in local_var_params and local_var_params['string_group'] is not None:  # noqa: E501
             query_params.append(('string_group', local_var_params['string_group']))  # noqa: E501
-        if 'int64_group' in local_var_params:
+        if 'int64_group' in local_var_params and local_var_params['int64_group'] is not None:  # noqa: E501
             query_params.append(('int64_group', local_var_params['int64_group']))  # noqa: E501
 
         header_params = {}
@@ -1687,19 +1687,19 @@ class FakeApi(object):
         path_params = {}
 
         query_params = []
-        if 'pipe' in local_var_params:
+        if 'pipe' in local_var_params and local_var_params['pipe'] is not None:  # noqa: E501
             query_params.append(('pipe', local_var_params['pipe']))  # noqa: E501
             collection_formats['pipe'] = 'multi'  # noqa: E501
-        if 'ioutil' in local_var_params:
+        if 'ioutil' in local_var_params and local_var_params['ioutil'] is not None:  # noqa: E501
             query_params.append(('ioutil', local_var_params['ioutil']))  # noqa: E501
             collection_formats['ioutil'] = 'csv'  # noqa: E501
-        if 'http' in local_var_params:
+        if 'http' in local_var_params and local_var_params['http'] is not None:  # noqa: E501
             query_params.append(('http', local_var_params['http']))  # noqa: E501
             collection_formats['http'] = 'space'  # noqa: E501
-        if 'url' in local_var_params:
+        if 'url' in local_var_params and local_var_params['url'] is not None:  # noqa: E501
             query_params.append(('url', local_var_params['url']))  # noqa: E501
             collection_formats['url'] = 'csv'  # noqa: E501
-        if 'context' in local_var_params:
+        if 'context' in local_var_params and local_var_params['context'] is not None:  # noqa: E501
             query_params.append(('context', local_var_params['context']))  # noqa: E501
             collection_formats['context'] = 'multi'  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -331,7 +331,7 @@ class PetApi(object):
         path_params = {}
 
         query_params = []
-        if 'status' in local_var_params:
+        if 'status' in local_var_params and local_var_params['status'] is not None:  # noqa: E501
             query_params.append(('status', local_var_params['status']))  # noqa: E501
             collection_formats['status'] = 'csv'  # noqa: E501
 
@@ -440,7 +440,7 @@ class PetApi(object):
         path_params = {}
 
         query_params = []
-        if 'tags' in local_var_params:
+        if 'tags' in local_var_params and local_var_params['tags'] is not None:  # noqa: E501
             query_params.append(('tags', local_var_params['tags']))  # noqa: E501
             collection_formats['tags'] = 'csv'  # noqa: E501
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -646,9 +646,9 @@ class UserApi(object):
         path_params = {}
 
         query_params = []
-        if 'username' in local_var_params:
+        if 'username' in local_var_params and local_var_params['username'] is not None:  # noqa: E501
             query_params.append(('username', local_var_params['username']))  # noqa: E501
-        if 'password' in local_var_params:
+        if 'password' in local_var_params and local_var_params['password'] is not None:  # noqa: E501
             query_params.append(('password', local_var_params['password']))  # noqa: E501
 
         header_params = {}


### PR DESCRIPTION
If we send None for a non mandatory query parameter. OpenAPIGenerator now makes the URL something like `?query=None` this should not be passed as the string None rather should be ignored as None is a special keyword

If the user passes the query as "None" (Str) only then url should be considered as `?query=None`

fixes https://github.com/OpenAPITools/openapi-generator/issues/4151

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before .
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
