### PR TITLE
[go-server] Return Router interface from controller constructor.

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -15,7 +15,7 @@ type {{classname}}Controller struct {
 }
 
 // New{{classname}}Controller creates a default api controller
-func New{{classname}}Controller(s {{classname}}Servicer) {{classname}}Router {
+func New{{classname}}Controller(s {{classname}}Servicer) Router {
 	return &{{classname}}Controller{ service: s }
 }
 

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -23,7 +23,7 @@ type PetApiController struct {
 }
 
 // NewPetApiController creates a default api controller
-func NewPetApiController(s PetApiServicer) PetApiRouter {
+func NewPetApiController(s PetApiServicer) Router {
 	return &PetApiController{ service: s }
 }
 

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -23,7 +23,7 @@ type StoreApiController struct {
 }
 
 // NewStoreApiController creates a default api controller
-func NewStoreApiController(s StoreApiServicer) StoreApiRouter {
+func NewStoreApiController(s StoreApiServicer) Router {
 	return &StoreApiController{ service: s }
 }
 

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -23,7 +23,7 @@ type UserApiController struct {
 }
 
 // NewUserApiController creates a default api controller
-func NewUserApiController(s UserApiServicer) UserApiRouter {
+func NewUserApiController(s UserApiServicer) Router {
 	return &UserApiController{ service: s }
 }
 


### PR DESCRIPTION
Update the go server api controller template to return the Router interface instead of the api specific router.
The Router interface type has the Routes function, which is what the generated `NewRouter` function needs. (not the api specific interface).

The change added in https://github.com/OpenAPITools/openapi-generator/pull/4038 would cause the following error since it was working with the wrong interface type 
```
./main.go:38:36: cannot use PetApiController (type petstoreserver.PetApiRouter) as type petstoreserver.Router in argument to petstoreserver.NewRouter:
        petstoreserver.PetApiRouter does not implement petstoreserver.Router (missing Routes method)
```

@antihax @bvwells @grokify @kemokemo @bkabrda


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before .
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
