### PR TITLE
java: allow aliased types to have custom mappings

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1666,7 +1666,11 @@ public class DefaultCodegen implements CodegenConfig {
      * @return The alias of the given type, if it exists. If there is no alias
      * for this type, then returns the input type name.
      */
-    public String getAlias(String name) {
+    private String getAlias(String name) {
+        if (typeMapping != null && typeMapping.containsKey(name)) {
+            // allow aliased types to have custom mappings, the mapping will be resolved later
+            return name;
+        }
         if (typeAliases != null && typeAliases.containsKey(name)) {
             return typeAliases.get(name);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
@@ -207,14 +207,6 @@ public abstract class AbstractApexCodegen extends DefaultCodegen implements Code
     }
 
     @Override
-    public String getAlias(String name) {
-        if (typeAliases != null && typeAliases.containsKey(name)) {
-            return typeAliases.get(name);
-        }
-        return name;
-    }
-
-    @Override
     public String toDefaultValue(Schema p) {
         if (ModelUtils.isArraySchema(p)) {
             final ArraySchema ap = (ArraySchema) p;
@@ -399,8 +391,6 @@ public abstract class AbstractApexCodegen extends DefaultCodegen implements Code
     @Override
     public String getSchemaType(Schema p) {
         String schemaType = super.getSchemaType(p);
-
-        schemaType = getAlias(schemaType);
 
         // don't apply renaming on types from the typeMapping
         if (typeMapping.containsKey(schemaType)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -704,6 +704,10 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
     @Override
     public String getAlias(String name) {
+        if (typeMapping != null && typeMapping.containsKey(name)) {
+            // allow aliased types to have custom mappings, the mapping will be resolved later
+            return name;
+        }
         if (typeAliases != null && typeAliases.containsKey(name)) {
             return typeAliases.get(name);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -703,18 +703,6 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     }
 
     @Override
-    public String getAlias(String name) {
-        if (typeMapping != null && typeMapping.containsKey(name)) {
-            // allow aliased types to have custom mappings, the mapping will be resolved later
-            return name;
-        }
-        if (typeAliases != null && typeAliases.containsKey(name)) {
-            return typeAliases.get(name);
-        }
-        return name;
-    }
-
-    @Override
     public String toDefaultValue(Schema p) {
         p = ModelUtils.getReferencedSchema(this.openAPI, p);
         if (ModelUtils.isArraySchema(p)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaPlayFrameworkServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaPlayFrameworkServerCodegen.java
@@ -284,7 +284,6 @@ public class ScalaPlayFrameworkServerCodegen extends AbstractScalaCodegen implem
     @Override
     public String getSchemaType(Schema p) {
         String openAPIType = super.getSchemaType(p);
-        openAPIType = getAlias(openAPIType);
 
         // don't apply renaming on types from the typeMapping
         if (typeMapping.containsKey(openAPIType)) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -30,6 +30,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.util.HashMap;
 
 public class AbstractJavaCodegenTest {
 
@@ -53,6 +54,15 @@ public class AbstractJavaCodegenTest {
     public void toModelNameShouldUseProvidedMapping() throws Exception {
         fakeJavaCodegen.importMapping().put("json_myclass", "com.test.MyClass");
         Assert.assertEquals("com.test.MyClass", fakeJavaCodegen.toModelName("json_myclass"));
+    }
+
+    @Test
+    public void aliasedTypeCanHaveCustomMapping() throws Exception {
+        final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+        Schema schema = new ObjectSchema().type("customtype");
+        codegen.addTypeAlias("customtype", "string");
+        codegen.typeMapping().put("customtype", "my.CustomType");
+        Assert.assertEquals("my.CustomType", codegen.getSchemaType(schema));
     }
 
     @Test
@@ -402,6 +412,13 @@ public class AbstractJavaCodegenTest {
          */
         public String getArtifactVersion() {
             return this.artifactVersion;
+        }
+
+        private void addTypeAlias(String name, String alias) {
+            if (typeAliases == null) {
+                typeAliases = new HashMap<>();
+            }
+            typeAliases.put(name, alias);
         }
     }
 }


### PR DESCRIPTION
~Fixes #2858.~ UPDATE: I was wrong and misundertood the code, this PR does not fix the issue, but https://github.com/OpenAPITools/openapi-generator/pull/4182#issuecomment-546092134 discusses an alternative on how to accomplish the same. I'd still consider the original issue to be a bug, it should be possible to define type mappings for any type definition in the spec.

This will allow `kubernetes-client-java` to switch to openapi-generator (kubernetes-client/java#709).

The kubernetes API swagger spec has types aliased to primitive types, e.g.: 

```
    "intstr.IntOrString": {
      "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
      "format": "int-or-string",
      "type": "string"
    },
```

However, these types need to be mapped to custom types in the Java client, so we can have custom serialization for them. The generator is being invoked with the following options:

```
  <type-mappings>intstr.IntOrString=IntOrString,resource.Quantity=Quantity</type-mappings>
  <import-mappings>IntOrString=io.kubernetes.client.custom.IntOrString,Quantity=io.kubernetes.client.custom.Quantity</import-mappings>
```

Without changes in this PR, `type-mappings` gets ignored, since `IntOrString` is first resolved to its alias (`string`), before mappings are evaluated.

cc @wing328 @brendandburns @yue9944882 