### PR TITLE
Remove deprecated API use of ObjectFactory.property() (#2613)

### DIFF
--- a/modules/openapi-generator-gradle-plugin/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.3.20'
     repositories {
         mavenLocal()
         mavenCentral()
@@ -15,7 +15,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins:1.0-rc-3"
+        classpath "gradle.plugin.org.gradle.kotlin:gradle-kotlin-dsl-plugins:1.1.3"
         classpath "com.gradle.publish:plugin-publish-plugin:0.10.1"
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.20.0"
         classpath "de.marcphilipp.gradle:nexus-publish-plugin:0.2.0"

--- a/modules/openapi-generator-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/modules/openapi-generator-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://downloads.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-        <gradleVersion>4.10.2</gradleVersion>
+        <gradleVersion>5.2.1</gradleVersion>
     </properties>
 
     <pluginRepositories>

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -18,6 +18,7 @@ package org.openapitools.generator.gradle.plugin.extensions
 
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.listProperty
+import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 
 /**
@@ -66,7 +67,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * Sets specified system properties.
      */
-    val systemProperties = project.objects.property<Map<String, String>>()
+    val systemProperties = project.objects.mapProperty<String, String>()
 
     /**
      * Path to json configuration file.
@@ -108,22 +109,22 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * Sets instantiation type mappings.
      */
-    val instantiationTypes = project.objects.property<Map<String, String>>()
+    val instantiationTypes = project.objects.mapProperty<String, String>()
 
     /**
      * Sets mappings between OpenAPI spec types and generated code types.
      */
-    val typeMappings = project.objects.property<Map<String, String>>()
+    val typeMappings = project.objects.mapProperty<String, String>()
 
     /**
      * Sets additional properties that can be referenced by the mustache templates.
      */
-    val additionalProperties = project.objects.property<Map<String, String>>()
+    val additionalProperties = project.objects.mapProperty<String, String>()
 
     /**
      * Sets server variable for server URL template substitution, in the format of name=value,name=value.
      */
-    val serverVariables = project.objects.property<Map<String, String>>()
+    val serverVariables = project.objects.mapProperty<String, String>()
 
     /**
      * Specifies additional language specific primitive types in the format of type1,type2,type3,type3. For example: String,boolean,Boolean,Double.
@@ -133,7 +134,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * Specifies mappings between a given class and the import that should be used for that class.
      */
-    val importMappings = project.objects.property<Map<String, String>>()
+    val importMappings = project.objects.mapProperty<String, String>()
 
     /**
      * Root package for generated code.
@@ -188,7 +189,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * Specifies how a reserved name should be escaped to. Otherwise, the default _<name> is used.
      */
-    val reservedWordsMappings = project.objects.property<Map<String, String>>()
+    val reservedWordsMappings = project.objects.mapProperty<String, String>()
 
     /**
      * Specifies an override location for the .openapi-generator-ignore file. Most useful on initial generation.
@@ -304,7 +305,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * A map of options specific to a generator.
      */
-    val configOptions = project.objects.property<Map<String, String>>()
+    val configOptions = project.objects.mapProperty<String, String>()
 
     init {
         applyDefaults()

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.kotlin.dsl.listProperty
+import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 import org.openapitools.codegen.CodegenConstants
 import org.openapitools.codegen.DefaultGenerator
@@ -90,7 +91,7 @@ open class GenerateTask : DefaultTask() {
      * Sets specified system properties.
      */
     @get:Internal
-    val systemProperties = project.objects.property<Map<String, String>>()
+    val systemProperties = project.objects.mapProperty<String, String>()
 
     /**
      * Path to json configuration file.
@@ -140,27 +141,27 @@ open class GenerateTask : DefaultTask() {
      * Sets instantiation type mappings.
      */
     @get:Internal
-    val instantiationTypes = project.objects.property<Map<String, String>>()
+    val instantiationTypes = project.objects.mapProperty<String, String>()
 
     /**
      * Sets mappings between OpenAPI spec types and generated code types.
      */
     @get:Internal
-    val typeMappings = project.objects.property<Map<String, String>>()
+    val typeMappings = project.objects.mapProperty<String, String>()
 
     /**
      * Sets additional properties that can be referenced by the mustache templates in the format of name=value,name=value.
      * You can also have multiple occurrences of this option.
      */
     @get:Internal
-    val additionalProperties = project.objects.property<Map<String, String>>()
+    val additionalProperties = project.objects.mapProperty<String, String>()
 
     /**
      * Sets server variable for server URL template substitution, in the format of name=value,name=value.
      * You can also have multiple occurrences of this option.
      */
     @get:Internal
-    val serverVariables = project.objects.property<Map<String, String>>()
+    val serverVariables = project.objects.mapProperty<String, String>()
 
     /**
      * Specifies additional language specific primitive types in the format of type1,type2,type3,type3. For example: String,boolean,Boolean,Double.
@@ -172,7 +173,7 @@ open class GenerateTask : DefaultTask() {
      * Specifies mappings between a given class and the import that should be used for that class.
      */
     @get:Internal
-    val importMappings = project.objects.property<Map<String, String>>()
+    val importMappings = project.objects.mapProperty<String, String>()
 
     /**
      * Root package for generated code.
@@ -238,7 +239,7 @@ open class GenerateTask : DefaultTask() {
      * Specifies how a reserved name should be escaped to.
      */
     @get:Internal
-    val reservedWordsMappings = project.objects.property<Map<String, String>>()
+    val reservedWordsMappings = project.objects.mapProperty<String, String>()
 
     /**
      * Specifies an override location for the .openapi-generator-ignore file. Most useful on initial generation.
@@ -372,7 +373,7 @@ open class GenerateTask : DefaultTask() {
      * A dynamic map of options specific to a generator.
      */
     @get:Internal
-    val configOptions = project.objects.property<Map<String, String>>()
+    val configOptions = project.objects.mapProperty<String, String>()
 
     private fun <T : Any?> Property<T>.ifNotEmpty(block: Property<T>.(T) -> Unit) {
         if (isPresent) {


### PR DESCRIPTION
**Description**
```
A problem occurred evaluating project ':ua.aval.biz.client.android'.
> Failed to apply plugin [id 'org.openapi.generator']
   > Could not create an instance of type org.openapitools.generator.gradle.plugin.extensions.OpenApiGeneratorGenerateExtension.
      > Please use the ObjectFactory.mapProperty() method to create a property of type Map<K, V>.
```
There error was produced in Gradle 6.0-rc-2
 
**openapi-generator version**
4.2.0

**Related issues/PRs**
#2613 
