### PR TITLE
Add bearer token authentication documentation to template

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/README.mustache
@@ -91,7 +91,7 @@ public class {{{classname}}}Example {
         defaultClient.setBasePath("{{{basePath}}}");
         {{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
         // Configure HTTP basic authorization: {{{name}}}
-        HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication();
+        HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setUsername("YOUR USERNAME");
         {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
         // Configure HTTP bearer authorization: {{{name}}}

--- a/modules/openapi-generator/src/main/resources/Java/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/README.mustache
@@ -89,11 +89,14 @@ public class {{{classname}}}Example {
     public static void main(String[] args) {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("{{{basePath}}}");
-        {{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}
+        {{#hasAuthMethods}}{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
         // Configure HTTP basic authorization: {{{name}}}
-        HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
+        HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication();
         {{{name}}}.setUsername("YOUR USERNAME");
-        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
+        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
+        // Configure HTTP bearer authorization: {{{name}}}
+        HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
+        {{{name}}}.setToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");

--- a/modules/openapi-generator/src/main/resources/Java/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/README.mustache
@@ -96,7 +96,7 @@ public class {{{classname}}}Example {
         {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
         // Configure HTTP bearer authorization: {{{name}}}
         HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+        {{{name}}}.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");

--- a/modules/openapi-generator/src/main/resources/Java/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/api_doc.mustache
@@ -43,7 +43,7 @@ public class Example {
         {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
         // Configure HTTP bearer authorization: {{{name}}}
         HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+        {{{name}}}.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");

--- a/modules/openapi-generator/src/main/resources/Java/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/api_doc.mustache
@@ -36,11 +36,14 @@ public class Example {
         ApiClient defaultClient = Configuration.getDefaultApiClient();
         defaultClient.setBasePath("{{{basePath}}}");
         {{#hasAuthMethods}}
-        {{#authMethods}}{{#isBasic}}
+        {{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
         // Configure HTTP basic authorization: {{{name}}}
         HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setUsername("YOUR USERNAME");
-        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
+        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
+        // Configure HTTP bearer authorization: {{{name}}}
+        HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
+        {{{name}}}.setToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/README.mustache
@@ -97,7 +97,7 @@ public class Example {
     {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
     // Configure HTTP bearer authorization: {{{name}}}
     HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
-    {{{name}}}.setToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+    {{{name}}}.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
     // Configure API key authorization: {{{name}}}
     ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
     {{{name}}}.setApiKey("YOUR API KEY");

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/README.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/README.mustache
@@ -90,11 +90,14 @@ public class Example {
     ApiClient defaultClient = Configuration.getDefaultApiClient();
     defaultClient.setBasePath("{{{basePath}}}");
     {{#hasAuthMethods}}
-    {{#authMethods}}{{#isBasic}}
+    {{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
     // Configure HTTP basic authorization: {{{name}}}
     HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
     {{{name}}}.setUsername("YOUR USERNAME");
-    {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
+    {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
+    // Configure HTTP bearer authorization: {{{name}}}
+    HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
+    {{{name}}}.setToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
     // Configure API key authorization: {{{name}}}
     ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
     {{{name}}}.setApiKey("YOUR API KEY");

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_doc.mustache
@@ -41,7 +41,7 @@ public class Example {
     {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
     // Configure HTTP bearer authorization: {{{name}}}
     HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
-    {{{name}}}.setToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
+    {{{name}}}.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
     // Configure API key authorization: {{{name}}}
     ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
     {{{name}}}.setApiKey("YOUR API KEY");

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/api_doc.mustache
@@ -34,11 +34,14 @@ public class Example {
     ApiClient defaultClient = Configuration.getDefaultApiClient();
     defaultClient.setBasePath("{{{basePath}}}");
     {{#hasAuthMethods}}
-    {{#authMethods}}{{#isBasic}}
+    {{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
     // Configure HTTP basic authorization: {{{name}}}
     HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
     {{{name}}}.setUsername("YOUR USERNAME");
-    {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
+    {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasicBasic}}{{#isBasicBearer}}
+    // Configure HTTP bearer authorization: {{{name}}}
+    HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
+    {{{name}}}.setToken("BEARER TOKEN");{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
     // Configure API key authorization: {{{name}}}
     ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
     {{{name}}}.setApiKey("YOUR API KEY");

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_java.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_java.mustache
@@ -17,7 +17,7 @@ public class {{{classname}}}Example {
         {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isBasicBearer}}
         // Configure HTTP bearer authorization: {{{name}}}
         HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
-        {{{name}}}.setToken("BEARER TOKEN");{{/isBasicBearer}}{{#isApiKey}}
+        {{{name}}}.setBearerToken("BEARER TOKEN");{{/isBasicBearer}}{{#isApiKey}}
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/sample_java.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/sample_java.mustache
@@ -14,7 +14,10 @@ public class {{{classname}}}Example {
         // Configure HTTP basic authorization: {{{name}}}
         HttpBasicAuth {{{name}}} = (HttpBasicAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setUsername("YOUR USERNAME");
-        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isApiKey}}
+        {{{name}}}.setPassword("YOUR PASSWORD");{{/isBasic}}{{#isBasicBearer}}
+        // Configure HTTP bearer authorization: {{{name}}}
+        HttpBearerAuth {{{name}}} = (HttpBearerAuth) defaultClient.getAuthentication("{{{name}}}");
+        {{{name}}}.setToken("BEARER TOKEN");{{/isBasicBearer}}{{#isApiKey}}
         // Configure API key authorization: {{{name}}}
         ApiKeyAuth {{{name}}} = (ApiKeyAuth) defaultClient.getAuthentication("{{{name}}}");
         {{{name}}}.setApiKey("YOUR API KEY");


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
The Readme files generated  for java currently only adds HttpBasicAuth example. This update checks if the auth is a bearer auth and adds appropriate example for that. 

This fixes #4178

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
