### PR TITLE
Add support to install openapi-generator via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ OpenAPI Generator allows generation of API client libraries (SDK generation), se
     - [1.5 - Homebrew](#15---homebrew)
     - [1.6 - Docker](#16---docker)
     - [1.7 - NPM](#17---npm)    
+    - [1.8 - PIP](#18---pip)
   - [2 - Getting Started](#2---getting-started)
   - [3 - Usage](#3---usage)
     - [3.1 - Customization](#31---customization)
@@ -396,6 +397,27 @@ Or install it as dev-dependency:
 npm install @openapitools/openapi-generator-cli -D
 ```
 <!-- /RELEASE_VERSION -->
+
+### [1.8 - PIP](#table-of-contents)
+
+Openapi Generator also supports a [PIP package wrapper](https://pypi.org/project/openapigenerator/) available for different platforms (e.g. Linux, Mac, Windows). (JVM is still required)
+Please see the [project's README](https://github.com/openapitools/openapi-generator-cli-pip) for more information.
+
+Install it globally to get the CLI available on the command line:
+
+```sh
+pip install openapigenerator
+openapi-generator version
+```
+
+<!-- RELEASE_VERSION -->
+Or install a particular OpenAPI Generator version (e.g. v4.2.0):
+
+```sh
+pip install openapigenerator==4.2.0
+```
+<!-- /RELEASE_VERSION -->
+
 ## [2 - Getting Started](#table-of-contents)
 
 To generate a PHP client for [petstore.yaml](https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml), please run the following

--- a/README.md
+++ b/README.md
@@ -406,15 +406,15 @@ Please see the [project's README](https://github.com/openapitools/openapi-genera
 Install it globally to get the CLI available on the command line:
 
 ```sh
-pip install openapigenerator
+pip install openapi-generator-cli
 openapi-generator version
 ```
 
 <!-- RELEASE_VERSION -->
-Or install a particular OpenAPI Generator version (e.g. v4.2.0):
+Or install a particular OpenAPI Generator version (e.g. v4.3.1):
 
 ```sh
-pip install openapigenerator==4.2.0
+pip install openapi-generator-cli==4.3.1
 ```
 <!-- /RELEASE_VERSION -->
 


### PR DESCRIPTION
openapi-generator can be installed via npm this is an attempt to make the same available via pip

Code Repo: https://github.com/slash-arun/openapi-generator-cli-pip
PYPI: https://pypi.org/project/openapigenerator/

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
