### PR TITLE
fix(typescript-angular): do not call .toISOString() on a string (#4330)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -182,7 +182,7 @@ export class {{classname}} {
         {{^isListContainer}}
         if ({{paramName}} !== undefined && {{paramName}} !== null) {
         {{#isDateTime}}
-            {{#useHttpClient}}queryParameters = {{/useHttpClient}}queryParameters.set('{{baseName}}', <any>{{paramName}}.toISOString());
+            {{#useHttpClient}}queryParameters = {{/useHttpClient}}queryParameters.set('{{baseName}}', ({{paramName}} as any instanceof Date) ? ({{paramName}} as any).toISOString().substr(0, 10) : {{paramName}});
         {{/isDateTime}}
         {{^isDateTime}}
             {{#useHttpClient}}queryParameters = {{/useHttpClient}}queryParameters.set('{{baseName}}', <any>{{paramName}});


### PR DESCRIPTION
fixes #4330, analogous to #3423.