### PR TITLE
[JavascriptFlowtyped] Adding parent flow type to child type using "& ParentType" to allow flow js access parent fields from child types

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript-Flowtyped/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript-Flowtyped/modelGeneric.mustache
@@ -23,5 +23,5 @@ export type {{classname}} = {
      */
     {{name}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{/isEnum}};
 {{/vars}}
-}
+}{{#parent}} & {{parent}}{{/parent}}
 


### PR DESCRIPTION
Issue: https://github.com/OpenAPITools/openapi-generator/issues/4262

Javascript Flowtyped generator does not add parent type to created types.

Example how it is now:

```
type ChildType = { ... }

type ParentType = { ... }
```

What's done:

```
type ChildType = { ... } & ParentType

type ParentType = { ... }
```

In this case Flow will not complain when client code will access fields from ParentType if object has ChildType.

@CodeNinjai (2017/07) @frol (2017/07) @cliffano (2017/07)
What do you think?