### PR TITLE
[Python] Remove redundant else statement

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -353,7 +353,7 @@ class ApiClient(object):
                                                        query_params,
                                                        header_params, body,
                                                        post_params, files,
-                                                       response_type, 
+                                                       response_type,
                                                        auth_settings,
                                                        _return_http_data_only,
                                                        collection_formats,

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -347,18 +347,17 @@ class ApiClient(object):
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
                                    _preload_content, _request_timeout, _host)
-        else:
-            thread = self.pool.apply_async(self.__call_api, (resource_path,
-                                           method, path_params, query_params,
-                                           header_params, body,
-                                           post_params, files,
-                                           response_type, auth_settings,
-                                           _return_http_data_only,
-                                           collection_formats,
-                                           _preload_content,
-                                           _request_timeout,
-                                           _host))
-        return thread
+
+        return self.pool.apply_async(self.__call_api, (resource_path,
+                                        method, path_params, query_params,
+                                        header_params, body,
+                                        post_params, files,
+                                        response_type, auth_settings,
+                                        _return_http_data_only,
+                                        collection_formats,
+                                        _preload_content,
+                                        _request_timeout,
+                                        _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -349,15 +349,15 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                                        method, path_params, query_params,
-                                                        header_params, body,
-                                                        post_params, files,
-                                                        response_type, auth_settings,
-                                                        _return_http_data_only,
-                                                        collection_formats,
-                                                        _preload_content,
-                                                        _request_timeout,
-                                                        _host))
+                                                       method, path_params, query_params,
+                                                       header_params, body,
+                                                       post_params, files,
+                                                       response_type, auth_settings,
+                                                       _return_http_data_only,
+                                                       collection_formats,
+                                                       _preload_content,
+                                                       _request_timeout,
+                                                       _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 
 import datetime
-from dateutil.parser import parse
 import json
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -586,6 +585,7 @@ class ApiClient(object):
         :return: date.
         """
         try:
+            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -604,6 +604,7 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
+            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -349,15 +349,15 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                        method, path_params, query_params,
-                                        header_params, body,
-                                        post_params, files,
-                                        response_type, auth_settings,
-                                        _return_http_data_only,
-                                        collection_formats,
-                                        _preload_content,
-                                        _request_timeout,
-                                        _host))
+                                                        method, path_params, query_params,
+                                                        header_params, body,
+                                                        post_params, files,
+                                                        response_type, auth_settings,
+                                                        _return_http_data_only,
+                                                        collection_formats,
+                                                        _preload_content,
+                                                        _request_timeout,
+                                                        _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import datetime
+from dateutil.parser import parse
 import json
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -585,7 +586,6 @@ class ApiClient(object):
         :return: date.
         """
         try:
-            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -604,7 +604,6 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
-            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -349,10 +349,12 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                                       method, path_params, query_params,
+                                                       method, path_params,
+                                                       query_params,
                                                        header_params, body,
                                                        post_params, files,
-                                                       response_type, auth_settings,
+                                                       response_type, 
+                                                       auth_settings,
                                                        _return_http_data_only,
                                                        collection_formats,
                                                        _preload_content,

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -340,18 +340,17 @@ class ApiClient(object):
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
                                    _preload_content, _request_timeout, _host)
-        else:
-            thread = self.pool.apply_async(self.__call_api, (resource_path,
-                                           method, path_params, query_params,
-                                           header_params, body,
-                                           post_params, files,
-                                           response_type, auth_settings,
-                                           _return_http_data_only,
-                                           collection_formats,
-                                           _preload_content,
-                                           _request_timeout,
-                                           _host))
-        return thread
+
+        return self.pool.apply_async(self.__call_api, (resource_path,
+                                        method, path_params, query_params,
+                                        header_params, body,
+                                        post_params, files,
+                                        response_type, auth_settings,
+                                        _return_http_data_only,
+                                        collection_formats,
+                                        _preload_content,
+                                        _request_timeout,
+                                        _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import
 
 import datetime
-from dateutil.parser import parse
 import json
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -579,6 +578,7 @@ class ApiClient(object):
         :return: date.
         """
         try:
+            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -597,6 +597,7 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
+            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -342,10 +342,12 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                                       method, path_params, query_params,
+                                                       method, path_params,
+                                                       query_params,
                                                        header_params, body,
                                                        post_params, files,
-                                                       response_type, auth_settings,
+                                                       response_type, 
+                                                       auth_settings,
                                                        _return_http_data_only,
                                                        collection_formats,
                                                        _preload_content,

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -342,15 +342,15 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                                        method, path_params, query_params,
-                                                        header_params, body,
-                                                        post_params, files,
-                                                        response_type, auth_settings,
-                                                        _return_http_data_only,
-                                                        collection_formats,
-                                                        _preload_content,
-                                                        _request_timeout,
-                                                        _host))
+                                                       method, path_params, query_params,
+                                                       header_params, body,
+                                                       post_params, files,
+                                                       response_type, auth_settings,
+                                                       _return_http_data_only,
+                                                       collection_formats,
+                                                       _preload_content,
+                                                       _request_timeout,
+                                                       _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -346,7 +346,7 @@ class ApiClient(object):
                                                        query_params,
                                                        header_params, body,
                                                        post_params, files,
-                                                       response_type, 
+                                                       response_type,
                                                        auth_settings,
                                                        _return_http_data_only,
                                                        collection_formats,

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 
 import datetime
+from dateutil.parser import parse
 import json
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -578,7 +579,6 @@ class ApiClient(object):
         :return: date.
         """
         try:
-            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -597,7 +597,6 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
-            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -342,15 +342,15 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                        method, path_params, query_params,
-                                        header_params, body,
-                                        post_params, files,
-                                        response_type, auth_settings,
-                                        _return_http_data_only,
-                                        collection_formats,
-                                        _preload_content,
-                                        _request_timeout,
-                                        _host))
+                                                        method, path_params, query_params,
+                                                        header_params, body,
+                                                        post_params, files,
+                                                        response_type, auth_settings,
+                                                        _return_http_data_only,
+                                                        collection_formats,
+                                                        _preload_content,
+                                                        _request_timeout,
+                                                        _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -344,15 +344,15 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                                        method, path_params, query_params,
-                                                        header_params, body,
-                                                        post_params, files,
-                                                        response_type, auth_settings,
-                                                        _return_http_data_only,
-                                                        collection_formats,
-                                                        _preload_content,
-                                                        _request_timeout,
-                                                        _host))
+                                                       method, path_params, query_params,
+                                                       header_params, body,
+                                                       post_params, files,
+                                                       response_type, auth_settings,
+                                                       _return_http_data_only,
+                                                       collection_formats,
+                                                       _preload_content,
+                                                       _request_timeout,
+                                                       _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -342,18 +342,17 @@ class ApiClient(object):
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
                                    _preload_content, _request_timeout, _host)
-        else:
-            thread = self.pool.apply_async(self.__call_api, (resource_path,
-                                           method, path_params, query_params,
-                                           header_params, body,
-                                           post_params, files,
-                                           response_type, auth_settings,
-                                           _return_http_data_only,
-                                           collection_formats,
-                                           _preload_content,
-                                           _request_timeout,
-                                           _host))
-        return thread
+
+        return self.pool.apply_async(self.__call_api, (resource_path,
+                                        method, path_params, query_params,
+                                        header_params, body,
+                                        post_params, files,
+                                        response_type, auth_settings,
+                                        _return_http_data_only,
+                                        collection_formats,
+                                        _preload_content,
+                                        _request_timeout,
+                                        _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -344,15 +344,15 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                        method, path_params, query_params,
-                                        header_params, body,
-                                        post_params, files,
-                                        response_type, auth_settings,
-                                        _return_http_data_only,
-                                        collection_formats,
-                                        _preload_content,
-                                        _request_timeout,
-                                        _host))
+                                                        method, path_params, query_params,
+                                                        header_params, body,
+                                                        post_params, files,
+                                                        response_type, auth_settings,
+                                                        _return_http_data_only,
+                                                        collection_formats,
+                                                        _preload_content,
+                                                        _request_timeout,
+                                                        _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -344,10 +344,12 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                                       method, path_params, query_params,
+                                                       method, path_params,
+                                                       query_params,
                                                        header_params, body,
                                                        post_params, files,
-                                                       response_type, auth_settings,
+                                                       response_type, 
+                                                       auth_settings,
                                                        _return_http_data_only,
                                                        collection_formats,
                                                        _preload_content,

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 
 import datetime
+from dateutil.parser import parse
 import json
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -580,7 +581,6 @@ class ApiClient(object):
         :return: date.
         """
         try:
-            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -599,7 +599,6 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
-            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -348,7 +348,7 @@ class ApiClient(object):
                                                        query_params,
                                                        header_params, body,
                                                        post_params, files,
-                                                       response_type, 
+                                                       response_type,
                                                        auth_settings,
                                                        _return_http_data_only,
                                                        collection_formats,

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import
 
 import datetime
-from dateutil.parser import parse
 import json
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -581,6 +580,7 @@ class ApiClient(object):
         :return: date.
         """
         try:
+            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -599,6 +599,7 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
+            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -340,18 +340,17 @@ class ApiClient(object):
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
                                    _preload_content, _request_timeout, _host)
-        else:
-            thread = self.pool.apply_async(self.__call_api, (resource_path,
-                                           method, path_params, query_params,
-                                           header_params, body,
-                                           post_params, files,
-                                           response_type, auth_settings,
-                                           _return_http_data_only,
-                                           collection_formats,
-                                           _preload_content,
-                                           _request_timeout,
-                                           _host))
-        return thread
+
+        return self.pool.apply_async(self.__call_api, (resource_path,
+                                        method, path_params, query_params,
+                                        header_params, body,
+                                        post_params, files,
+                                        response_type, auth_settings,
+                                        _return_http_data_only,
+                                        collection_formats,
+                                        _preload_content,
+                                        _request_timeout,
+                                        _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import
 
 import datetime
-from dateutil.parser import parse
 import json
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -579,6 +578,7 @@ class ApiClient(object):
         :return: date.
         """
         try:
+            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -597,6 +597,7 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
+            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -342,10 +342,12 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                                       method, path_params, query_params,
+                                                       method, path_params,
+                                                       query_params,
                                                        header_params, body,
                                                        post_params, files,
-                                                       response_type, auth_settings,
+                                                       response_type, 
+                                                       auth_settings,
                                                        _return_http_data_only,
                                                        collection_formats,
                                                        _preload_content,

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -342,15 +342,15 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                                        method, path_params, query_params,
-                                                        header_params, body,
-                                                        post_params, files,
-                                                        response_type, auth_settings,
-                                                        _return_http_data_only,
-                                                        collection_formats,
-                                                        _preload_content,
-                                                        _request_timeout,
-                                                        _host))
+                                                       method, path_params, query_params,
+                                                       header_params, body,
+                                                       post_params, files,
+                                                       response_type, auth_settings,
+                                                       _return_http_data_only,
+                                                       collection_formats,
+                                                       _preload_content,
+                                                       _request_timeout,
+                                                       _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -346,7 +346,7 @@ class ApiClient(object):
                                                        query_params,
                                                        header_params, body,
                                                        post_params, files,
-                                                       response_type, 
+                                                       response_type,
                                                        auth_settings,
                                                        _return_http_data_only,
                                                        collection_formats,

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 
 import datetime
+from dateutil.parser import parse
 import json
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -578,7 +579,6 @@ class ApiClient(object):
         :return: date.
         """
         try:
-            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -597,7 +597,6 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
-            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -342,15 +342,15 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                        method, path_params, query_params,
-                                        header_params, body,
-                                        post_params, files,
-                                        response_type, auth_settings,
-                                        _return_http_data_only,
-                                        collection_formats,
-                                        _preload_content,
-                                        _request_timeout,
-                                        _host))
+                                                        method, path_params, query_params,
+                                                        header_params, body,
+                                                        post_params, files,
+                                                        response_type, auth_settings,
+                                                        _return_http_data_only,
+                                                        collection_formats,
+                                                        _preload_content,
+                                                        _request_timeout,
+                                                        _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -340,18 +340,17 @@ class ApiClient(object):
                                    response_type, auth_settings,
                                    _return_http_data_only, collection_formats,
                                    _preload_content, _request_timeout, _host)
-        else:
-            thread = self.pool.apply_async(self.__call_api, (resource_path,
-                                           method, path_params, query_params,
-                                           header_params, body,
-                                           post_params, files,
-                                           response_type, auth_settings,
-                                           _return_http_data_only,
-                                           collection_formats,
-                                           _preload_content,
-                                           _request_timeout,
-                                           _host))
-        return thread
+
+        return self.pool.apply_async(self.__call_api, (resource_path,
+                                        method, path_params, query_params,
+                                        header_params, body,
+                                        post_params, files,
+                                        response_type, auth_settings,
+                                        _return_http_data_only,
+                                        collection_formats,
+                                        _preload_content,
+                                        _request_timeout,
+                                        _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import
 
 import datetime
-from dateutil.parser import parse
 import json
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -579,6 +578,7 @@ class ApiClient(object):
         :return: date.
         """
         try:
+            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -597,6 +597,7 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
+            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -342,10 +342,12 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                                       method, path_params, query_params,
+                                                       method, path_params,
+                                                       query_params,
                                                        header_params, body,
                                                        post_params, files,
-                                                       response_type, auth_settings,
+                                                       response_type, 
+                                                       auth_settings,
                                                        _return_http_data_only,
                                                        collection_formats,
                                                        _preload_content,

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -342,15 +342,15 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                                        method, path_params, query_params,
-                                                        header_params, body,
-                                                        post_params, files,
-                                                        response_type, auth_settings,
-                                                        _return_http_data_only,
-                                                        collection_formats,
-                                                        _preload_content,
-                                                        _request_timeout,
-                                                        _host))
+                                                       method, path_params, query_params,
+                                                       header_params, body,
+                                                       post_params, files,
+                                                       response_type, auth_settings,
+                                                       _return_http_data_only,
+                                                       collection_formats,
+                                                       _preload_content,
+                                                       _request_timeout,
+                                                       _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -346,7 +346,7 @@ class ApiClient(object):
                                                        query_params,
                                                        header_params, body,
                                                        post_params, files,
-                                                       response_type, 
+                                                       response_type,
                                                        auth_settings,
                                                        _return_http_data_only,
                                                        collection_formats,

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 
 import datetime
+from dateutil.parser import parse
 import json
 import mimetypes
 from multiprocessing.pool import ThreadPool
@@ -578,7 +579,6 @@ class ApiClient(object):
         :return: date.
         """
         try:
-            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -597,7 +597,6 @@ class ApiClient(object):
         :return: datetime.
         """
         try:
-            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -342,15 +342,15 @@ class ApiClient(object):
                                    _preload_content, _request_timeout, _host)
 
         return self.pool.apply_async(self.__call_api, (resource_path,
-                                        method, path_params, query_params,
-                                        header_params, body,
-                                        post_params, files,
-                                        response_type, auth_settings,
-                                        _return_http_data_only,
-                                        collection_formats,
-                                        _preload_content,
-                                        _request_timeout,
-                                        _host))
+                                                        method, path_params, query_params,
+                                                        header_params, body,
+                                                        post_params, files,
+                                                        response_type, auth_settings,
+                                                        _return_http_data_only,
+                                                        collection_formats,
+                                                        _preload_content,
+                                                        _request_timeout,
+                                                        _host))
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,


### PR DESCRIPTION
If statement has a return statement inside it. There is no need for having else and introducing indentation in the code. 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
