### PR TITLE
fix(dart-dio): enum class generation is not implemented

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -38,6 +38,7 @@ import java.util.Set;
 
 import io.swagger.v3.oas.models.media.Schema;
 
+import static org.openapitools.codegen.utils.StringUtils.camelize;
 import static org.openapitools.codegen.utils.StringUtils.underscore;
 
 public class DartDioClientCodegen extends DartClientCodegen {
@@ -61,7 +62,6 @@ public class DartDioClientCodegen extends DartClientCodegen {
     private static final String SERIALIZATION_JSON = "json";
 
     private boolean nullableFields = true;
-    private String serialization = SERIALIZATION_JSON;
 
     public DartDioClientCodegen() {
         super();
@@ -100,6 +100,32 @@ public class DartDioClientCodegen extends DartClientCodegen {
             return "const []";
         }
         return super.toDefaultValue(p);
+    }
+
+    @Override
+    public String escapeReservedWord(String name) {
+        if (this.reservedWordsMappings().containsKey(name)) {
+            return this.reservedWordsMappings().get(name);
+        }
+        return "_" + name;
+    }
+
+    @Override
+    public String toEnumVarName(String name, String datatype) {
+        if (name.length() == 0) {
+            return "empty";
+        }
+        if ("number".equalsIgnoreCase(datatype) ||
+            "int".equalsIgnoreCase(datatype)) {
+            name = "Number" + name;
+        }
+        name = camelize(name, true);
+
+        // for reserved word or word starting with number, append _
+        if (isReservedWord(name) || name.matches("^\\d.*")) {
+            name = escapeReservedWord(name);
+        }
+        return name;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
@@ -15,7 +15,7 @@ abstract class {{classname}} implements Built<{{classname}}, {{classname}}Builde
     @BuiltValueField(wireName: '{{baseName}}')
     {{{dataType}}} get {{name}};
     {{#allowableValues}}
-        {{#min}} // range from {{min}} to {{max}}{{/min}}//{{^min}}enum {{name}}Enum { {{#values}} {{.}}, {{/values}} };{{/min}}{
+        {{#min}} // range from {{min}} to {{max}}{{/min}}//{{^min}}enum {{name}}Enum { {{#values}} {{.}}, {{/values}} };{{/min}}
     {{/allowableValues}}
 {{/vars}}
 

--- a/modules/openapi-generator/src/main/resources/dart-dio/enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/enum.mustache
@@ -1,36 +1,34 @@
-@Entity()
-class {{classname}} {
-  /// The underlying value of this enum member.
-  final {{dataType}} value;
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
 
-  const {{classname}}._internal(this.value);
+part '{{classFilename}}.g.dart';
+
+class {{classname}} extends EnumClass {
 
   {{#allowableValues}}
     {{#enumVars}}
       {{#description}}
   /// {{description}}
       {{/description}}
-  static const {{classname}} {{{name}}} = const {{classname}}._internal({{{value}}});
+  @BuiltValueEnumConst(wireName: '{{name}}')
+  static const {{classname}} {{name}} = _${{name}};
     {{/enumVars}}
   {{/allowableValues}}
+
+
+  static Serializer<{{classname}}> get serializer => _${{classVarName}}Serializer;
+
+  const {{classname}}._(String name): super(name);
+
+  static BuiltSet<{{classname}}> get values => _$values;
+  static {{classname}} valueOf(String name) => _$valueOf(name);
 }
 
-class {{classname}}TypeTransformer extends TypeTransformer<{{classname}}> {
-
-  @override
-  dynamic encode({{classname}} data) {
-    return data.value;
-  }
-
-  @override
-  {{classname}} decode(dynamic data) {
-    switch (data) {
-      {{#allowableValues}}
-        {{#enumVars}}
-      case {{{value}}}: return {{classname}}.{{{name}}};
-        {{/enumVars}}
-      {{/allowableValues}}
-      default: throw('Unknown enum value to decode: $data');
-    }
-  }
-}
+/// Optionally, enum_class can generate a mixin to go with your enum for use
+/// with Angular. It exposes your enum constants as getters. So, if you mix it
+/// in to your Dart component class, the values become available to the
+/// corresponding Angular template.
+///
+/// Trigger mixin generation by writing a line like this one next to your enum.
+abstract class {{classname}}Mixin = Object with _${{classname}}Mixin;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The `dart-dio` generator does not generate the `enum` class properly. The current implementation seems to be from an existing `dart` generator.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ircecho (2017/07) @swipesight (2018/09) @jaumard (2018/09) @nickmeinhold (2019/09)