### PR TITLE
Mark Slim3 server generator as deprecated

### DIFF
--- a/bin/ci/php-slim-server-petstore.json
+++ b/bin/ci/php-slim-server-petstore.json
@@ -1,5 +1,5 @@
 {
-  "generatorName": "php-slim",
+  "generatorName": "php-slim-deprecated",
   "inputSpec": "modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml",
   "outputDir": "samples/server/petstore/php-slim",
   "templateDir": "modules/openapi-generator/src/main/resources/php-slim-server"

--- a/bin/openapi3/php-slim-server-petstore.sh
+++ b/bin/openapi3/php-slim-server-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/openapi-generator/src/main/resources/php-slim-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g php-slim -o samples/server/petstore/php-slim $@"
+ags="generate -t modules/openapi-generator/src/main/resources/php-slim-server -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -g php-slim-deprecated -o samples/server/petstore/php-slim $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/php-slim-server-petstore.sh
+++ b/bin/php-slim-server-petstore.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/openapi-generator/src/main/resources/php-slim-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g php-slim -o samples/server/petstore/php-slim $@"
+ags="generate -t modules/openapi-generator/src/main/resources/php-slim-server -i modules/openapi-generator/src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml -g php-slim-deprecated -o samples/server/petstore/php-slim $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/windows/php-slim-server-petstore.bat
+++ b/bin/windows/php-slim-server-petstore.bat
@@ -5,6 +5,6 @@ If Not Exist %executable% (
 )
 
 REM set JAVA_OPTS=%JAVA_OPTS% -Xmx1024M
-set ags=generate -i modules\openapi-generator\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -g php-slim -o samples\server\petstore\php-slim
+set ags=generate -i modules\openapi-generator\src\test\resources\2_0\petstore-with-fake-endpoints-models-for-testing.yaml -g php-slim-deprecated -o samples\server\petstore\php-slim
 
 java %JAVA_OPTS% -jar %executable% %ags%

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -103,7 +103,7 @@ The following generators are available:
 * [php-laravel](generators/php-laravel.md)  
 * [php-lumen](generators/php-lumen.md)  
 * [php-silex](generators/php-silex.md)  
-* [php-slim (deprecated)](generators/php-slim.md)  
+* [php-slim-deprecated (deprecated)](generators/php-slim-deprecated.md)  
 * [php-slim4](generators/php-slim4.md)  
 * [php-symfony](generators/php-symfony.md)  
 * [php-ze-ph](generators/php-ze-ph.md)  

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -103,7 +103,7 @@ The following generators are available:
 * [php-laravel](generators/php-laravel.md)  
 * [php-lumen](generators/php-lumen.md)  
 * [php-silex](generators/php-silex.md)  
-* [php-slim](generators/php-slim.md)  
+* [php-slim (deprecated)](generators/php-slim.md)  
 * [php-slim4](generators/php-slim4.md)  
 * [php-symfony](generators/php-symfony.md)  
 * [php-ze-ph](generators/php-ze-ph.md)  

--- a/docs/generators/php-slim-deprecated.md
+++ b/docs/generators/php-slim-deprecated.md
@@ -1,0 +1,18 @@
+---
+title: Config Options for php-slim-deprecated
+sidebar_label: php-slim-deprecated
+---
+
+| Option | Description | Values | Default |
+| ------ | ----------- | ------ | ------- |
+|sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
+|ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
+|allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
+|prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
+|modelPackage|package for generated models| |null|
+|apiPackage|package for generated api classes| |null|
+|variableNamingConvention|naming convention of variable name, e.g. camelCase.| |camelCase|
+|invokerPackage|The main namespace to use for all classes. e.g. Yay\Pets| |null|
+|packageName|The main package name for classes. e.g. GeneratedPetstore| |null|
+|srcBasePath|The directory to serve as source root.| |null|
+|artifactVersion|The version to use in the composer package version field. e.g. 1.2.3| |null|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlim4ServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlim4ServerCodegen.java
@@ -22,6 +22,8 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.meta.GeneratorMetadata;
+import org.openapitools.codegen.meta.Stability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +45,10 @@ public class PhpSlim4ServerCodegen extends PhpSlimServerCodegen {
 
     public PhpSlim4ServerCodegen() {
         super();
+
+        generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata)
+                .stability(Stability.STABLE)
+                .build();
 
         outputFolder = "generated-code" + File.separator + "slim4";
         embeddedTemplateDir = templateDir = "php-slim4-server";

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
@@ -23,6 +23,8 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.meta.GeneratorMetadata;
+import org.openapitools.codegen.meta.Stability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +47,10 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
 
     public PhpSlimServerCodegen() {
         super();
+
+        generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata)
+                .stability(Stability.DEPRECATED)
+                .build();
 
         // clear import mapping (from default generator) as slim does not use it
         // at the moment

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlimServerCodegen.java
@@ -91,12 +91,12 @@ public class PhpSlimServerCodegen extends AbstractPhpCodegen {
 
     @Override
     public String getName() {
-        return "php-slim";
+        return "php-slim-deprecated";
     }
 
     @Override
     public String getHelp() {
-        return "Generates a PHP Slim Framework server library.";
+        return "Generates a PHP Slim Framework server library. IMPORTANT NOTE: this generator (Slim 3.x)  is no longer actively maintained so please use 'php-slim4' generator instead.";
     }
 
     @Override


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Abandon Slim3 generator in favor of Slim4. #3658 
It doesn't make sense to enhance/support generator based on outdated framework.

cc @jebentier, @dkarlovi, @mandrean, @jfastnacht, @ackintosh, @renepardon
