### PR TITLE
[Kotlin] Correct isInherited flag for Kotlin generators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -617,18 +617,6 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
         }
     }
 
-    // Can't figure out the logic in DefaultCodegen but optional vars are getting duplicated when there's
-    // inheritance involved. Also, isInherited doesn't seem to be getting set properly ¯\_(ツ)_/¯
-    @Override
-    public CodegenModel fromModel(String name, Schema schema) {
-        CodegenModel m = super.fromModel(name, schema);
-
-        m.optionalVars = m.optionalVars.stream().distinct().collect(Collectors.toList());
-        m.allVars.stream().filter(p -> !m.vars.contains(p)).forEach(p -> p.isInherited = true);
-
-        return m;
-    }
-
     /**
      * Output the proper model name (capitalized).
      * In case the name belongs to the TypeSystem it won't be renamed.

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -16,6 +16,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -221,10 +222,9 @@ public class AbstractKotlinCodegenTest {
                 .addAllOfItem(new Schema().$ref("Parent"))
                 .addAllOfItem(new ObjectSchema()
                         .addProperties("c", new StringSchema())
-                        .addProperties("d", new StringSchema()))
-                .name("Child")
-                .addRequiredItem("a")
-                .addRequiredItem("c");
+                        .addProperties("d", new StringSchema())
+                        .addRequiredItem("c"))
+                .name("Child");
         OpenAPI openAPI = TestUtils.createOpenAPI();
         openAPI.getComponents().addSchemas(parent.getName(), parent);
         openAPI.getComponents().addSchemas(child.getName(), child);
@@ -239,8 +239,16 @@ public class AbstractKotlinCodegenTest {
         for (CodegenProperty p : pm.requiredVars) {
             Assert.assertEquals(allVarsMap.get(p.baseName).isInherited, p.isInherited);
         }
+        Assert.assertEqualsNoOrder(
+            pm.requiredVars.stream().map(CodegenProperty::getBaseName).toArray(),
+            new String[] {"a", "c"}
+        );
         for (CodegenProperty p : pm.optionalVars) {
             Assert.assertEquals(allVarsMap.get(p.baseName).isInherited, p.isInherited);
         }
+        Assert.assertEqualsNoOrder(
+            pm.optionalVars.stream().map(CodegenProperty::getBaseName).toArray(),
+            new String[] {"b", "d"}
+        );
     }
 }


### PR DESCRIPTION
Most of the Kotlin generator templates loop `requiredVars` and `optionalVars` ([1](https://github.com/OpenAPITools/openapi-generator/blob/v4.1.3/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache#L32-L36), [2](https://github.com/OpenAPITools/openapi-generator/blob/v4.1.3/modules/openapi-generator/src/main/resources/kotlin-spring/dataClass.mustache#L11-L13)) .  Unfortunately, it looks like during the [`CodegenModel.removeAllDuplicatedProperty`](https://github.com/OpenAPITools/openapi-generator/blob/v4.1.3/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java#L527), the CodegenProperty's are all [cloned](https://github.com/OpenAPITools/openapi-generator/blob/v4.1.3/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java#L550-L552) and therefore the current implementation of only updating the `allVars` list isn't sufficient to reflect that in `requiredVars` or `optionalVars`.

All 3 lists (`allVars`, `requiredVars`, `optionalVars`) should be updated with the `isInherited` property.

Also, the `KotlinSpringServerCodegen` was doing the same thing as `AbstractKotlinCodegen` so I removed it.

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jimschubert @dr4ke616 @karismann @Zomzog