### PR TITLE
Support labeling changes which affect all typescript generators with [typescript] (only) in title

### DIFF
--- a/.github/.test/samples.json
+++ b/.github/.test/samples.json
@@ -134,7 +134,7 @@
       ]
     },
     {
-      "input": "csharp-refactor-petstore.sh",
+      "input": "csharp-netcore-petstore.sh",
       "matches": [
         "Client: C-Sharp"
       ]
@@ -218,7 +218,7 @@
       ]
     },
     {
-      "input": "finch-petstore-server.sh",
+      "input": "scala-finch-petstore-server.sh",
       "matches": [
         "Server: Scala"
       ]
@@ -260,7 +260,7 @@
       ]
     },
     {
-      "input": "graphql-server-petstore.sh",
+      "input": "graphql-nodejs-express-server.sh",
       "matches": [
         "Server: GraphQL"
       ]
@@ -825,13 +825,13 @@
       ]
     },
     {
-      "input": "python-flask-petstore-python2.sh",
+      "input": "python-server-flask-petstore-python2.sh",
       "matches": [
         "Server: Python"
       ]
     },
     {
-      "input": "python-flask-petstore.sh",
+      "input": "python-server-flask-petstore.sh",
       "matches": [
         "Server: Python"
       ]
@@ -874,12 +874,6 @@
     },
     {
       "input": "rust-petstore.sh",
-      "matches": [
-        "Client: Rust"
-      ]
-    },
-    {
-      "input": "rust-reqwest-petstore.sh",
       "matches": [
         "Client: Rust"
       ]
@@ -1310,6 +1304,72 @@
       "input": "[announcement] Release 2.0",
       "matches": [
         "Announcement"
+      ]
+    },
+    {
+      "input": "[typescript] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
+      ]
+    },
+    {
+      "input": "[typescript] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
+      ]
+    },
+    {
+      "input": "[typescript-angular] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
+      ]
+    },
+    {
+      "input": "[typescript-angularjs] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
+      ]
+    },
+    {
+      "input": "[typescript-aurelia] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
+      ]
+    },
+    {
+      "input": "[typescript-axios] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
+      ]
+    },
+    {
+      "input": "[typescript-fetch] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
+      ]
+    },
+    {
+      "input": "[typescript-inversify] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
+      ]
+    },
+    {
+      "input": "[typescript-jquery] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
+      ]
+    },
+    {
+      "input": "[typescript-node] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
+      ]
+    },
+    {
+      "input": "[typescript-rxjs] Generic typescript text",
+      "matches": [
+        "Client: TypeScript"
       ]
     }
   ]

--- a/.github/.test/samples.json
+++ b/.github/.test/samples.json
@@ -1371,6 +1371,10 @@
       "matches": [
         "Client: TypeScript"
       ]
+    },
+    {
+      "input": "Should not auto-label for typescript outside of brackets.",
+      "matches": []
     }
   ]
 }

--- a/.github/auto-labeler.yml
+++ b/.github/auto-labeler.yml
@@ -138,6 +138,7 @@ labels:
       - '\s*?-[gl] swift[34]+\s*?'
       - '\s*?-[gl] swift2-deprecated\s*?'
     'Client: TypeScript':
+      - '\s*?\[typescript\]\s*?'
       - '\s*?\[typescript-[\-a-z]+\]\s*?'
       - '\s*?-[gl] typescript-[\-a-z]+\s*?'
     # 'Client: VB/VB.net': # NOTE: Not yet implemented


### PR DESCRIPTION
Per comment (https://github.com/OpenAPITools/openapi-generator/issues/802#issuecomment-543615003) from #802, this adds support for "generic" changes for all typescript generators.

Rather than `[typescript-angular]` or any other generator-specific tag, you can use just `[typescript]`.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before .
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
