### PR TITLE
[default codegen] #4171 - Correct parent variables being duplicated in child

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1895,6 +1895,7 @@ public class DefaultCodegen implements CodegenConfig {
 
             if (composed.getRequired() != null) {
                 required.addAll(composed.getRequired());
+                allRequired.addAll(composed.getRequired());
             }
             addVars(m, unaliasPropertySchema(properties), required, unaliasPropertySchema(allProperties), allRequired);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaInheritanceTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaInheritanceTest.java
@@ -22,9 +22,13 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Discriminator;
+import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.DefaultCodegen;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.testng.Assert;
@@ -77,5 +81,103 @@ public class JavaInheritanceTest {
         Assert.assertEquals(cm.classname, "Sample");
         Assert.assertEquals(cm.parent, "Base");
         Assert.assertEquals(cm.imports, Sets.newHashSet("Base"));
+    }
+
+    @Test(description = "composed model has the required attributes on the child")
+    public void javaInheritanceWithRequiredAttributesOnAllOfObject() {
+        Schema parent = new ObjectSchema()
+                .addProperties("a", new StringSchema())
+                .addProperties("b", new StringSchema())
+                .addRequiredItem("a")
+                .name("Parent");
+        Schema child = new ComposedSchema()
+                .addAllOfItem(new Schema().$ref("Parent"))
+                .addAllOfItem(new ObjectSchema()
+                        .addProperties("c", new StringSchema())
+                        .addProperties("d", new StringSchema())
+                        .addRequiredItem("a")
+                        .addRequiredItem("c"))
+                .name("Child");
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.getComponents().addSchemas(parent.getName(), parent);
+        openAPI.getComponents().addSchemas(child.getName(), child);
+
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final CodegenModel pm = codegen
+                .fromModel("Parent", parent);
+        final CodegenProperty propertyPA = pm.allVars.get(0);
+        Assert.assertEquals(propertyPA.name, "a");
+        Assert.assertTrue(propertyPA.required);
+        final CodegenProperty propertyPB = pm.allVars.get(1);
+        Assert.assertEquals(propertyPB.name, "b");
+        Assert.assertFalse(propertyPB.required);
+        Assert.assertEquals(pm.requiredVars.size() + pm.optionalVars.size(), pm.allVars.size());
+
+        final CodegenModel cm = codegen
+                .fromModel("Child", child);
+        final CodegenProperty propertyCA = cm.allVars.get(0);
+        Assert.assertEquals(propertyCA.name, "a");
+        Assert.assertTrue(propertyCA.required);
+        final CodegenProperty propertyCB = cm.allVars.get(1);
+        Assert.assertEquals(propertyCB.name, "b");
+        Assert.assertFalse(propertyCB.required);
+        final CodegenProperty propertyCC = cm.allVars.get(2);
+        Assert.assertEquals(propertyCC.name, "c");
+        Assert.assertTrue(propertyCC.required);
+        final CodegenProperty propertyCD = cm.allVars.get(3);
+        Assert.assertEquals(propertyCD.name, "d");
+        Assert.assertFalse(propertyCD.required);
+        Assert.assertEquals(cm.requiredVars.size() + cm.optionalVars.size(), cm.allVars.size());
+    }
+
+    @Test(description = "composed model has the required attributes for both parent & child")
+    public void javaInheritanceWithRequiredAttributesOnComposedObject() {
+        Schema parent = new ObjectSchema()
+                .addProperties("a", new StringSchema())
+                .addProperties("b", new StringSchema())
+                .addRequiredItem("a")
+                .name("Parent");
+        Schema child = new ComposedSchema()
+                .addAllOfItem(new Schema().$ref("Parent"))
+                .addAllOfItem(new ObjectSchema()
+                        .addProperties("c", new StringSchema())
+                        .addProperties("d", new StringSchema()))
+                .name("Child")
+                .addRequiredItem("a")
+                .addRequiredItem("c");
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.getComponents().addSchemas(parent.getName(), parent);
+        openAPI.getComponents().addSchemas(child.getName(), child);
+
+        final DefaultCodegen codegen = new JavaClientCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final CodegenModel pm = codegen
+                .fromModel("Parent", parent);
+        final CodegenProperty propertyPA = pm.allVars.get(0);
+        Assert.assertEquals(propertyPA.name, "a");
+        Assert.assertTrue(propertyPA.required);
+        final CodegenProperty propertyPB = pm.allVars.get(1);
+        Assert.assertEquals(propertyPB.name, "b");
+        Assert.assertFalse(propertyPB.required);
+        Assert.assertEquals(pm.requiredVars.size() + pm.optionalVars.size(), pm.allVars.size());
+
+        final CodegenModel cm = codegen
+                .fromModel("Child", child);
+        final CodegenProperty propertyCA = cm.allVars.get(0);
+        Assert.assertEquals(propertyCA.name, "a");
+        Assert.assertTrue(propertyCA.required);
+        final CodegenProperty propertyCB = cm.allVars.get(1);
+        Assert.assertEquals(propertyCB.name, "b");
+        Assert.assertFalse(propertyCB.required);
+        final CodegenProperty propertyCC = cm.allVars.get(2);
+        Assert.assertEquals(propertyCC.name, "c");
+        Assert.assertTrue(propertyCC.required);
+        final CodegenProperty propertyCD = cm.allVars.get(3);
+        Assert.assertEquals(propertyCD.name, "d");
+        Assert.assertFalse(propertyCD.required);
+        Assert.assertEquals(cm.requiredVars.size() + cm.optionalVars.size(), cm.allVars.size());
     }
 }


### PR DESCRIPTION
Related to #4171.

When a composed schema has `required` attributes, it incorrectly adds duplicate `optionalVars` from the parent which should have been in the `requiredVars` and deduplicated.

For example:
```json
{
    "Parent": {
        "required": [
            "a"
        ],
        "type": "object",
        "properties": {
            "a": {
                "type": "string"
            }
        }
    },
    "Child": {
        "required": [
            "a",
            "c"
        ],
        "type": "object",
        "allOf": [
            {
                "$ref": "#/components/schemas/Parent"
            },
            {
                "type": "object",
                "properties": {
                    "c": {
                        "type": "string"
                    }
                }
            }
        ]
    }
}
```

If a template loops required and optional properties separately it generates something like the following, where the property `c` is duplicated:
```kotlin
data class Child (
    @Json(name = "a")
    val a: kotlin.String,
    @Json(name = "c")
    val c: kotlin.String,
    @Json(name = "c")
    val c: kotlin.String? = null
)
```

The composedSchema required attributes should be added to both `required` and `allRequired` arrays.

I added tests to check both this functionality and where the child has the `required` property, not the composed model.

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Not sure who to attach to this... @wing328 