### PR TITLE
[typescript-fetch] Fix for nullable enums + separate treatment of null and undefined

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -19,6 +19,6 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     return json as {{classname}};
 }
 
-export function {{classname}}ToJSON(value?: {{classname}}): any {
+export function {{classname}}ToJSON(value?: {{classname}} | null): any {
     return value as any;
 }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -63,10 +63,10 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{#vars}}
         {{#isPrimitiveType}}
         {{#isDate}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}new Date(json['{{baseName}}']),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
         {{/isDate}}
         {{#isDateTime}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}new Date(json['{{baseName}}']),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}new Date(json['{{baseName}}'])),
         {{/isDateTime}}
         {{^isDate}}
         {{^isDateTime}}
@@ -76,10 +76,10 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isListContainer}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/isListContainer}}
         {{#isMapContainer}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON),
+        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#isNullable}}json['{{baseName}}'] === null ? null : {{/isNullable}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/isMapContainer}}
         {{^isListContainer}}
         {{^isMapContainer}}
@@ -116,14 +116,14 @@ export function {{classname}}ToJSON(value?: {{classname}} | null): any {
         {{#vars}}
         {{^isReadOnly}}
         {{#isPrimitiveType}}
-        '{{baseName}}': {{#isDate}}{{^required}}value.{{name}} == null ? undefined : {{/required}}value.{{name}}.toISOString().substr(0,10){{/isDate}}{{#isDateTime}}{{^required}}value.{{name}} == null ? undefined : {{/required}}value.{{name}}.toISOString(){{/isDateTime}}{{^isDate}}{{^isDateTime}}value.{{name}}{{/isDateTime}}{{/isDate}},
+        '{{baseName}}': {{#isDate}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString().substr(0,10)){{/isDate}}{{#isDateTime}}{{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}value.{{name}}.toISOString()){{/isDateTime}}{{^isDate}}{{^isDateTime}}value.{{name}}{{/isDateTime}}{{/isDate}},
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isListContainer}}
-        '{{baseName}}': {{^required}}value.{{name}} == null ? undefined : {{/required}}(value.{{name}} as Array<any>).map({{#items}}{{datatype}}{{/items}}ToJSON),
+        '{{baseName}}': {{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}(value.{{name}} as Array<any>).map({{#items}}{{datatype}}{{/items}}ToJSON)),
         {{/isListContainer}}
         {{#isMapContainer}}
-        '{{baseName}}': {{^required}}value.{{name}} == null ? undefined : {{/required}}mapValues(value.{{name}}, {{#items}}{{datatype}}{{/items}}ToJSON),
+        '{{baseName}}': {{^required}}value.{{name}} === undefined ? undefined : {{/required}}({{#isNullable}}value.{{name}} === null ? null : {{/isNullable}}mapValues(value.{{name}}, {{#items}}{{datatype}}{{/items}}ToJSON)),
         {{/isMapContainer}}
         {{^isListContainer}}
         {{^isMapContainer}}
@@ -134,7 +134,7 @@ export function {{classname}}ToJSON(value?: {{classname}} | null): any {
         '{{baseName}}': value.{{name}},
         {{/isFreeFormObject}}
         {{/isMapContainer}}
-        {{/isListContainer}}        
+        {{/isListContainer}}
         {{/isPrimitiveType}}
         {{/isReadOnly}}
         {{/vars}}

--- a/samples/client/petstore/typescript-fetch/builds/default/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/src/models/Order.ts
@@ -70,7 +70,7 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'id': !exists(json, 'id') ? undefined : json['id'],
         'petId': !exists(json, 'petId') ? undefined : json['petId'],
         'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : new Date(json['shipDate']),
+        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
         'status': !exists(json, 'status') ? undefined : json['status'],
         'complete': !exists(json, 'complete') ? undefined : json['complete'],
     };
@@ -88,7 +88,7 @@ export function OrderToJSON(value?: Order | null): any {
         'id': value.id,
         'petId': value.petId,
         'quantity': value.quantity,
-        'shipDate': value.shipDate == null ? undefined : value.shipDate.toISOString(),
+        'shipDate': value.shipDate === undefined ? undefined : (value.shipDate.toISOString()),
         'status': value.status,
         'complete': value.complete,
     };

--- a/samples/client/petstore/typescript-fetch/builds/default/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/src/models/Pet.ts
@@ -82,7 +82,7 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : (json['tags'] as Array<any>).map(TagFromJSON),
+        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': !exists(json, 'status') ? undefined : json['status'],
     };
 }
@@ -100,7 +100,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': value.tags == null ? undefined : (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : ((value.tags as Array<any>).map(TagToJSON)),
         'status': value.status,
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -70,7 +70,7 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'id': !exists(json, 'id') ? undefined : json['id'],
         'petId': !exists(json, 'petId') ? undefined : json['petId'],
         'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : new Date(json['shipDate']),
+        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
         'status': !exists(json, 'status') ? undefined : json['status'],
         'complete': !exists(json, 'complete') ? undefined : json['complete'],
     };
@@ -88,7 +88,7 @@ export function OrderToJSON(value?: Order | null): any {
         'id': value.id,
         'petId': value.petId,
         'quantity': value.quantity,
-        'shipDate': value.shipDate == null ? undefined : value.shipDate.toISOString(),
+        'shipDate': value.shipDate === undefined ? undefined : (value.shipDate.toISOString()),
         'status': value.status,
         'complete': value.complete,
     };

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -82,7 +82,7 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : (json['tags'] as Array<any>).map(TagFromJSON),
+        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': !exists(json, 'status') ? undefined : json['status'],
     };
 }
@@ -100,7 +100,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': value.tags == null ? undefined : (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : ((value.tags as Array<any>).map(TagToJSON)),
         'status': value.status,
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/models/Order.ts
@@ -70,7 +70,7 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'id': !exists(json, 'id') ? undefined : json['id'],
         'petId': !exists(json, 'petId') ? undefined : json['petId'],
         'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : new Date(json['shipDate']),
+        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
         'status': !exists(json, 'status') ? undefined : json['status'],
         'complete': !exists(json, 'complete') ? undefined : json['complete'],
     };
@@ -88,7 +88,7 @@ export function OrderToJSON(value?: Order | null): any {
         'id': value.id,
         'petId': value.petId,
         'quantity': value.quantity,
-        'shipDate': value.shipDate == null ? undefined : value.shipDate.toISOString(),
+        'shipDate': value.shipDate === undefined ? undefined : (value.shipDate.toISOString()),
         'status': value.status,
         'complete': value.complete,
     };

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/src/models/Pet.ts
@@ -82,7 +82,7 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : (json['tags'] as Array<any>).map(TagFromJSON),
+        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': !exists(json, 'status') ? undefined : json['status'],
     };
 }
@@ -100,7 +100,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': value.tags == null ? undefined : (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : ((value.tags as Array<any>).map(TagToJSON)),
         'status': value.status,
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -70,7 +70,7 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'id': !exists(json, 'id') ? undefined : json['id'],
         'petId': !exists(json, 'petId') ? undefined : json['petId'],
         'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : new Date(json['shipDate']),
+        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
         'status': !exists(json, 'status') ? undefined : json['status'],
         'complete': !exists(json, 'complete') ? undefined : json['complete'],
     };
@@ -88,7 +88,7 @@ export function OrderToJSON(value?: Order | null): any {
         'id': value.id,
         'petId': value.petId,
         'quantity': value.quantity,
-        'shipDate': value.shipDate == null ? undefined : value.shipDate.toISOString(),
+        'shipDate': value.shipDate === undefined ? undefined : (value.shipDate.toISOString()),
         'status': value.status,
         'complete': value.complete,
     };

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -82,7 +82,7 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : (json['tags'] as Array<any>).map(TagFromJSON),
+        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': !exists(json, 'status') ? undefined : json['status'],
     };
 }
@@ -100,7 +100,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': value.tags == null ? undefined : (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : ((value.tags as Array<any>).map(TagToJSON)),
         'status': value.status,
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Order.ts
@@ -70,7 +70,7 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'id': !exists(json, 'id') ? undefined : json['id'],
         'petId': !exists(json, 'petId') ? undefined : json['petId'],
         'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : new Date(json['shipDate']),
+        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
         'status': !exists(json, 'status') ? undefined : json['status'],
         'complete': !exists(json, 'complete') ? undefined : json['complete'],
     };
@@ -88,7 +88,7 @@ export function OrderToJSON(value?: Order | null): any {
         'id': value.id,
         'petId': value.petId,
         'quantity': value.quantity,
-        'shipDate': value.shipDate == null ? undefined : value.shipDate.toISOString(),
+        'shipDate': value.shipDate === undefined ? undefined : (value.shipDate.toISOString()),
         'status': value.status,
         'complete': value.complete,
     };

--- a/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/typescript-three-plus/src/models/Pet.ts
@@ -82,7 +82,7 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : (json['tags'] as Array<any>).map(TagFromJSON),
+        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': !exists(json, 'status') ? undefined : json['status'],
     };
 }
@@ -100,7 +100,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': value.tags == null ? undefined : (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : ((value.tags as Array<any>).map(TagToJSON)),
         'status': value.status,
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/models/Order.ts
@@ -70,7 +70,7 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'id': !exists(json, 'id') ? undefined : json['id'],
         'petId': !exists(json, 'petId') ? undefined : json['petId'],
         'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : new Date(json['shipDate']),
+        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
         'status': !exists(json, 'status') ? undefined : json['status'],
         'complete': !exists(json, 'complete') ? undefined : json['complete'],
     };
@@ -88,7 +88,7 @@ export function OrderToJSON(value?: Order | null): any {
         'id': value.id,
         'petId': value.petId,
         'quantity': value.quantity,
-        'shipDate': value.shipDate == null ? undefined : value.shipDate.toISOString(),
+        'shipDate': value.shipDate === undefined ? undefined : (value.shipDate.toISOString()),
         'status': value.status,
         'complete': value.complete,
     };

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/src/models/Pet.ts
@@ -82,7 +82,7 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : (json['tags'] as Array<any>).map(TagFromJSON),
+        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': !exists(json, 'status') ? undefined : json['status'],
     };
 }
@@ -100,7 +100,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': value.tags == null ? undefined : (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : ((value.tags as Array<any>).map(TagToJSON)),
         'status': value.status,
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -70,7 +70,7 @@ export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Ord
         'id': !exists(json, 'id') ? undefined : json['id'],
         'petId': !exists(json, 'petId') ? undefined : json['petId'],
         'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : new Date(json['shipDate']),
+        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
         'status': !exists(json, 'status') ? undefined : json['status'],
         'complete': !exists(json, 'complete') ? undefined : json['complete'],
     };
@@ -88,7 +88,7 @@ export function OrderToJSON(value?: Order | null): any {
         'id': value.id,
         'petId': value.petId,
         'quantity': value.quantity,
-        'shipDate': value.shipDate == null ? undefined : value.shipDate.toISOString(),
+        'shipDate': value.shipDate === undefined ? undefined : (value.shipDate.toISOString()),
         'status': value.status,
         'complete': value.complete,
     };

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -82,7 +82,7 @@ export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
         'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : (json['tags'] as Array<any>).map(TagFromJSON),
+        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'status': !exists(json, 'status') ? undefined : json['status'],
     };
 }
@@ -100,7 +100,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value.category),
         'name': value.name,
         'photoUrls': value.photoUrls,
-        'tags': value.tags == null ? undefined : (value.tags as Array<any>).map(TagToJSON),
+        'tags': value.tags === undefined ? undefined : ((value.tags as Array<any>).map(TagToJSON)),
         'status': value.status,
     };
 }


### PR DESCRIPTION
The typescript-fetch generator can still generate code with type failures in the case of nullable enum values. This addresses this by applying a similar fix that was made to modelGenericMustache to modelEnumMustache.

In addition, tweak the previous fix to modelGenericMustache so that it handles null and undefined separately rather than using == to map them both to undefined. There is a difference between a key existing vs. a key existing with a null value.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
