### PR TITLE
Remove discriminator property so it's not serialized twice in Jackson…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -601,4 +601,42 @@ public class CodegenModel {
             }
         }
     }
+
+    /**
+     * Remove the discriminator property, so it is not serialized twice
+     */
+    public void removeDiscriminatorProperty() {
+        String discriminatorName = getDiscriminatorName();
+
+        if (discriminatorName != null) {
+            removeSingleProperty(vars, discriminatorName);
+            removeSingleProperty(optionalVars, discriminatorName);
+            removeSingleProperty(requiredVars, discriminatorName);
+            removeSingleProperty(parentVars, discriminatorName);
+            removeSingleProperty(allVars, discriminatorName);
+            removeSingleProperty(readOnlyVars, discriminatorName);
+            removeSingleProperty(readWriteVars, discriminatorName);
+
+            // update property list's "hasMore"
+            updatePropertyListHasMore(vars);
+            updatePropertyListHasMore(optionalVars);
+            updatePropertyListHasMore(requiredVars);
+            updatePropertyListHasMore(parentVars);
+            updatePropertyListHasMore(allVars);
+            updatePropertyListHasMore(readOnlyVars);
+            updatePropertyListHasMore(readWriteVars);
+        }
+    }
+
+    private void removeSingleProperty(List<CodegenProperty> vars, String nameToRemove) {
+        ListIterator<CodegenProperty> iterator = vars.listIterator();
+        while (iterator.hasNext()) {
+            CodegenProperty element = iterator.next();
+
+            if (nameToRemove.equals(element.baseName)) {
+                iterator.remove();
+                break;
+            }
+        }
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -946,6 +946,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         if ("BigDecimal".equals(codegenModel.dataType)) {
             codegenModel.imports.add("BigDecimal");
         }
+        codegenModel.removeDiscriminatorProperty();
         return codegenModel;
     }
 


### PR DESCRIPTION
… serialization

Fixes issue #3796. Wasn't exactly sure the scope of languages/generators that should have this change, so I made it in AbstractJavaCodegen since that makes sense to me.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [N/A] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [N/A] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04)