### PR TITLE
Fix conflict if swagger paramName is data

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/api.mustache
@@ -51,14 +51,14 @@ class {{classname}} {
             {{^isListContainer}}
             var serializedBody = _serializers.serialize({{paramName}});
             {{/isListContainer}}
-            var data = json.encode(serializedBody);
+            var json{{paramName}} = json.encode(serializedBody);
         {{/bodyParam}}
 
             return _dio.request(
             path,
             queryParameters: queryParams,
         {{#bodyParam}}
-                data: data,
+                data: json{{paramName}},
         {{/bodyParam}}
             options: Options(
             method: '{{httpMethod}}'.toUpperCase(),

--- a/samples/client/petstore/dart-dio/lib/api.dart
+++ b/samples/client/petstore/dart-dio/lib/api.dart
@@ -8,45 +8,52 @@ import 'package:openapi/api/pet_api.dart';
 import 'package:openapi/api/store_api.dart';
 import 'package:openapi/api/user_api.dart';
 
-class Openapi {
-  Dio dio;
-  Serializers serializers;
-  String basePath = "http://petstore.swagger.io/v2";
 
-  Openapi({this.dio, Serializers serializers}) {
+class Openapi {
+
+    Dio dio;
+    Serializers serializers;
+    String basePath = "http://petstore.swagger.io/v2";
+
+    Openapi({this.dio, Serializers serializers}) {
     if (dio == null) {
-      BaseOptions options = new BaseOptions(
-        baseUrl: basePath,
-        connectTimeout: 5000,
-        receiveTimeout: 3000,
-      );
-      this.dio = new Dio(options);
+        BaseOptions options = new BaseOptions(
+            baseUrl: basePath,
+            connectTimeout: 5000,
+            receiveTimeout: 3000,
+        );
+        this.dio = new Dio(options);
     }
 
     this.serializers = serializers ?? standardSerializers;
-  }
+}
 
-  /**
+
+    /**
     * Get PetApi instance, base route and serializer can be overridden by a given but be careful,
     * by doing that all interceptors will not be executed
     */
-  PetApi getPetApi() {
+    PetApi getPetApi() {
     return PetApi(dio, serializers);
-  }
+    }
 
-  /**
+
+    /**
     * Get StoreApi instance, base route and serializer can be overridden by a given but be careful,
     * by doing that all interceptors will not be executed
     */
-  StoreApi getStoreApi() {
+    StoreApi getStoreApi() {
     return StoreApi(dio, serializers);
-  }
+    }
 
-  /**
+
+    /**
     * Get UserApi instance, base route and serializer can be overridden by a given but be careful,
     * by doing that all interceptors will not be executed
     */
-  UserApi getUserApi() {
+    UserApi getUserApi() {
     return UserApi(dio, serializers);
-  }
+    }
+
+
 }

--- a/samples/client/petstore/dart-dio/lib/api/pet_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/pet_api.dart
@@ -10,367 +10,322 @@ import 'package:openapi/model/api_response.dart';
 import 'dart:typed_data';
 
 class PetApi {
-  final Dio _dio;
-  Serializers _serializers;
+    final Dio _dio;
+    Serializers _serializers;
 
-  PetApi(this._dio, this._serializers);
+    PetApi(this._dio, this._serializers);
 
-  /// Add a new pet to the store
-  ///
-  ///
-  Future<Response> addPet(
-    Pet body, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/pet";
+        /// Add a new pet to the store
+        ///
+        /// 
+        Future<Response>addPet(Pet body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            String path = "/pet";
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    List<String> contentTypes = ["application/json", "application/xml"];
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-    var serializedBody = _serializers.serialize(body);
-    var data = json.encode(serializedBody);
+            List<String> contentTypes = [
+                "application/json",
+                "application/xml"];
 
-    return _dio.request(
-      path,
-      queryParameters: queryParams,
-      data: data,
-      options: Options(
-        method: 'post'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    );
-  }
+            var serializedBody = _serializers.serialize(body);
+            var jsonbody = json.encode(serializedBody);
 
-  /// Deletes a pet
-  ///
-  ///
-  Future<Response> deletePet(
-    int petId, {
-    String apiKey,
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path =
-        "/pet/{petId}".replaceAll("{" + "petId" + "}", petId.toString());
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+                data: jsonbody,
+            options: Options(
+            method: 'post'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            );
+            }
+        /// Deletes a pet
+        ///
+        /// 
+        Future<Response>deletePet(int petId,{ String apiKey,CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            String path = "/pet/{petId}".replaceAll("{" + "petId" + "}", petId.toString());
 
-    headerParams["api_key"] = apiKey;
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    List<String> contentTypes = [];
+                headerParams["api_key"] = apiKey;
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-    return _dio.request(
-      path,
-      queryParameters: queryParams,
-      options: Options(
-        method: 'delete'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    );
-  }
+            List<String> contentTypes = [];
 
-  /// Finds Pets by status
-  ///
-  /// Multiple status values can be provided with comma separated strings
-  Future<Response<List<Pet>>> findPetsByStatus(
-    List<String> status, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/pet/findByStatus";
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+            options: Options(
+            method: 'delete'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            );
+            }
+        /// Finds Pets by status
+        ///
+        /// Multiple status values can be provided with comma separated strings
+        Future<Response<List<Pet>>>findPetsByStatus(List<String> status,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    queryParams["status"] = status;
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            String path = "/pet/findByStatus";
 
-    List<String> contentTypes = [];
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    return _dio
-        .request(
-      path,
-      queryParameters: queryParams,
-      options: Options(
-        method: 'get'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    )
-        .then((response) {
-      final FullType type =
-          const FullType(BuiltList, const [const FullType(Pet)]);
-      BuiltList<Pet> dataList =
-          _serializers.deserialize(response.data, specifiedType: type);
-      var data = dataList.toList();
+                queryParams["status"] = status;
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-      return Response<List<Pet>>(
-        data: data,
-        headers: response.headers,
-        request: response.request,
-        redirects: response.redirects,
-        statusCode: response.statusCode,
-        statusMessage: response.statusMessage,
-        extra: response.extra,
-      );
-    });
-  }
+            List<String> contentTypes = [];
 
-  /// Finds Pets by tags
-  ///
-  /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
-  Future<Response<List<Pet>>> findPetsByTags(
-    List<String> tags, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/pet/findByTags";
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+            options: Options(
+            method: 'get'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            ).then((response) {
 
-    queryParams["tags"] = tags;
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+                final FullType type = const FullType(BuiltList, const [const FullType(Pet)]);
+                BuiltList<Pet> dataList = _serializers.deserialize(response.data, specifiedType: type);
+                var data = dataList.toList();
 
-    List<String> contentTypes = [];
+            return Response<List<Pet>>(
+                data: data,
+                headers: response.headers,
+                request: response.request,
+                redirects: response.redirects,
+                statusCode: response.statusCode,
+                statusMessage: response.statusMessage,
+                extra: response.extra,
+            );
+            });
+            }
+        /// Finds Pets by tags
+        ///
+        /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+        Future<Response<List<Pet>>>findPetsByTags(List<String> tags,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    return _dio
-        .request(
-      path,
-      queryParameters: queryParams,
-      options: Options(
-        method: 'get'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    )
-        .then((response) {
-      final FullType type =
-          const FullType(BuiltList, const [const FullType(Pet)]);
-      BuiltList<Pet> dataList =
-          _serializers.deserialize(response.data, specifiedType: type);
-      var data = dataList.toList();
+            String path = "/pet/findByTags";
 
-      return Response<List<Pet>>(
-        data: data,
-        headers: response.headers,
-        request: response.request,
-        redirects: response.redirects,
-        statusCode: response.statusCode,
-        statusMessage: response.statusMessage,
-        extra: response.extra,
-      );
-    });
-  }
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-  /// Find pet by ID
-  ///
-  /// Returns a single pet
-  Future<Response<Pet>> getPetById(
-    int petId, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path =
-        "/pet/{petId}".replaceAll("{" + "petId" + "}", petId.toString());
+                queryParams["tags"] = tags;
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            List<String> contentTypes = [];
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
 
-    List<String> contentTypes = [];
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+            options: Options(
+            method: 'get'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            ).then((response) {
 
-    return _dio
-        .request(
-      path,
-      queryParameters: queryParams,
-      options: Options(
-        method: 'get'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    )
-        .then((response) {
-      var serializer = _serializers.serializerForType(Pet);
-      var data = _serializers.deserializeWith<Pet>(serializer, response.data);
+                final FullType type = const FullType(BuiltList, const [const FullType(Pet)]);
+                BuiltList<Pet> dataList = _serializers.deserialize(response.data, specifiedType: type);
+                var data = dataList.toList();
 
-      return Response<Pet>(
-        data: data,
-        headers: response.headers,
-        request: response.request,
-        redirects: response.redirects,
-        statusCode: response.statusCode,
-        statusMessage: response.statusMessage,
-        extra: response.extra,
-      );
-    });
-  }
+            return Response<List<Pet>>(
+                data: data,
+                headers: response.headers,
+                request: response.request,
+                redirects: response.redirects,
+                statusCode: response.statusCode,
+                statusMessage: response.statusMessage,
+                extra: response.extra,
+            );
+            });
+            }
+        /// Find pet by ID
+        ///
+        /// Returns a single pet
+        Future<Response<Pet>>getPetById(int petId,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-  /// Update an existing pet
-  ///
-  ///
-  Future<Response> updatePet(
-    Pet body, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/pet";
+            String path = "/pet/{petId}".replaceAll("{" + "petId" + "}", petId.toString());
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-    List<String> contentTypes = ["application/json", "application/xml"];
+            List<String> contentTypes = [];
 
-    var serializedBody = _serializers.serialize(body);
-    var data = json.encode(serializedBody);
 
-    return _dio.request(
-      path,
-      queryParameters: queryParams,
-      data: data,
-      options: Options(
-        method: 'put'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    );
-  }
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+            options: Options(
+            method: 'get'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            ).then((response) {
 
-  /// Updates a pet in the store with form data
-  ///
-  ///
-  Future<Response> updatePetWithForm(
-    int petId, {
-    String name,
-    String status,
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path =
-        "/pet/{petId}".replaceAll("{" + "petId" + "}", petId.toString());
+        var serializer = _serializers.serializerForType(Pet);
+        var data = _serializers.deserializeWith<Pet>(serializer, response.data);
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            return Response<Pet>(
+                data: data,
+                headers: response.headers,
+                request: response.request,
+                redirects: response.redirects,
+                statusCode: response.statusCode,
+                statusMessage: response.statusMessage,
+                extra: response.extra,
+            );
+            });
+            }
+        /// Update an existing pet
+        ///
+        /// 
+        Future<Response>updatePet(Pet body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            String path = "/pet";
 
-    List<String> contentTypes = ["application/x-www-form-urlencoded"];
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    return _dio.request(
-      path,
-      queryParameters: queryParams,
-      options: Options(
-        method: 'post'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    );
-  }
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-  /// uploads an image
-  ///
-  ///
-  Future<Response<ApiResponse>> uploadFile(
-    int petId, {
-    String additionalMetadata,
-    Uint8List file,
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/pet/{petId}/uploadImage"
-        .replaceAll("{" + "petId" + "}", petId.toString());
+            List<String> contentTypes = [
+                "application/json",
+                "application/xml"];
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            var serializedBody = _serializers.serialize(body);
+            var jsonbody = json.encode(serializedBody);
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+                data: jsonbody,
+            options: Options(
+            method: 'put'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            );
+            }
+        /// Updates a pet in the store with form data
+        ///
+        /// 
+        Future<Response>updatePetWithForm(int petId,{ String name,String status,CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    List<String> contentTypes = ["multipart/form-data"];
+            String path = "/pet/{petId}".replaceAll("{" + "petId" + "}", petId.toString());
 
-    return _dio
-        .request(
-      path,
-      queryParameters: queryParams,
-      options: Options(
-        method: 'post'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    )
-        .then((response) {
-      var serializer = _serializers.serializerForType(ApiResponse);
-      var data =
-          _serializers.deserializeWith<ApiResponse>(serializer, response.data);
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-      return Response<ApiResponse>(
-        data: data,
-        headers: response.headers,
-        request: response.request,
-        redirects: response.redirects,
-        statusCode: response.statusCode,
-        statusMessage: response.statusMessage,
-        extra: response.extra,
-      );
-    });
-  }
-}
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
+
+            List<String> contentTypes = [
+                "application/x-www-form-urlencoded"];
+
+
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+            options: Options(
+            method: 'post'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            );
+            }
+        /// uploads an image
+        ///
+        /// 
+        Future<Response<ApiResponse>>uploadFile(int petId,{ String additionalMetadata,Uint8List file,CancelToken cancelToken, Map<String, String> headers,}) async {
+
+            String path = "/pet/{petId}/uploadImage".replaceAll("{" + "petId" + "}", petId.toString());
+
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
+
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
+
+            List<String> contentTypes = [
+                "multipart/form-data"];
+
+
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+            options: Options(
+            method: 'post'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            ).then((response) {
+
+        var serializer = _serializers.serializerForType(ApiResponse);
+        var data = _serializers.deserializeWith<ApiResponse>(serializer, response.data);
+
+            return Response<ApiResponse>(
+                data: data,
+                headers: response.headers,
+                request: response.request,
+                redirects: response.redirects,
+                statusCode: response.statusCode,
+                statusMessage: response.statusMessage,
+                extra: response.extra,
+            );
+            });
+            }
+        }

--- a/samples/client/petstore/dart-dio/lib/api/store_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/store_api.dart
@@ -150,12 +150,12 @@ class StoreApi {
             List<String> contentTypes = [];
 
             var serializedBody = _serializers.serialize(body);
-            var data = json.encode(serializedBody);
+            var jsonbody = json.encode(serializedBody);
 
             return _dio.request(
             path,
             queryParameters: queryParams,
-                data: data,
+                data: jsonbody,
             options: Options(
             method: 'post'.toUpperCase(),
             headers: headerParams,

--- a/samples/client/petstore/dart-dio/lib/api/user_api.dart
+++ b/samples/client/petstore/dart-dio/lib/api/user_api.dart
@@ -8,337 +8,293 @@ import 'package:built_value/serializer.dart';
 import 'package:openapi/model/user.dart';
 
 class UserApi {
-  final Dio _dio;
-  Serializers _serializers;
+    final Dio _dio;
+    Serializers _serializers;
 
-  UserApi(this._dio, this._serializers);
+    UserApi(this._dio, this._serializers);
 
-  /// Create user
-  ///
-  /// This can only be done by the logged in user.
-  Future<Response> createUser(
-    User body, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/user";
+        /// Create user
+        ///
+        /// This can only be done by the logged in user.
+        Future<Response>createUser(User body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            String path = "/user";
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    List<String> contentTypes = [];
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-    var serializedBody = _serializers.serialize(body);
-    var data = json.encode(serializedBody);
+            List<String> contentTypes = [];
 
-    return _dio.request(
-      path,
-      queryParameters: queryParams,
-      data: data,
-      options: Options(
-        method: 'post'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    );
-  }
+            var serializedBody = _serializers.serialize(body);
+            var jsonbody = json.encode(serializedBody);
 
-  /// Creates list of users with given input array
-  ///
-  ///
-  Future<Response> createUsersWithArrayInput(
-    List<User> body, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/user/createWithArray";
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+                data: jsonbody,
+            options: Options(
+            method: 'post'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            );
+            }
+        /// Creates list of users with given input array
+        ///
+        /// 
+        Future<Response>createUsersWithArrayInput(List<User> body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            String path = "/user/createWithArray";
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    List<String> contentTypes = [];
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-    final type = const FullType(BuiltList, const [const FullType(User)]);
-    var serializedBody =
-        _serializers.serialize(BuiltList<User>.from(body), specifiedType: type);
-    var data = json.encode(serializedBody);
+            List<String> contentTypes = [];
 
-    return _dio.request(
-      path,
-      queryParameters: queryParams,
-      data: data,
-      options: Options(
-        method: 'post'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    );
-  }
+            final type = const FullType(BuiltList, const [const FullType(User)]);
+            var serializedBody = _serializers.serialize(BuiltList<User>.from(body), specifiedType: type);
+            var jsonbody = json.encode(serializedBody);
 
-  /// Creates list of users with given input array
-  ///
-  ///
-  Future<Response> createUsersWithListInput(
-    List<User> body, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/user/createWithList";
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+                data: jsonbody,
+            options: Options(
+            method: 'post'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            );
+            }
+        /// Creates list of users with given input array
+        ///
+        /// 
+        Future<Response>createUsersWithListInput(List<User> body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            String path = "/user/createWithList";
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    List<String> contentTypes = [];
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-    final type = const FullType(BuiltList, const [const FullType(User)]);
-    var serializedBody =
-        _serializers.serialize(BuiltList<User>.from(body), specifiedType: type);
-    var data = json.encode(serializedBody);
+            List<String> contentTypes = [];
 
-    return _dio.request(
-      path,
-      queryParameters: queryParams,
-      data: data,
-      options: Options(
-        method: 'post'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    );
-  }
+            final type = const FullType(BuiltList, const [const FullType(User)]);
+            var serializedBody = _serializers.serialize(BuiltList<User>.from(body), specifiedType: type);
+            var jsonbody = json.encode(serializedBody);
 
-  /// Delete user
-  ///
-  /// This can only be done by the logged in user.
-  Future<Response> deleteUser(
-    String username, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/user/{username}"
-        .replaceAll("{" + "username" + "}", username.toString());
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+                data: jsonbody,
+            options: Options(
+            method: 'post'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            );
+            }
+        /// Delete user
+        ///
+        /// This can only be done by the logged in user.
+        Future<Response>deleteUser(String username,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            String path = "/user/{username}".replaceAll("{" + "username" + "}", username.toString());
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    List<String> contentTypes = [];
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-    return _dio.request(
-      path,
-      queryParameters: queryParams,
-      options: Options(
-        method: 'delete'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    );
-  }
+            List<String> contentTypes = [];
 
-  /// Get user by user name
-  ///
-  ///
-  Future<Response<User>> getUserByName(
-    String username, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/user/{username}"
-        .replaceAll("{" + "username" + "}", username.toString());
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+            options: Options(
+            method: 'delete'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            );
+            }
+        /// Get user by user name
+        ///
+        /// 
+        Future<Response<User>>getUserByName(String username,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            String path = "/user/{username}".replaceAll("{" + "username" + "}", username.toString());
 
-    List<String> contentTypes = [];
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    return _dio
-        .request(
-      path,
-      queryParameters: queryParams,
-      options: Options(
-        method: 'get'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    )
-        .then((response) {
-      var serializer = _serializers.serializerForType(User);
-      var data = _serializers.deserializeWith<User>(serializer, response.data);
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-      return Response<User>(
-        data: data,
-        headers: response.headers,
-        request: response.request,
-        redirects: response.redirects,
-        statusCode: response.statusCode,
-        statusMessage: response.statusMessage,
-        extra: response.extra,
-      );
-    });
-  }
+            List<String> contentTypes = [];
 
-  /// Logs user into the system
-  ///
-  ///
-  Future<Response<String>> loginUser(
-    String username,
-    String password, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/user/login";
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+            options: Options(
+            method: 'get'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            ).then((response) {
 
-    queryParams["username"] = username;
-    queryParams["password"] = password;
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+        var serializer = _serializers.serializerForType(User);
+        var data = _serializers.deserializeWith<User>(serializer, response.data);
 
-    List<String> contentTypes = [];
+            return Response<User>(
+                data: data,
+                headers: response.headers,
+                request: response.request,
+                redirects: response.redirects,
+                statusCode: response.statusCode,
+                statusMessage: response.statusMessage,
+                extra: response.extra,
+            );
+            });
+            }
+        /// Logs user into the system
+        ///
+        /// 
+        Future<Response<String>>loginUser(String username,String password,{ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    return _dio
-        .request(
-      path,
-      queryParameters: queryParams,
-      options: Options(
-        method: 'get'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    )
-        .then((response) {
-      var serializer = _serializers.serializerForType(String);
-      var data =
-          _serializers.deserializeWith<String>(serializer, response.data);
+            String path = "/user/login";
 
-      return Response<String>(
-        data: data,
-        headers: response.headers,
-        request: response.request,
-        redirects: response.redirects,
-        statusCode: response.statusCode,
-        statusMessage: response.statusMessage,
-        extra: response.extra,
-      );
-    });
-  }
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-  /// Logs out current logged in user session
-  ///
-  ///
-  Future<Response> logoutUser({
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/user/logout";
+                queryParams["username"] = username;
+                queryParams["password"] = password;
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            List<String> contentTypes = [];
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
 
-    List<String> contentTypes = [];
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+            options: Options(
+            method: 'get'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            ).then((response) {
 
-    return _dio.request(
-      path,
-      queryParameters: queryParams,
-      options: Options(
-        method: 'get'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    );
-  }
+        var serializer = _serializers.serializerForType(String);
+        var data = _serializers.deserializeWith<String>(serializer, response.data);
 
-  /// Updated user
-  ///
-  /// This can only be done by the logged in user.
-  Future<Response> updateUser(
-    String username,
-    User body, {
-    CancelToken cancelToken,
-    Map<String, String> headers,
-  }) async {
-    String path = "/user/{username}"
-        .replaceAll("{" + "username" + "}", username.toString());
+            return Response<String>(
+                data: data,
+                headers: response.headers,
+                request: response.request,
+                redirects: response.redirects,
+                statusCode: response.statusCode,
+                statusMessage: response.statusMessage,
+                extra: response.extra,
+            );
+            });
+            }
+        /// Logs out current logged in user session
+        ///
+        /// 
+        Future<Response>logoutUser({ CancelToken cancelToken, Map<String, String> headers,}) async {
 
-    // query params
-    Map<String, dynamic> queryParams = {};
-    Map<String, String> headerParams = Map.from(headers ?? {});
-    Map<String, String> formParams = {};
+            String path = "/user/logout";
 
-    queryParams.removeWhere((key, value) => value == null);
-    headerParams.removeWhere((key, value) => value == null);
-    formParams.removeWhere((key, value) => value == null);
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
 
-    List<String> contentTypes = [];
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
 
-    var serializedBody = _serializers.serialize(body);
-    var data = json.encode(serializedBody);
+            List<String> contentTypes = [];
 
-    return _dio.request(
-      path,
-      queryParameters: queryParams,
-      data: data,
-      options: Options(
-        method: 'put'.toUpperCase(),
-        headers: headerParams,
-        contentType:
-            contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
-      ),
-      cancelToken: cancelToken,
-    );
-  }
-}
+
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+            options: Options(
+            method: 'get'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            );
+            }
+        /// Updated user
+        ///
+        /// This can only be done by the logged in user.
+        Future<Response>updateUser(String username,User body,{ CancelToken cancelToken, Map<String, String> headers,}) async {
+
+            String path = "/user/{username}".replaceAll("{" + "username" + "}", username.toString());
+
+            // query params
+            Map<String, dynamic> queryParams = {};
+            Map<String, String> headerParams = Map.from(headers ?? {});
+            Map<String, String> formParams = {};
+
+            queryParams.removeWhere((key, value) => value == null);
+            headerParams.removeWhere((key, value) => value == null);
+            formParams.removeWhere((key, value) => value == null);
+
+            List<String> contentTypes = [];
+
+            var serializedBody = _serializers.serialize(body);
+            var jsonbody = json.encode(serializedBody);
+
+            return _dio.request(
+            path,
+            queryParameters: queryParams,
+                data: jsonbody,
+            options: Options(
+            method: 'put'.toUpperCase(),
+            headers: headerParams,
+            contentType: contentTypes.isNotEmpty ? contentTypes[0] : "application/json",
+            ),
+            cancelToken: cancelToken,
+            );
+            }
+        }

--- a/samples/client/petstore/dart-dio/lib/model/api_response.dart
+++ b/samples/client/petstore/dart-dio/lib/model/api_response.dart
@@ -1,24 +1,34 @@
-import 'package:built_value/built_value.dart';
+        import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
 part 'api_response.g.dart';
 
 abstract class ApiResponse implements Built<ApiResponse, ApiResponseBuilder> {
-  @nullable
-  @BuiltValueField(wireName: 'code')
-  int get code;
 
-  @nullable
-  @BuiltValueField(wireName: 'type')
-  String get type;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'message')
-  String get message;
+    
+    @BuiltValueField(wireName: 'code')
+    int get code;
+    
+        @nullable
 
-  // Boilerplate code needed to wire-up generated code
-  ApiResponse._();
+    
+    @BuiltValueField(wireName: 'type')
+    String get type;
+    
+        @nullable
 
-  factory ApiResponse([updates(ApiResponseBuilder b)]) = _$ApiResponse;
-  static Serializer<ApiResponse> get serializer => _$apiResponseSerializer;
+    
+    @BuiltValueField(wireName: 'message')
+    String get message;
+
+    // Boilerplate code needed to wire-up generated code
+    ApiResponse._();
+
+    factory ApiResponse([updates(ApiResponseBuilder b)]) = _$ApiResponse;
+    static Serializer<ApiResponse> get serializer => _$apiResponseSerializer;
+
 }
+

--- a/samples/client/petstore/dart-dio/lib/model/category.dart
+++ b/samples/client/petstore/dart-dio/lib/model/category.dart
@@ -1,20 +1,28 @@
-import 'package:built_value/built_value.dart';
+        import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
 part 'category.g.dart';
 
 abstract class Category implements Built<Category, CategoryBuilder> {
-  @nullable
-  @BuiltValueField(wireName: 'id')
-  int get id;
 
-  @nullable
-  @BuiltValueField(wireName: 'name')
-  String get name;
+    
+        @nullable
 
-  // Boilerplate code needed to wire-up generated code
-  Category._();
+    
+    @BuiltValueField(wireName: 'id')
+    int get id;
+    
+        @nullable
 
-  factory Category([updates(CategoryBuilder b)]) = _$Category;
-  static Serializer<Category> get serializer => _$categorySerializer;
+    
+    @BuiltValueField(wireName: 'name')
+    String get name;
+
+    // Boilerplate code needed to wire-up generated code
+    Category._();
+
+    factory Category([updates(CategoryBuilder b)]) = _$Category;
+    static Serializer<Category> get serializer => _$categorySerializer;
+
 }
+

--- a/samples/client/petstore/dart-dio/lib/model/order.dart
+++ b/samples/client/petstore/dart-dio/lib/model/order.dart
@@ -1,39 +1,53 @@
-import 'package:built_value/built_value.dart';
+        import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
 part 'order.g.dart';
 
 abstract class Order implements Built<Order, OrderBuilder> {
-  @nullable
-  @BuiltValueField(wireName: 'id')
-  int get id;
 
-  @nullable
-  @BuiltValueField(wireName: 'petId')
-  int get petId;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'quantity')
-  int get quantity;
+    
+    @BuiltValueField(wireName: 'id')
+    int get id;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'shipDate')
-  DateTime get shipDate;
-  /* Order Status */
-  @nullable
+    
+    @BuiltValueField(wireName: 'petId')
+    int get petId;
+    
+        @nullable
 
-  /* Order Status */
-  @BuiltValueField(wireName: 'status')
-  String get status;
-  //enum statusEnum {  placed,  approved,  delivered,  };{
+    
+    @BuiltValueField(wireName: 'quantity')
+    int get quantity;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'complete')
-  bool get complete;
+    
+    @BuiltValueField(wireName: 'shipDate')
+    DateTime get shipDate;
+    /* Order Status */
+        @nullable
 
-  // Boilerplate code needed to wire-up generated code
-  Order._();
+    /* Order Status */
+    @BuiltValueField(wireName: 'status')
+    String get status;
+        //enum statusEnum {  placed,  approved,  delivered,  };
+    
+        @nullable
 
-  factory Order([updates(OrderBuilder b)]) = _$Order;
-  static Serializer<Order> get serializer => _$orderSerializer;
+    
+    @BuiltValueField(wireName: 'complete')
+    bool get complete;
+
+    // Boilerplate code needed to wire-up generated code
+    Order._();
+
+    factory Order([updates(OrderBuilder b)]) = _$Order;
+    static Serializer<Order> get serializer => _$orderSerializer;
+
 }
+

--- a/samples/client/petstore/dart-dio/lib/model/pet.dart
+++ b/samples/client/petstore/dart-dio/lib/model/pet.dart
@@ -1,42 +1,56 @@
-import 'package:openapi/model/tag.dart';
-import 'package:openapi/model/category.dart';
-import 'package:built_collection/built_collection.dart';
-import 'package:built_value/built_value.dart';
+            import 'package:openapi/model/tag.dart';
+            import 'package:openapi/model/category.dart';
+            import 'package:built_collection/built_collection.dart';
+        import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
 part 'pet.g.dart';
 
 abstract class Pet implements Built<Pet, PetBuilder> {
-  @nullable
-  @BuiltValueField(wireName: 'id')
-  int get id;
 
-  @nullable
-  @BuiltValueField(wireName: 'category')
-  Category get category;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'name')
-  String get name;
+    
+    @BuiltValueField(wireName: 'id')
+    int get id;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'photoUrls')
-  BuiltList<String> get photoUrls;
+    
+    @BuiltValueField(wireName: 'category')
+    Category get category;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'tags')
-  BuiltList<Tag> get tags;
-  /* pet status in the store */
-  @nullable
+    
+    @BuiltValueField(wireName: 'name')
+    String get name;
+    
+        @nullable
 
-  /* pet status in the store */
-  @BuiltValueField(wireName: 'status')
-  String get status;
-  //enum statusEnum {  available,  pending,  sold,  };{
+    
+    @BuiltValueField(wireName: 'photoUrls')
+    BuiltList<String> get photoUrls;
+    
+        @nullable
 
-  // Boilerplate code needed to wire-up generated code
-  Pet._();
+    
+    @BuiltValueField(wireName: 'tags')
+    BuiltList<Tag> get tags;
+    /* pet status in the store */
+        @nullable
 
-  factory Pet([updates(PetBuilder b)]) = _$Pet;
-  static Serializer<Pet> get serializer => _$petSerializer;
+    /* pet status in the store */
+    @BuiltValueField(wireName: 'status')
+    String get status;
+        //enum statusEnum {  available,  pending,  sold,  };
+
+    // Boilerplate code needed to wire-up generated code
+    Pet._();
+
+    factory Pet([updates(PetBuilder b)]) = _$Pet;
+    static Serializer<Pet> get serializer => _$petSerializer;
+
 }
+

--- a/samples/client/petstore/dart-dio/lib/model/tag.dart
+++ b/samples/client/petstore/dart-dio/lib/model/tag.dart
@@ -1,20 +1,28 @@
-import 'package:built_value/built_value.dart';
+        import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
 part 'tag.g.dart';
 
 abstract class Tag implements Built<Tag, TagBuilder> {
-  @nullable
-  @BuiltValueField(wireName: 'id')
-  int get id;
 
-  @nullable
-  @BuiltValueField(wireName: 'name')
-  String get name;
+    
+        @nullable
 
-  // Boilerplate code needed to wire-up generated code
-  Tag._();
+    
+    @BuiltValueField(wireName: 'id')
+    int get id;
+    
+        @nullable
 
-  factory Tag([updates(TagBuilder b)]) = _$Tag;
-  static Serializer<Tag> get serializer => _$tagSerializer;
+    
+    @BuiltValueField(wireName: 'name')
+    String get name;
+
+    // Boilerplate code needed to wire-up generated code
+    Tag._();
+
+    factory Tag([updates(TagBuilder b)]) = _$Tag;
+    static Serializer<Tag> get serializer => _$tagSerializer;
+
 }
+

--- a/samples/client/petstore/dart-dio/lib/model/user.dart
+++ b/samples/client/petstore/dart-dio/lib/model/user.dart
@@ -1,46 +1,64 @@
-import 'package:built_value/built_value.dart';
+        import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
 part 'user.g.dart';
 
 abstract class User implements Built<User, UserBuilder> {
-  @nullable
-  @BuiltValueField(wireName: 'id')
-  int get id;
 
-  @nullable
-  @BuiltValueField(wireName: 'username')
-  String get username;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'firstName')
-  String get firstName;
+    
+    @BuiltValueField(wireName: 'id')
+    int get id;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'lastName')
-  String get lastName;
+    
+    @BuiltValueField(wireName: 'username')
+    String get username;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'email')
-  String get email;
+    
+    @BuiltValueField(wireName: 'firstName')
+    String get firstName;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'password')
-  String get password;
+    
+    @BuiltValueField(wireName: 'lastName')
+    String get lastName;
+    
+        @nullable
 
-  @nullable
-  @BuiltValueField(wireName: 'phone')
-  String get phone;
-  /* User Status */
-  @nullable
+    
+    @BuiltValueField(wireName: 'email')
+    String get email;
+    
+        @nullable
 
-  /* User Status */
-  @BuiltValueField(wireName: 'userStatus')
-  int get userStatus;
+    
+    @BuiltValueField(wireName: 'password')
+    String get password;
+    
+        @nullable
 
-  // Boilerplate code needed to wire-up generated code
-  User._();
+    
+    @BuiltValueField(wireName: 'phone')
+    String get phone;
+    /* User Status */
+        @nullable
 
-  factory User([updates(UserBuilder b)]) = _$User;
-  static Serializer<User> get serializer => _$userSerializer;
+    /* User Status */
+    @BuiltValueField(wireName: 'userStatus')
+    int get userStatus;
+
+    // Boilerplate code needed to wire-up generated code
+    User._();
+
+    factory User([updates(UserBuilder b)]) = _$User;
+    static Serializer<User> get serializer => _$userSerializer;
+
 }
+

--- a/samples/client/petstore/dart-dio/lib/serializers.dart
+++ b/samples/client/petstore/dart-dio/lib/serializers.dart
@@ -11,38 +11,41 @@ import 'package:openapi/model/pet.dart';
 import 'package:openapi/model/tag.dart';
 import 'package:openapi/model/user.dart';
 
+
 part 'serializers.g.dart';
 
 @SerializersFor(const [
-  ApiResponse,
-  Category,
-  Order,
-  Pet,
-  Tag,
-  User,
+ApiResponse,
+Category,
+Order,
+Pet,
+Tag,
+User,
+
 ])
 
 //allow all models to be serialized within a list
 Serializers serializers = (_$serializers.toBuilder()
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType(ApiResponse)]),
-          () => new ListBuilder<ApiResponse>())
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType(Category)]),
-          () => new ListBuilder<Category>())
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType(Order)]),
-          () => new ListBuilder<Order>())
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType(Pet)]),
-          () => new ListBuilder<Pet>())
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType(Tag)]),
-          () => new ListBuilder<Tag>())
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType(User)]),
-          () => new ListBuilder<User>()))
-    .build();
+..addBuilderFactory(
+const FullType(BuiltList, const [const FullType(ApiResponse)]),
+() => new ListBuilder<ApiResponse>())
+..addBuilderFactory(
+const FullType(BuiltList, const [const FullType(Category)]),
+() => new ListBuilder<Category>())
+..addBuilderFactory(
+const FullType(BuiltList, const [const FullType(Order)]),
+() => new ListBuilder<Order>())
+..addBuilderFactory(
+const FullType(BuiltList, const [const FullType(Pet)]),
+() => new ListBuilder<Pet>())
+..addBuilderFactory(
+const FullType(BuiltList, const [const FullType(Tag)]),
+() => new ListBuilder<Tag>())
+..addBuilderFactory(
+const FullType(BuiltList, const [const FullType(User)]),
+() => new ListBuilder<User>())
+
+).build();
 
 Serializers standardSerializers =
-    (serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();
+(serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
If a the paramName inside a swagger doc is called data then the generated code does not compile.

<!-- Please check the completed items below -->
### PR checklist

- [ Y] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ Y] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ Y] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [Y ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [Y ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
