### PR TITLE
[Python] [Performance] Avoid unnecessary checks inside the loop

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -629,11 +629,11 @@ class ApiClient(object):
             return data
 
         kwargs = {}
-        if klass.openapi_types is not None:
+        if (data is not None and
+                klass.openapi_types is not None and
+                isinstance(data, (list, dict))):
             for attr, attr_type in six.iteritems(klass.openapi_types):
-                if (data is not None and
-                        klass.attribute_map[attr] in data and
-                        isinstance(data, (list, dict))):
+                if klass.attribute_map[attr] in data:
                     value = data[klass.attribute_map[attr]]
                     kwargs[attr] = self.__deserialize(value, attr_type)
 

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -622,11 +622,11 @@ class ApiClient(object):
             return data
 
         kwargs = {}
-        if klass.openapi_types is not None:
+        if (data is not None and
+                klass.openapi_types is not None and
+                isinstance(data, (list, dict))):
             for attr, attr_type in six.iteritems(klass.openapi_types):
-                if (data is not None and
-                        klass.attribute_map[attr] in data and
-                        isinstance(data, (list, dict))):
+                if klass.attribute_map[attr] in data:
                     value = data[klass.attribute_map[attr]]
                     kwargs[attr] = self.__deserialize(value, attr_type)
 

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -624,11 +624,11 @@ class ApiClient(object):
             return data
 
         kwargs = {}
-        if klass.openapi_types is not None:
+        if (data is not None and
+                klass.openapi_types is not None and
+                isinstance(data, (list, dict))):
             for attr, attr_type in six.iteritems(klass.openapi_types):
-                if (data is not None and
-                        klass.attribute_map[attr] in data and
-                        isinstance(data, (list, dict))):
+                if klass.attribute_map[attr] in data:
                     value = data[klass.attribute_map[attr]]
                     kwargs[attr] = self.__deserialize(value, attr_type)
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -622,11 +622,11 @@ class ApiClient(object):
             return data
 
         kwargs = {}
-        if klass.openapi_types is not None:
+        if (data is not None and
+                klass.openapi_types is not None and
+                isinstance(data, (list, dict))):
             for attr, attr_type in six.iteritems(klass.openapi_types):
-                if (data is not None and
-                        klass.attribute_map[attr] in data and
-                        isinstance(data, (list, dict))):
+                if klass.attribute_map[attr] in data:
                     value = data[klass.attribute_map[attr]]
                     kwargs[attr] = self.__deserialize(value, attr_type)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -622,11 +622,11 @@ class ApiClient(object):
             return data
 
         kwargs = {}
-        if klass.openapi_types is not None:
+        if (data is not None and
+                klass.openapi_types is not None and
+                isinstance(data, (list, dict))):
             for attr, attr_type in six.iteritems(klass.openapi_types):
-                if (data is not None and
-                        klass.attribute_map[attr] in data and
-                        isinstance(data, (list, dict))):
+                if klass.attribute_map[attr] in data:
                     value = data[klass.attribute_map[attr]]
                     kwargs[attr] = self.__deserialize(value, attr_type)
 


### PR DESCRIPTION
isinstance is not a very cheap operation and this check is being performed multiple times inside the for loop unnecessarily.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
