### PR TITLE
Fixes Kotlin client property names that include a dollar sign for template overrides

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -30,6 +30,8 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class KotlinClientCodegen extends AbstractKotlinCodegen {
 
@@ -287,15 +289,20 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
             CodegenModel cm = (CodegenModel) mo.get("model");
 
             // escape the variable base name for use as a string literal
-            if (cm.requiredVars != null) {
-                for (CodegenProperty var : cm.requiredVars) {
-                    var.vendorExtensions.put(VENDOR_EXTENSION_BASE_NAME_LITERAL, var.baseName.replace("$", "\\$"));
-                }
-            }
-            if (cm.optionalVars != null) {
-                for (CodegenProperty var : cm.optionalVars) {
-                    var.vendorExtensions.put(VENDOR_EXTENSION_BASE_NAME_LITERAL, var.baseName.replace("$", "\\$"));
-                }
+            List<CodegenProperty> vars = Stream.of(
+                    cm.vars,
+                    cm.allVars,
+                    cm.optionalVars,
+                    cm.requiredVars,
+                    cm.readOnlyVars,
+                    cm.readWriteVars,
+                    cm.parentVars
+                )
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+
+            for (CodegenProperty var : vars) {
+                var.vendorExtensions.put(VENDOR_EXTENSION_BASE_NAME_LITERAL, var.baseName.replace("$", "\\$"));
             }
         }
 


### PR DESCRIPTION
This applies #4229, which fixes #4228 but on all vars, not only on `requiredVars` and `optionalVars`.
This allows template overrides relying on another set of `vars` to work properly.
(For example, our templates rely on `vars` so we don't need req_var and opt_var templates)

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. (/cc @jimschubert)
