### PR TITLE
[C++] Enable Qt5 Petstore tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,16 +94,11 @@ before_install:
   # - Rely on `kerl` for [pre-compiled versions available](https://docs.travis-ci.com/user/languages/erlang#Choosing-OTP-releases-to-test-against). Rely on installation path chosen by [`travis-erlang-builder`](https://github.com/travis-ci/travis-erlang-builder/blob/e6d016b1a91ca7ecac5a5a46395bde917ea13d36/bin/compile#L18).
   # - . ~/otp/18.2.1/activate && erl -version
   #- curl -f -L -o ./rebar3 https://s3.amazonaws.com/rebar3/rebar3 && chmod +x ./rebar3 && ./rebar3 version && export PATH="${TRAVIS_BUILD_DIR}:$PATH"
-  # install valgrind for C++ memory test
-  - sudo apt-get install valgrind
-  # install Qt 5.10
-  # comment out the following due to failure in downloading http://ppa.launchpad.net/beineri/opt-qt-5.10.1-trusty/ubuntu/dists/xenial/main/binary-amd64/Packages
-  #- sudo add-apt-repository --yes ppa:beineri/opt-qt-5.10.1-trusty
-  #- sudo apt-get update -qq
-  #- sudo apt-get install qt510-meta-minimal
-  #- source /opt/qt510/bin/qt510-env.sh
-  #- qmake -v
-
+  # install C++ tools 
+  - sudo apt install -y --no-install-recommends valgrind cmake build-essential 
+  # install Qt5
+  - sudo apt install -y --no-install-recommends qt5-default 
+  - cmake --version
   # show host table to confirm petstore.swagger.io is mapped to localhost
   - cat /etc/hosts
   # show java version

--- a/pom.xml
+++ b/pom.xml
@@ -1037,7 +1037,7 @@
                 <module>samples/server/petstore/python-aiohttp</module>
                 <!-- clients -->
                 <module>samples/client/petstore/c</module>
-                <!-- <module>samples/client/petstore/cpp-qt5</module> -->
+                <module>samples/client/petstore/cpp-qt5</module>
                 <module>samples/client/petstore/elm-0.18</module>
                 <module>samples/client/petstore/rust</module>
                 <!--<module>samples/client/petstore/perl</module>-->

--- a/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
@@ -3,12 +3,6 @@
 #include <QTest>
 #include <QTimer>
 
-OAIPetApi* PetApiTests::getApi() {
-    auto api = new OAIPetApi();
-    api->setHost("http://petstore.swagger.io");
-    return api;
-}
-
 OAIPet PetApiTests::createRandomPet() {
     OAIPet pet;
     qint64 id = QDateTime::currentMSecsSinceEpoch();
@@ -19,11 +13,12 @@ OAIPet PetApiTests::createRandomPet() {
 }
 
 void PetApiTests::findPetsByStatusTest() {
-    OAIPetApi* api = getApi();
+    OAIPetApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool petFound = false;
 
-    connect(api, &OAIPetApi::findPetsByStatusSignal, [&](QList<OAIPet> pets) {
+    connect(&api, &OAIPetApi::findPetsByStatusSignal, [&](QList<OAIPet> pets) {
         petFound = true;
         foreach(OAIPet pet, pets) {
             QVERIFY(pet.getStatus().startsWith("available") || pet.getStatus().startsWith("sold"));
@@ -31,19 +26,19 @@ void PetApiTests::findPetsByStatusTest() {
         loop.quit();
     });
 
-    api->findPetsByStatus({"available", "sold"});
+    api.findPetsByStatus({"available", "sold"});
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petFound, "didn't finish within timeout");
-    delete api;
 }
 
 void PetApiTests::createAndGetPetTest() {
-    OAIPetApi* api = getApi();
+    OAIPetApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool petCreated = false;
 
-    connect(api, &OAIPetApi::addPetSignal, [&]() {
+    connect(&api, &OAIPetApi::addPetSignal, [&]() {
         // pet created
         petCreated = true;
         loop.quit();
@@ -52,30 +47,30 @@ void PetApiTests::createAndGetPetTest() {
     OAIPet pet = createRandomPet();
     qint64 id = pet.getId();
 
-    api->addPet(pet);
+    api.addPet(pet);
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petCreated, "didn't finish within timeout");
 
     bool petFetched = false;
 
-    connect(api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
+    connect(&api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
         QVERIFY(pet.getId() > 0);
         QVERIFY(pet.getStatus().compare("freaky") == 0);
         loop.quit();
         petFetched = true;
     });
 
-    api->getPetById(id);
+    api.getPetById(id);
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petFetched, "didn't finish within timeout");
 
-    delete api;
 }
 
 void PetApiTests::updatePetTest() {
-    OAIPetApi* api = getApi();
+    OAIPetApi api;
+    api.setHost(PetStoreHost);
 
     OAIPet pet = createRandomPet();
     OAIPet petToCheck;
@@ -83,13 +78,13 @@ void PetApiTests::updatePetTest() {
     QEventLoop loop;
     bool petAdded = false;
 
-    connect(api, &OAIPetApi::addPetSignal, [&](){
+    connect(&api, &OAIPetApi::addPetSignal, [&](){
         petAdded = true;
         loop.quit();
     });
 
     // create pet
-    api->addPet(pet);
+    api.addPet(pet);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petAdded, "didn't finish within timeout");
@@ -97,50 +92,49 @@ void PetApiTests::updatePetTest() {
     // fetch it
 
     bool petFetched = false;
-    connect(api, &OAIPetApi::getPetByIdSignal, this, [&](OAIPet pet) {
+    connect(&api, &OAIPetApi::getPetByIdSignal, this, [&](OAIPet pet) {
             petFetched = true;
             petToCheck = pet;
             loop.quit();
     });
 
     // create pet
-    api->getPetById(id);
+    api.getPetById(id);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petFetched, "didn't finish within timeout");
 
     // update it
     bool petUpdated = false;
-    connect(api, &OAIPetApi::updatePetSignal, [&]() {
+    connect(&api, &OAIPetApi::updatePetSignal, [&]() {
         petUpdated = true;
         loop.quit();
     });
 
     // update pet
     petToCheck.setStatus(QString("scary"));
-    api->updatePet(petToCheck);
+    api.updatePet(petToCheck);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petUpdated, "didn't finish within timeout");
 
     // check it
     bool petFetched2 = false;
-    connect(api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
+    connect(&api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
         petFetched2 = true;
         QVERIFY(pet.getId() == petToCheck.getId());
         QVERIFY(pet.getStatus().compare(petToCheck.getStatus()) == 0);
         loop.quit();
     });
-    api->getPetById(id);
+    api.getPetById(id);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petFetched2, "didn't finish within timeout");
-
-    delete api;
 }
 
 void PetApiTests::updatePetWithFormTest() {
-    OAIPetApi* api = getApi();
+    OAIPetApi api;
+    api.setHost(PetStoreHost);
 
     OAIPet pet = createRandomPet();
     OAIPet petToCheck;
@@ -149,54 +143,52 @@ void PetApiTests::updatePetWithFormTest() {
 
     // create pet
     bool petAdded = false;
-    connect(api, &OAIPetApi::addPetSignal, [&](){
+    connect(&api, &OAIPetApi::addPetSignal, [&](){
         petAdded = true;
         loop.quit();
     });
 
-    api->addPet(pet);
+    api.addPet(pet);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petAdded, "didn't finish within timeout");
 
     // fetch it
     bool petFetched = false;
-    connect(api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
+    connect(&api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
         petFetched = true;
         petToCheck = pet;
         loop.quit();
     });
 
-    api->getPetById(id);
+    api.getPetById(id);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petFetched, "didn't finish within timeout");
 
     // update it
     bool petUpdated = false;
-    connect(api, &OAIPetApi::updatePetWithFormSignal, [&](){
+    connect(&api, &OAIPetApi::updatePetWithFormSignal, [&](){
         petUpdated = true;
         loop.quit();
     });
 
     QString name("gorilla");
-    api->updatePetWithForm(id, name, nullptr);
+    api.updatePetWithForm(id, name, nullptr);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petUpdated, "didn't finish within timeout");
 
     // fetch it
     bool petUpdated2 = false;
-    connect(api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
+    connect(&api, &OAIPetApi::getPetByIdSignal, [&](OAIPet pet) {
         petUpdated2 = true;
         QVERIFY(pet.getName().compare(QString("gorilla")) == 0);
         loop.quit();
     });
 
-    api->getPetById(id);
+    api.getPetById(id);
     QTimer::singleShot(5000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petUpdated2, "didn't finish within timeout");
-
-    delete api;
 }

--- a/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.h
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.h
@@ -7,7 +7,6 @@ using namespace OpenAPI;
 class PetApiTests: public QObject {
     Q_OBJECT
 
-    OAIPetApi* getApi();
     OAIPet createRandomPet();
 
 private slots:
@@ -15,4 +14,6 @@ private slots:
     void createAndGetPetTest();
     void updatePetTest();
     void updatePetWithFormTest();
+private:
+    const QString PetStoreHost = QStringLiteral("http://petstore.swagger.io");
 };

--- a/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.cpp
@@ -4,25 +4,20 @@
 #include <QTimer>
 #include <QDebug>
 
-OAIStoreApi* StoreApiTests::getApi() {
-    auto api = new OAIStoreApi();
-    api->setHost("http://petstore.swagger.io");
-    return api;
-}
-
 void StoreApiTests::placeOrderTest() {
-    auto api = getApi();
+    OAIStoreApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool orderPlaced = false;
 
-    connect(api, &OAIStoreApi::placeOrderSignal, [&](OAIOrder order) {
+    connect(&api, &OAIStoreApi::placeOrderSignal, [&](OAIOrder order) {
         orderPlaced = true;
         QVERIFY(order.getPetId() == 10000);
         QVERIFY((order.getId() == 500));
         qDebug() << order.getShipDate();
         loop.quit();
     });
-    connect(api, &OAIStoreApi::placeOrderSignalE, [&](){
+    connect(&api, &OAIStoreApi::placeOrderSignalE, [&](){
         QFAIL("shouldn't trigger error");
         loop.quit();
     });
@@ -34,20 +29,20 @@ void StoreApiTests::placeOrderTest() {
     order.setComplete(false);
     order.setStatus("shipping");
     order.setShipDate(QDateTime::currentDateTime());
-    api->placeOrder(order);
+    api.placeOrder(order);
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(orderPlaced, "didn't finish within timeout");
 
-    delete api;
 }
 
 void StoreApiTests::getOrderByIdTest() {
-    auto api = getApi();
+    OAIStoreApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool orderFetched = false;
 
-    connect(api, &OAIStoreApi::getOrderByIdSignal, [&](OAIOrder order) {
+    connect(&api, &OAIStoreApi::getOrderByIdSignal, [&](OAIOrder order) {
         orderFetched = true;
         QVERIFY(order.getPetId() == 10000);
         QVERIFY((order.getId() == 500));
@@ -55,20 +50,20 @@ void StoreApiTests::getOrderByIdTest() {
         loop.quit();
     });
 
-    api->getOrderById(500);
+    api.getOrderById(500);
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(orderFetched, "didn't finish within timeout");
 
-    delete api;
 }
 
 void StoreApiTests::getInventoryTest() {
-    auto api = getApi();
+    OAIStoreApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool inventoryFetched = false;
 
-    connect(api, &OAIStoreApi::getInventorySignal, [&](QMap<QString, qint32> status) {
+    connect(&api, &OAIStoreApi::getInventorySignal, [&](QMap<QString, qint32> status) {
         inventoryFetched = true;
         for(const auto& key : status.keys()) {
             qDebug() << (key) << " Quantities " << status.value(key);
@@ -76,10 +71,9 @@ void StoreApiTests::getInventoryTest() {
         loop.quit();
     });
 
-    api->getInventory();
+    api.getInventory();
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(inventoryFetched, "didn't finish within timeout");
 
-    delete api;
 }

--- a/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.h
+++ b/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.h
@@ -7,10 +7,10 @@ using namespace OpenAPI;
 class StoreApiTests: public QObject {
     Q_OBJECT
 
-    OAIStoreApi* getApi();
-
 private slots:
     void placeOrderTest();
     void getOrderByIdTest();
     void getInventoryTest();
+private:
+    const QString PetStoreHost = QStringLiteral("http://petstore.swagger.io");
 };

--- a/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.cpp
@@ -4,12 +4,6 @@
 #include <QTimer>
 #include <QDebug>
 
-OAIUserApi* UserApiTests::getApi() {
-    auto api = new OAIUserApi();
-    api->setHost("http://petstore.swagger.io");
-    return api;
-}
-
 OAIUser UserApiTests::createRandomUser() {
     OAIUser user;
     user.setId(QDateTime::currentMSecsSinceEpoch());
@@ -24,29 +18,29 @@ OAIUser UserApiTests::createRandomUser() {
 }
 
 void UserApiTests::createUserTest(){
-    auto api = getApi();
+    OAIUserApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userCreated = false;
 
-    connect(api, &OAIUserApi::createUserSignal, [&](){
+    connect(&api, &OAIUserApi::createUserSignal, [&](){
             userCreated = true;
             loop.quit();
     });
 
-    api->createUser(createRandomUser());
+    api.createUser(createRandomUser());
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(userCreated, "didn't finish within timeout");
-
-    delete api;
 }
 
 void UserApiTests::createUsersWithArrayInputTest(){
-    auto api = getApi();
+    OAIUserApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool usersCreated = false;
 
-    connect(api, &OAIUserApi::createUsersWithArrayInputSignal, [&](){
+    connect(&api, &OAIUserApi::createUsersWithArrayInputSignal, [&](){
             usersCreated = true;
             loop.quit();
     });
@@ -55,20 +49,19 @@ void UserApiTests::createUsersWithArrayInputTest(){
     users.append(createRandomUser());
     users.append(createRandomUser());
     users.append(createRandomUser());
-    api->createUsersWithArrayInput(users);
+    api.createUsersWithArrayInput(users);
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(usersCreated, "didn't finish within timeout");
-
-    delete api;
 }
 
 void UserApiTests::createUsersWithListInputTest(){
-    auto api = getApi();
+    OAIUserApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool usersCreated = false;
 
-    connect(api, &OAIUserApi::createUsersWithListInputSignal, [&](){
+    connect(&api, &OAIUserApi::createUsersWithListInputSignal, [&](){
             usersCreated = true;
             loop.quit();
     });
@@ -81,105 +74,98 @@ void UserApiTests::createUsersWithListInputTest(){
     users.append(johndoe);
     users.append(rambo);
     users.append(createRandomUser());
-    api->createUsersWithListInput(users);
+    api.createUsersWithListInput(users);
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(usersCreated, "didn't finish within timeout");
-
-    delete api;
 }
 
 void UserApiTests::deleteUserTest(){
-    auto api = getApi();
+    OAIUserApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userDeleted = false;
 
-    connect(api, &OAIUserApi::deleteUserSignal, [&](){
+    connect(&api, &OAIUserApi::deleteUserSignal, [&](){
             userDeleted = true;
             loop.quit();
     });
 
-    api->deleteUser("rambo");
+    api.deleteUser("rambo");
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(userDeleted, "didn't finish within timeout");
-
-    delete api;
 }
 
 void UserApiTests::getUserByNameTest(){
-    auto api = getApi();
+    OAIUserApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userFetched = false;
 
-    connect(api, &OAIUserApi::getUserByNameSignal, [&](OAIUser summary) {
+    connect(&api, &OAIUserApi::getUserByNameSignal, [&](OAIUser summary) {
         userFetched = true;
         qDebug() << summary.getUsername();
         QVERIFY(summary.getUsername() == "johndoe");
         loop.quit();
     });
 
-    api->getUserByName("johndoe");
+    api.getUserByName("johndoe");
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(userFetched, "didn't finish within timeout");
-
-    delete api;
 }
 
 void UserApiTests::loginUserTest(){
-    auto api = getApi();
+    OAIUserApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userLogged = false;
 
-    connect(api, &OAIUserApi::loginUserSignal, [&](QString summary) {
+    connect(&api, &OAIUserApi::loginUserSignal, [&](QString summary) {
         userLogged = true;
         qDebug() << summary;
         loop.quit();
     });
 
-    api->loginUser("johndoe", "123456789");
+    api.loginUser("johndoe", "123456789");
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(userLogged, "didn't finish within timeout");
-
-    delete api;
 }
 
 void UserApiTests::logoutUserTest(){
-    auto api = getApi();
+    OAIUserApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userLoggedOut = false;
 
-    connect(api, &OAIUserApi::logoutUserSignal, [&](){
+    connect(&api, &OAIUserApi::logoutUserSignal, [&](){
         userLoggedOut = true;
         loop.quit();
     });
 
-    api->logoutUser();
+    api.logoutUser();
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(userLoggedOut, "didn't finish within timeout");
-
-    delete api;
 }
 
 void UserApiTests::updateUserTest(){
-    auto api = getApi();
+    OAIUserApi api;
+    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userUpdated = false;
 
-    connect(api, &OAIUserApi::updateUserSignal, [&]() {
+    connect(&api, &OAIUserApi::updateUserSignal, [&]() {
             userUpdated = true;
             loop.quit();
     });
 
     auto johndoe = createRandomUser();
     johndoe.setUsername("johndoe");
-    api->updateUser("johndoe", johndoe);
+    api.updateUser("johndoe", johndoe);
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(userUpdated, "didn't finish within timeout");
-
-    delete api;
 }

--- a/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.h
+++ b/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.h
@@ -7,7 +7,6 @@ using namespace OpenAPI;
 class UserApiTests: public QObject {
     Q_OBJECT
 
-    OAIUserApi* getApi();
     OAIUser createRandomUser();
 
 private slots:
@@ -19,4 +18,6 @@ private slots:
     void loginUserTest();
     void logoutUserTest();
     void updateUserTest();
+private:
+    const QString PetStoreHost = QStringLiteral("http://petstore.swagger.io");
 };

--- a/samples/client/petstore/cpp-qt5/build-and-test.bash
+++ b/samples/client/petstore/cpp-qt5/build-and-test.bash
@@ -1,42 +1,48 @@
 #!/bin/bash
 
 set -e
+# export RUN_VALGRIND_TESTS=TRUE
 
 mkdir -p build
 cd build
 
-qmake ../PetStore/PetStore.pro CONFIG+=debug
+cmake ..
 
 make
 
-valgrind --leak-check=full ./PetStore |& tee result.log || exit 1
-
-echo "Make sure the tests are launched:"
-testCount=$(cat result.log | grep 'Finished testing of' | wc -l)
-if [ $testCount == 3 ]
-then
-  echo "Ok"
+if [[ -z "${RUN_VALGRIND_TESTS}" ]]; then
+    echo "Running Qt5 Petstore Tests"
+    ./cpp-qt5-petstore
 else
-  echo "The tests were not run!!!"
-  exit 1
+  echo "Running Qt5 Petstore Tests with Valgrind"
+  valgrind --leak-check=full ./cpp-qt5-petstore |& tee result.log || exit 1
+  testCount=$(cat result.log | grep 'Finished testing of' | wc -l)
+  if [ $testCount == 3 ]
+  then
+    echo "Ok"
+  else
+    echo "The tests were not run!!!"
+    exit 1
+  fi
+
+  echo "Make sure the tests passed:"
+  successCount=$(cat result.log | grep '0 failed' | wc -l)
+  if [ $successCount == 3 ]
+  then
+    echo "Ok"
+  else
+    echo "The tests failed!!!"
+    exit 1
+  fi
+
+  echo "Check if no memory leaks occured:"
+  leakCount=$(cat result.log | grep 'lost: 0 bytes in 0 blocks' | wc -l)
+  if [ $leakCount == 3 ]
+  then
+    echo "Ok"
+  else
+    echo "There was memory leaks!!!"
+    exit 1
+  fi
 fi
 
-echo "Make sure the tests passed:"
-successCount=$(cat result.log | grep '0 failed' | wc -l)
-if [ $successCount == 3 ]
-then
-  echo "Ok"
-else
-  echo "The tests failed!!!"
-  exit 1
-fi
-
-echo "Check if no memory leaks occured:"
-leakCount=$(cat result.log | grep 'lost: 0 bytes in 0 blocks' | wc -l)
-if [ $leakCount == 3 ]
-then
-  echo "Ok"
-else
-  echo "There was memory leaks!!!"
-  exit 1
-fi


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before .
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


Fixes #4098

@stkrwork @MartinDelille @muttleyxd @ravinikam 
@wing328 