### PR TITLE
[Java] Fix security alerts due to com.fasterxml.jackson.core:jackson-databind

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -121,7 +121,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
-    jackson_databind_version = "2.9.10"
+    jackson_databind_version = "2.9.10.1"
     jackson_databind_nullable_version = "0.2.0"
     {{#threetenbp}}
     jackson_threetenbp_version = "2.9.10"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.sbt.mustache
@@ -16,7 +16,7 @@ lazy val root = (project in file(".")).
       "io.github.openfeign.form" % "feign-form" % "2.1.0" % "compile",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.9.10" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.10" % "compile",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-{{^java8}}joda{{/java8}}{{#java8}}jsr310{{/java8}}" % "2.9.10" % "compile",
       "com.github.joschi.jackson" % "jackson-datatype-threetenbp" % "2.9.10" % "compile",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.1" % "compile",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -316,7 +316,7 @@
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
-        <jackson-databind-version>2.9.10</jackson-databind-version>
+        <jackson-databind-version>2.9.10.1</jackson-databind-version>
         {{#threetenbp}}
         <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>
         {{/threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -144,7 +144,7 @@
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
         <spring-web-version>5.0.7.RELEASE</spring-web-version>
         <jackson-version>2.9.10</jackson-version>
-        <jackson-databind-version>2.9.10</jackson-databind-version>
+        <jackson-databind-version>2.9.10.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
         <reactor-version>3.1.8.RELEASE</reactor-version>

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -97,7 +97,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
-    jackson_databind_version = "2.9.10"
+    jackson_databind_version = "2.9.10.1"
     jackson_databind_nullable_version = "0.2.0"
     jackson_threetenbp_version = "2.9.10"
     feign_version = "9.7.0"

--- a/samples/client/petstore/java/feign/build.sbt
+++ b/samples/client/petstore/java/feign/build.sbt
@@ -16,7 +16,7 @@ lazy val root = (project in file(".")).
       "io.github.openfeign.form" % "feign-form" % "2.1.0" % "compile",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.9.10" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.10" % "compile",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.9.10" % "compile",
       "com.github.joschi.jackson" % "jackson-datatype-threetenbp" % "2.9.10" % "compile",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.1" % "compile",

--- a/samples/client/petstore/java/feign/pom.xml
+++ b/samples/client/petstore/java/feign/pom.xml
@@ -283,7 +283,7 @@
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
-        <jackson-databind-version>2.9.10</jackson-databind-version>
+        <jackson-databind-version>2.9.10.1</jackson-databind-version>
         <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>
         <junit-version>4.12</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/feign10x/build.gradle
+++ b/samples/client/petstore/java/feign10x/build.gradle
@@ -97,7 +97,7 @@ if(hasProperty('target') && target == 'android') {
 ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
-    jackson_databind_version = "2.9.10"
+    jackson_databind_version = "2.9.10.1"
     jackson_databind_nullable_version = "0.2.0"
     jackson_threetenbp_version = "2.9.10"
     feign_version = "10.2.3"

--- a/samples/client/petstore/java/feign10x/build.sbt
+++ b/samples/client/petstore/java/feign10x/build.sbt
@@ -16,7 +16,7 @@ lazy val root = (project in file(".")).
       "io.github.openfeign.form" % "feign-form" % "2.1.0" % "compile",
       "com.fasterxml.jackson.core" % "jackson-core" % "2.9.10" % "compile",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.10" % "compile",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10" % "compile",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10.1" % "compile",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % "2.9.10" % "compile",
       "com.github.joschi.jackson" % "jackson-datatype-threetenbp" % "2.9.10" % "compile",
       "org.apache.oltu.oauth2" % "org.apache.oltu.oauth2.client" % "1.0.1" % "compile",

--- a/samples/client/petstore/java/feign10x/pom.xml
+++ b/samples/client/petstore/java/feign10x/pom.xml
@@ -283,7 +283,7 @@
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
-        <jackson-databind-version>2.9.10</jackson-databind-version>
+        <jackson-databind-version>2.9.10.1</jackson-databind-version>
         <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>
         <junit-version>4.12</junit-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/webclient/pom.xml
+++ b/samples/client/petstore/java/webclient/pom.xml
@@ -123,7 +123,7 @@
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
         <spring-web-version>5.0.7.RELEASE</spring-web-version>
         <jackson-version>2.9.10</jackson-version>
-        <jackson-databind-version>2.9.10</jackson-databind-version>
+        <jackson-databind-version>2.9.10.1</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
         <reactor-version>3.1.8.RELEASE</reactor-version>


### PR DESCRIPTION
- Fix security alerts due to com.fasterxml.jackson.core:jackson-databind

```
CVE-2019-16942 More information
moderate severity
Vulnerable versions: < 2.9.10.1
Patched version: 2.9.10.1
A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.10. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the commons-dbcp (1.4) jar in the classpath, and an attacker can find an RMI service endpoint to access, it is possible to make the service execute a malicious payload. This issue exists because of org.apache.commons.dbcp.datasources.SharedPoolDataSource and org.apache.commons.dbcp.datasources.PerUserPoolDataSource mishandling.
```


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)


