### PR TITLE
[JS] Update package.json

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/es6/package.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/package.mustache
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "prepack": "npm run build",
-    "test": "mocha --require js:@babel/register --recursive"
+    "test": "mocha --require @babel/register --recursive"
   },
   "browser": {
     "fs": false

--- a/modules/openapi-generator/src/main/resources/Javascript/es6/package.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/es6/package.mustache
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "prepack": "npm run build",
-    "test": "mocha --compilers js:@babel/register --recursive"
+    "test": "mocha --require js:@babel/register --recursive"
   },
   "browser": {
     "fs": false

--- a/samples/client/petstore/javascript-es6/package.json
+++ b/samples/client/petstore/javascript-es6/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "prepack": "npm run build",
-    "test": "mocha --require js:@babel/register --recursive"
+    "test": "mocha --require @babel/register --recursive"
   },
   "browser": {
     "fs": false

--- a/samples/client/petstore/javascript-es6/package.json
+++ b/samples/client/petstore/javascript-es6/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "prepack": "npm run build",
-    "test": "mocha --compilers js:@babel/register --recursive"
+    "test": "mocha --require js:@babel/register --recursive"
   },
   "browser": {
     "fs": false

--- a/samples/client/petstore/javascript-promise-es6/package.json
+++ b/samples/client/petstore/javascript-promise-es6/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "prepack": "npm run build",
-    "test": "mocha --require js:@babel/register --recursive"
+    "test": "mocha --require @babel/register --recursive"
   },
   "browser": {
     "fs": false

--- a/samples/client/petstore/javascript-promise-es6/package.json
+++ b/samples/client/petstore/javascript-promise-es6/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "prepack": "npm run build",
-    "test": "mocha --compilers js:@babel/register --recursive"
+    "test": "mocha --require js:@babel/register --recursive"
   },
   "browser": {
     "fs": false

--- a/samples/openapi3/client/petstore/javascript-es6/package.json
+++ b/samples/openapi3/client/petstore/javascript-es6/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "prepack": "npm run build",
-    "test": "mocha --require js:@babel/register --recursive"
+    "test": "mocha --require @babel/register --recursive"
   },
   "browser": {
     "fs": false

--- a/samples/openapi3/client/petstore/javascript-es6/package.json
+++ b/samples/openapi3/client/petstore/javascript-es6/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "prepack": "npm run build",
-    "test": "mocha --compilers js:@babel/register --recursive"
+    "test": "mocha --require js:@babel/register --recursive"
   },
   "browser": {
     "fs": false


### PR DESCRIPTION
Fixes #4258. Update package.json and package.mustache in some js packages. TypeScript files left unchanged.

openapi-generator version 4.1.3