### PR TITLE
Kotlin query collection format

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiAbstractions.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiAbstractions.kt.mustache
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 {{#nonPublicApi}}internal {{/nonPublicApi}}fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipes" -> "|"
-    "ssv" -> " "
+    "pipe" -> "|"
+    "space" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipes" -> "|"
-    "ssv" -> " "
+    "pipe" -> "|"
+    "space" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 internal fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipes" -> "|"
-    "ssv" -> " "
+    "pipe" -> "|"
+    "space" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipes" -> "|"
-    "ssv" -> " "
+    "pipe" -> "|"
+    "space" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipes" -> "|"
-    "ssv" -> " "
+    "pipe" -> "|"
+    "space" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipes" -> "|"
-    "ssv" -> " "
+    "pipe" -> "|"
+    "space" -> " "
     else -> ""
 }
 

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipes" -> "|"
-    "ssv" -> " "
+    "pipe" -> "|"
+    "space" -> " "
     else -> ""
 }
 

--- a/samples/openapi3/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/openapi3/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipes" -> "|"
-    "ssv" -> " "
+    "pipe" -> "|"
+    "space" -> " "
     else -> ""
 }
 

--- a/samples/openapi3/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/openapi3/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -5,8 +5,8 @@ typealias MultiValueMap = MutableMap<String,List<String>>
 fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","
     "tsv" -> "\t"
-    "pipes" -> "|"
-    "ssv" -> " "
+    "pipe" -> "|"
+    "space" -> " "
     else -> ""
 }
 


### PR DESCRIPTION
Fixes incorrect query header collection constants
    
The OpenAPI generator converts OpenAPI v2 documents into an OpenAPI v3
representation. The query parameter collection formats are squeezed
into different values from the raw OpenAPI 2 collection format values.

For example: csv -> space

See: DefaultCodegen#getCollectionFormat

To fix https://github.com/OpenAPITools/openapi-generator/issues/4285