### PR TITLE
[C#] allow customization of generated enum suffixes

### DIFF
--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -34,3 +34,5 @@ sidebar_label: aspnetcore
 |operationIsAsync|Set methods to async or sync (default).| |false|
 |operationResultTask|Set methods result to Task&lt;&gt;.| |false|
 |modelClassModifier|Model Class Modifier can be nothing or partial| |partial|
+|enumNameSuffix|Suffix for generated enum classes| |Enum|
+|enumValueNameSuffix|Suffix for generated enum values| |Enum|

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -27,6 +27,8 @@ sidebar_label: aspnetcore
 |useNewtonsoft|Uses the Newtonsoft JSON library.| |true|
 |newtonsoftVersion|Version for Microsoft.AspNetCore.Mvc.NewtonsoftJson for ASP.NET Core 3.0+| |3.0.0-preview5-19227-01|
 |useDefaultRouting|Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.| |true|
+|enumNameSuffix|Suffix that will be appended to all enum names.| |Enum|
+|enumValueNameSuffix|Suffix that will be appended to all enum value names.| |Enum|
 |classModifier|Class Modifier can be empty, abstract| ||
 |operationModifier|Operation Modifier can be virtual, abstract or partial| |virtual|
 |buildTarget|Target to build an application or library| |program|
@@ -34,5 +36,3 @@ sidebar_label: aspnetcore
 |operationIsAsync|Set methods to async or sync (default).| |false|
 |operationResultTask|Set methods result to Task&lt;&gt;.| |false|
 |modelClassModifier|Model Class Modifier can be nothing or partial| |partial|
-|enumNameSuffix|Suffix for generated enum classes| |Enum|
-|enumValueNameSuffix|Suffix for generated enum values| |Enum|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -218,6 +218,12 @@ public class CodegenConstants {
     public static final String MODEL_NAME_SUFFIX = "modelNameSuffix";
     public static final String MODEL_NAME_SUFFIX_DESC = "Suffix that will be appended to all model names.";
 
+    public static final String ENUM_NAME_SUFFIX = "enumNameSuffix";
+    public static final String ENUM_NAME_SUFFIX_DESC = "Suffix that will be appended to all enum names.";
+
+    public static final String ENUM_VALUE_NAME_SUFFIX = "enumValueNameSuffix";
+    public static final String ENUM_VALUE_NAME_SUFFIX_DESC = "Suffix that will be appended to all enum value names.";
+
     public static final String GIT_HOST = "gitHost";
     public static final String GIT_HOST_DESC = "Git host, e.g. gitlab.com.";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -62,6 +62,8 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
     protected String packageAuthors = "OpenAPI";
 
     protected String interfacePrefix = "I";
+    protected String enumNameSuffix = "Enum";
+    protected String enumValueNameSuffix = "Enum";
 
     protected String sourceFolder = "src";
 
@@ -359,6 +361,14 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                 // NOTE: if user passes "true" explicitly, we use the default I- prefix. The other supported case here is a custom prefix.
                 setInterfacePrefix(sanitizeName(useInterfacePrefix));
             }
+        }
+
+        if (additionalProperties().containsKey(CodegenConstants.ENUM_NAME_SUFFIX)) {
+            setEnumNameSuffix(additionalProperties.get(CodegenConstants.ENUM_NAME_SUFFIX).toString());
+        }
+
+        if (additionalProperties().containsKey(CodegenConstants.ENUM_VALUE_NAME_SUFFIX)) {
+            setEnumValueNameSuffix(additionalProperties.get(CodegenConstants.ENUM_VALUE_NAME_SUFFIX).toString());
         }
 
         // This either updates additionalProperties with the above fixes, or sets the default if the option was not specified.
@@ -1003,6 +1013,14 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         this.interfacePrefix = interfacePrefix;
     }
 
+    public void setEnumNameSuffix(final String enumNameSuffix) {
+        this.enumNameSuffix = enumNameSuffix;
+    }
+
+    public void setEnumValueNameSuffix(final String enumValueNameSuffix) {
+        this.enumValueNameSuffix = enumValueNameSuffix;
+    }
+
     public boolean isSupportNullable() {
         return supportNullable;
     }
@@ -1040,7 +1058,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         enumName = enumName.replaceFirst("^_", "");
         enumName = enumName.replaceFirst("_$", "");
 
-        enumName = camelize(enumName) + "Enum";
+        enumName = camelize(enumName) + this.enumValueNameSuffix;
 
         if (enumName.matches("\\d.*")) { // starts with number
             return "_" + enumName;
@@ -1051,7 +1069,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
     @Override
     public String toEnumName(CodegenProperty property) {
-        return sanitizeName(camelize(property.name)) + "Enum";
+        return sanitizeName(camelize(property.name)) + this.enumNameSuffix;
     }
 
     public String testPackageName() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AspNetCoreServerCodegen.java
@@ -206,10 +206,17 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
                 "Version for Microsoft.AspNetCore.Mvc.NewtonsoftJson for ASP.NET Core 3.0+",
                 newtonsoftVersion);
 
-
         addSwitch(USE_DEFAULT_ROUTING,
                 "Use default routing for the  ASP.NET Core version. For 3.0 turn off default because it is not yet supported.",
                 useDefaultRouting);
+
+        addOption(CodegenConstants.ENUM_NAME_SUFFIX,
+                CodegenConstants.ENUM_NAME_SUFFIX_DESC,
+                enumNameSuffix);
+
+        addOption(CodegenConstants.ENUM_VALUE_NAME_SUFFIX,
+                CodegenConstants.ENUM_VALUE_NAME_SUFFIX_DESC,
+                enumValueNameSuffix);
 
         classModifier.addEnum("", "Keep class default with no modifier");
         classModifier.addEnum("abstract", "Make class abstract");
@@ -347,7 +354,6 @@ public class AspNetCoreServerCodegen extends AbstractCSharpCodegen {
         } else {
             supportingFiles.add(new SupportingFile("Project.nuspec.mustache", packageFolder, packageName + ".nuspec"));
         }
-
 
         if (useSwashbuckle) {
             supportingFiles.add(new SupportingFile("Filters" + File.separator + "BasePathFilter.mustache",

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CsharpModelEnumTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharp/CsharpModelEnumTest.java
@@ -16,15 +16,21 @@
  */
 
 package org.openapitools.codegen.csharp;
-
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.DefaultCodegen;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.languages.AspNetCoreServerCodegen;
 import org.openapitools.codegen.languages.CSharpClientCodegen;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class CsharpModelEnumTest {
@@ -85,5 +91,41 @@ public class CsharpModelEnumTest {
         Assert.assertEquals(enumVar.datatypeWithEnum, "UnsharedThingEnum");
         Assert.assertTrue(enumVar.isEnum);
         */
+    }
+
+    @Test(description = "use default suffixes for enums")
+    public void useDefaultEnumSuffixes() {
+        final AspNetCoreServerCodegen codegen = new AspNetCoreServerCodegen();
+
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        codegen.setOpenAPI(openAPI);
+
+        final Schema petSchema = openAPI.getComponents().getSchemas().get("Pet");
+        final CodegenModel cm = codegen.fromModel("Pet", petSchema);
+        final CodegenProperty statusProperty = cm.vars.get(5);
+        Assert.assertEquals(statusProperty.name, "Status");
+        Assert.assertTrue(statusProperty.isEnum);
+        Assert.assertEquals(statusProperty.datatypeWithEnum, "StatusEnum");
+
+        Assert.assertEquals(codegen.toEnumVarName("Aaaa", ""), "AaaaEnum");
+    }
+
+    @Test(description = "use custom suffixes for enums")
+    public void useCustomEnumSuffixes() {
+        final AspNetCoreServerCodegen codegen = new AspNetCoreServerCodegen();
+        codegen.setEnumNameSuffix("EnumName");
+        codegen.setEnumValueNameSuffix("EnumValue");
+
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/petstore.yaml");
+        codegen.setOpenAPI(openAPI);
+
+        final Schema petSchema = openAPI.getComponents().getSchemas().get("Pet");
+        final CodegenModel cm = codegen.fromModel("Pet", petSchema);
+        final CodegenProperty statusProperty = cm.vars.get(5);
+        Assert.assertEquals(statusProperty.name, "Status");
+        Assert.assertTrue(statusProperty.isEnum);
+        Assert.assertEquals(statusProperty.datatypeWithEnum, "StatusEnumName");
+
+        Assert.assertEquals(codegen.toEnumVarName("Aaaa", ""), "AaaaEnumValue");
     }
 }


### PR DESCRIPTION
allows customization of enum suffixes for C#
addresses #4275 

```
{
    "apiPackage": "RestApi.Controllers",
    "modelPackage": "RestApi.Models",
    "packageName": "RestApi",
    "enumNameSuffix": "aaa",
    "enumValueNameSuffix": "bbb"
}
```
generates stuff like (not that i would ever want 'aaa' or 'bbb' suffixes, but it's a fine example...)
```
        /// <summary>
        /// Gets or Sets Status
        /// </summary>
        [TypeConverter(typeof(CustomEnumConverter<Statusaaa>))]
        [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
        public enum Statusaaa
        {
            
            /// <summary>
            /// Enum Activebbb for Active
            /// </summary>
            [EnumMember(Value = "Active")]
            Activebbb = 1,
            
            /// <summary>
            /// Enum Disabledbbb for Disabled
            /// </summary>
            [EnumMember(Value = "Disabled")]
            Disabledbbb = 2
        }
```

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
