### PR TITLE
[kotlin] [bugfix] [maven-plugin]: prevent ClassCastException with boolean config options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,6 +138,7 @@ script:
   # test maven plugin
   - mvn clean compile -f modules/openapi-generator-maven-plugin/examples/java-client.xml
   - mvn clean compile -f modules/openapi-generator-maven-plugin/examples/multi-module/pom.xml
+  - mvn clean compile -f modules/openapi-generator-maven-plugin/examples/kotlin.xml
   # test gradle plugin
   - (cd modules/openapi-generator-gradle-plugin/samples/local-spec && ./gradlew buildGoSdk)
   - (cd modules/openapi-generator-gradle-plugin/samples/local-spec && ./gradlew openApiGenerate)

--- a/modules/openapi-generator-maven-plugin/examples/kotlin.xml
+++ b/modules/openapi-generator-maven-plugin/examples/kotlin.xml
@@ -1,0 +1,187 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.openapitools</groupId>
+	<artifactId>sample-project</artifactId>
+	<packaging>jar</packaging>
+	<version>1.0-SNAPSHOT</version>
+	<name>sample-project</name>
+	<url>http://maven.apache.org</url>
+	<build>
+		<plugins>
+			<!-- activate the plugin -->
+			<plugin>
+				<groupId>org.openapitools</groupId>
+				<artifactId>openapi-generator-maven-plugin</artifactId>
+				<!-- RELEASE_VERSION -->
+				<version>4.2.1-SNAPSHOT</version>
+				<!-- /RELEASE_VERSION -->
+				<executions>
+					<execution>
+						<id>default</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<!-- specify the swagger yaml -->
+							<inputSpec>${project.basedir}/swagger.yaml</inputSpec>
+
+							<!-- target to generate java client code -->
+							<generatorName>kotlin</generatorName>
+
+							<!-- hint: if you want to generate java server code, e.g. based on Spring Boot,
+								 you can use the following target: <generatorName>spring</generatorName> -->
+
+							<!-- pass any necessary config options -->
+							<configOptions>
+								<serializableModel>true</serializableModel>
+							</configOptions>
+
+						</configuration>
+					</execution>
+					<execution>
+						<id>remote</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<!-- specify the swagger yaml -->
+							<inputSpec>https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/2_0/petstore.yaml
+							</inputSpec>
+
+							<!-- target to generate java client code -->
+							<generatorName>kotlin</generatorName>
+
+							<!-- hint: if you want to generate java server code, e.g. based on Spring Boot,
+								 you can use the following target: <generatorName>spring</generatorName> -->
+
+							<!-- pass any necessary config options -->
+							<configOptions>
+								<serializableModel>true</serializableModel>
+							</configOptions>
+
+							<output>${project.build.directory}/generated-sources/remote-openapi</output>
+							<apiPackage>remote.org.openapitools.client.api</apiPackage>
+							<modelPackage>remote.org.openapitools.client.model</modelPackage>
+							<invokerPackage>remote.org.openapitools.client</invokerPackage>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+					<proc>none</proc>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>sonatype-snapshots</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+		</pluginRepository>
+	</pluginRepositories>
+	<dependencies>
+		<!-- dependencies are needed for the client being generated -->
+
+		<dependency>
+			<groupId>io.swagger</groupId>
+			<artifactId>swagger-annotations</artifactId>
+			<version>${swagger-annotations-version}</version>
+		</dependency>
+
+		<!-- You can find the dependencies for the library configuation you chose by looking in JavaClientCodegen.
+			 Then find the corresponding dependency on Maven Central, and set the versions in the property section below -->
+
+		<!-- HTTP client: jersey-client -->
+		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-client</artifactId>
+			<version>${jersey-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-multipart</artifactId>
+			<version>${jersey-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-json-jackson</artifactId>
+			<version>${jersey-version}</version>
+		</dependency>
+
+		<!-- @Nullable annotation -->
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+
+		<!-- JSON processing: jackson -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.jaxrs</groupId>
+			<artifactId>jackson-jaxrs-base</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.jaxrs</groupId>
+			<artifactId>jackson-jaxrs-json-provider</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openapitools</groupId>
+			<artifactId>jackson-databind-nullable</artifactId>
+			<version>${jackson-databind-nullable-version}</version>
+		</dependency>
+
+		<!-- Joda time: if you use it -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-joda</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>${jodatime-version}</version>
+		</dependency>
+
+		<!-- Base64 encoding that works in both JVM and Android -->
+		<dependency>
+			<groupId>com.brsanthu</groupId>
+			<artifactId>migbase64</artifactId>
+			<version>2.2</version>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<swagger-annotations-version>1.5.8</swagger-annotations-version>
+		<jersey-version>2.27</jersey-version>
+		<jackson-version>2.8.9</jackson-version>
+		<jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+		<jodatime-version>2.7</jodatime-version>
+		<maven-plugin-version>1.0.0</maven-plugin-version>
+		<junit-version>4.8.1</junit-version>
+	</properties>
+</project>

--- a/modules/openapi-generator-maven-plugin/examples/kotlin.xml
+++ b/modules/openapi-generator-maven-plugin/examples/kotlin.xml
@@ -40,7 +40,7 @@
 						</configuration>
 					</execution>
 					<execution>
-						<id>remote</id>
+						<id>kotlin</id>
 						<phase>generate-sources</phase>
 						<goals>
 							<goal>generate</goal>
@@ -61,10 +61,10 @@
 								<serializableModel>true</serializableModel>
 							</configOptions>
 
-							<output>${project.build.directory}/generated-sources/remote-openapi</output>
-							<apiPackage>remote.org.openapitools.client.api</apiPackage>
-							<modelPackage>remote.org.openapitools.client.model</modelPackage>
-							<invokerPackage>remote.org.openapitools.client</invokerPackage>
+							<output>${project.build.directory}/generated-sources/kotlin</output>
+							<apiPackage>kotlin.org.openapitools.client.api</apiPackage>
+							<modelPackage>kotlin.org.openapitools.client.model</modelPackage>
+							<invokerPackage>kotlin.org.openapitools.client</invokerPackage>
 						</configuration>
 					</execution>
 				</executions>

--- a/modules/openapi-generator-maven-plugin/examples/kotlin.xml
+++ b/modules/openapi-generator-maven-plugin/examples/kotlin.xml
@@ -7,6 +7,7 @@
 	<version>1.0-SNAPSHOT</version>
 	<name>sample-project</name>
 	<url>http://maven.apache.org</url>
+
 	<build>
 		<plugins>
 			<!-- activate the plugin -->
@@ -62,9 +63,9 @@
 							</configOptions>
 
 							<output>${project.build.directory}/generated-sources/kotlin</output>
-							<apiPackage>kotlin.org.openapitools.client.api</apiPackage>
-							<modelPackage>kotlin.org.openapitools.client.model</modelPackage>
-							<invokerPackage>kotlin.org.openapitools.client</invokerPackage>
+							<apiPackage>kotlintest.org.openapitools.client.api</apiPackage>
+							<modelPackage>kotlintest.org.openapitools.client.model</modelPackage>
+							<invokerPackage>kotlintest.org.openapitools.client</invokerPackage>
 						</configuration>
 					</execution>
 				</executions>
@@ -74,12 +75,42 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<proc>none</proc>
 				</configuration>
 			</plugin>
+			<plugin>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<configuration>
+					<jvmTarget>${kotlinJvmTarget}</jvmTarget>
+					<javacOptions/>
+				</configuration>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.build.directory}/generated-sources/kotlin/src/main/kotlin</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>kotlin-maven-plugin</artifactId>
+					<groupId>org.jetbrains.kotlin</groupId>
+					<version>${kotlin.version}</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 	<pluginRepositories>
 		<pluginRepository>
@@ -171,7 +202,22 @@
 		<dependency>
 			<groupId>com.brsanthu</groupId>
 			<artifactId>migbase64</artifactId>
-			<version>2.2</version>
+			<version>${migbase64.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.moshi</groupId>
+			<artifactId>moshi-kotlin</artifactId>
+			<version>${moshi-kotlin.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.moshi</groupId>
+			<artifactId>moshi-adapters</artifactId>
+			<version>${moshi-kotlin.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>4.2.2</version>
 		</dependency>
 	</dependencies>
 
@@ -183,5 +229,9 @@
 		<jodatime-version>2.7</jodatime-version>
 		<maven-plugin-version>1.0.0</maven-plugin-version>
 		<junit-version>4.8.1</junit-version>
+		<kotlin.version>1.3.50</kotlin.version>
+		<kotlinJvmTarget>1.8</kotlinJvmTarget>
+		<moshi-kotlin.version>1.8.0</moshi-kotlin.version>
+		<migbase64.version>2.2</migbase64.version>
 	</properties>
 </project>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -32,7 +32,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.utils.StringUtils.*;
@@ -70,104 +76,104 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         supportsInheritance = true;
 
         languageSpecificPrimitives = new HashSet<String>(Arrays.asList(
-                "kotlin.Byte",
-                "kotlin.ByteArray",
-                "kotlin.Short",
-                "kotlin.Int",
-                "kotlin.Long",
-                "kotlin.Float",
-                "kotlin.Double",
-                "kotlin.Boolean",
-                "kotlin.Char",
-                "kotlin.String",
-                "kotlin.Array",
-                "kotlin.collections.List",
-                "kotlin.collections.Map",
-                "kotlin.collections.Set"
+            "kotlin.Byte",
+            "kotlin.ByteArray",
+            "kotlin.Short",
+            "kotlin.Int",
+            "kotlin.Long",
+            "kotlin.Float",
+            "kotlin.Double",
+            "kotlin.Boolean",
+            "kotlin.Char",
+            "kotlin.String",
+            "kotlin.Array",
+            "kotlin.collections.List",
+            "kotlin.collections.Map",
+            "kotlin.collections.Set"
         ));
 
         // this includes hard reserved words defined by https://github.com/JetBrains/kotlin/blob/master/core/descriptors/src/org/jetbrains/kotlin/renderer/KeywordStringsGenerated.java
         // as well as keywords from https://kotlinlang.org/docs/reference/keyword-reference.html
         reservedWords = new HashSet<String>(Arrays.asList(
-                "abstract",
-                "annotation",
-                "as",
-                "break",
-                "case",
-                "catch",
-                "class",
-                "companion",
-                "const",
-                "constructor",
-                "continue",
-                "crossinline",
-                "data",
-                "delegate",
-                "do",
-                "else",
-                "enum",
-                "external",
-                "false",
-                "final",
-                "finally",
-                "for",
-                "fun",
-                "if",
-                "in",
-                "infix",
-                "init",
-                "inline",
-                "inner",
-                "interface",
-                "internal",
-                "is",
-                "it",
-                "lateinit",
-                "lazy",
-                "noinline",
-                "null",
-                "object",
-                "open",
-                "operator",
-                "out",
-                "override",
-                "package",
-                "private",
-                "protected",
-                "public",
-                "reified",
-                "return",
-                "sealed",
-                "super",
-                "suspend",
-                "tailrec",
-                "this",
-                "throw",
-                "true",
-                "try",
-                "typealias",
-                "typeof",
-                "val",
-                "var",
-                "vararg",
-                "when",
-                "while"
+            "abstract",
+            "annotation",
+            "as",
+            "break",
+            "case",
+            "catch",
+            "class",
+            "companion",
+            "const",
+            "constructor",
+            "continue",
+            "crossinline",
+            "data",
+            "delegate",
+            "do",
+            "else",
+            "enum",
+            "external",
+            "false",
+            "final",
+            "finally",
+            "for",
+            "fun",
+            "if",
+            "in",
+            "infix",
+            "init",
+            "inline",
+            "inner",
+            "interface",
+            "internal",
+            "is",
+            "it",
+            "lateinit",
+            "lazy",
+            "noinline",
+            "null",
+            "object",
+            "open",
+            "operator",
+            "out",
+            "override",
+            "package",
+            "private",
+            "protected",
+            "public",
+            "reified",
+            "return",
+            "sealed",
+            "super",
+            "suspend",
+            "tailrec",
+            "this",
+            "throw",
+            "true",
+            "try",
+            "typealias",
+            "typeof",
+            "val",
+            "var",
+            "vararg",
+            "when",
+            "while"
         ));
 
         defaultIncludes = new HashSet<String>(Arrays.asList(
-                "kotlin.Byte",
-                "kotlin.ByteArray",
-                "kotlin.Short",
-                "kotlin.Int",
-                "kotlin.Long",
-                "kotlin.Float",
-                "kotlin.Double",
-                "kotlin.Boolean",
-                "kotlin.Char",
-                "kotlin.Array",
-                "kotlin.collections.List",
-                "kotlin.collections.Set",
-                "kotlin.collections.Map"
+            "kotlin.Byte",
+            "kotlin.ByteArray",
+            "kotlin.Short",
+            "kotlin.Int",
+            "kotlin.Long",
+            "kotlin.Float",
+            "kotlin.Double",
+            "kotlin.Boolean",
+            "kotlin.Char",
+            "kotlin.Array",
+            "kotlin.collections.List",
+            "kotlin.collections.Set",
+            "kotlin.collections.Map"
         ));
 
         typeMapping = new HashMap<String, String>();
@@ -306,6 +312,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * returns the OpenAPI type for the property
      *
      * @param p OpenAPI property object
+     *
      * @return string presentation of the type
      **/
     @Override
@@ -328,6 +335,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Output the type declaration of the property
      *
      * @param p OpenAPI Property object
+     *
      * @return a string presentation of the property type
      */
     @Override
@@ -376,7 +384,8 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         super.processOpts();
 
         if (StringUtils.isEmpty(System.getenv("KOTLIN_POST_PROCESS_FILE"))) {
-            LOGGER.info("Environment variable KOTLIN_POST_PROCESS_FILE not defined so the Kotlin code may not be properly formatted. To define it, try 'export KOTLIN_POST_PROCESS_FILE=\"/usr/local/bin/ktlint -F\"' (Linux/Mac)");
+            LOGGER.info(
+                "Environment variable KOTLIN_POST_PROCESS_FILE not defined so the Kotlin code may not be properly formatted. To define it, try 'export KOTLIN_POST_PROCESS_FILE=\"/usr/local/bin/ktlint -F\"' (Linux/Mac)");
             LOGGER.info("NOTE: To enable file post-processing, 'enablePostProcessFile' must be set to `true` (--enable-post-process-file for CLI).");
         }
 
@@ -399,10 +408,12 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
             this.setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
-            if (!additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE))
+            if (!additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)) {
                 this.setModelPackage(packageName + ".models");
-            if (!additionalProperties.containsKey(CodegenConstants.API_PACKAGE))
+            }
+            if (!additionalProperties.containsKey(CodegenConstants.API_PACKAGE)) {
                 this.setApiPackage(packageName + ".apis");
+            }
         } else {
             additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
         }
@@ -434,19 +445,19 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SERIALIZABLE_MODEL)) {
-            this.setSerializableModel(Boolean.valueOf((String) additionalProperties.get(CodegenConstants.SERIALIZABLE_MODEL)));
+            this.setSerializableModel(getBooleanOption(CodegenConstants.SERIALIZABLE_MODEL));
         } else {
             additionalProperties.put(CodegenConstants.SERIALIZABLE_MODEL, serializableModel);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.PARCELIZE_MODELS)) {
-            this.setParcelizeModels(Boolean.valueOf((String) additionalProperties.get(CodegenConstants.PARCELIZE_MODELS)));
+            this.setParcelizeModels(getBooleanOption(CodegenConstants.PARCELIZE_MODELS));
         } else {
             additionalProperties.put(CodegenConstants.PARCELIZE_MODELS, parcelizeModels);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.NON_PUBLIC_API)) {
-            this.setNonPublicApi(Boolean.valueOf((String) additionalProperties.get(CodegenConstants.NON_PUBLIC_API)));
+            this.setNonPublicApi(getBooleanOption(CodegenConstants.NON_PUBLIC_API));
         } else {
             additionalProperties.put(CodegenConstants.NON_PUBLIC_API, nonPublicApi);
         }
@@ -456,6 +467,18 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
         additionalProperties.put("apiDocPath", apiDocPath);
         additionalProperties.put("modelDocPath", modelDocPath);
+    }
+
+    private boolean getBooleanOption(String key) {
+        Object booleanValue = additionalProperties.get(key);
+        if (booleanValue instanceof Boolean) {
+            System.out.println("##### BOOLEAN");
+            return (Boolean) booleanValue;
+        } else if (booleanValue instanceof String) {
+            System.out.println("##### STRING");
+            return Boolean.parseBoolean((String) booleanValue);
+        }
+        return false;
     }
 
     public void setArtifactId(String artifactId) {
@@ -501,7 +524,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
     public void setSerializableModel(boolean serializableModel) {
         this.serializableModel = serializableModel;
     }
-    
+
     public boolean nonPublicApi() {
         return nonPublicApi;
     }
@@ -523,6 +546,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      *
      * @param value    enum variable name
      * @param datatype data type
+     *
      * @return the sanitized variable name for enum
      */
     @Override
@@ -585,6 +609,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Return the fully-qualified "Model" name for import
      *
      * @param name the name of the "Model"
+     *
      * @return the fully-qualified "Model" name for import
      */
     @Override
@@ -603,6 +628,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * In case the name belongs to the TypeSystem it won't be renamed.
      *
      * @param name the name of the model
+     *
      * @return capitalized model name
      */
     @Override
@@ -656,13 +682,15 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Return the operation ID (method name)
      *
      * @param operationId operation ID
+     *
      * @return the sanitized method name
      */
     @Override
     public String toOperationId(String operationId) {
         // throw exception if method name is empty
-        if (StringUtils.isEmpty(operationId))
+        if (StringUtils.isEmpty(operationId)) {
             throw new RuntimeException("Empty method/operation name (operationId) not allowed");
+        }
 
         operationId = camelize(sanitizeName(operationId), true);
 
@@ -692,6 +720,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Provides a strongly typed declaration for simple arrays of some type and arrays of arrays of some type.
      *
      * @param arr Array schema
+     *
      * @return type declaration of array
      */
     private String getArrayTypeDeclaration(ArraySchema arr) {
@@ -714,6 +743,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Sanitize against Kotlin specific naming conventions, which may differ from those required by {@link DefaultCodegen#sanitizeName}.
      *
      * @param name string to be sanitize
+     *
      * @return sanitized string
      */
     private String sanitizeKotlinSpecificNames(final String name) {
@@ -782,6 +812,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Check the type to see if it needs import the library/module/package
      *
      * @param type name of the type
+     *
      * @return true if the library/module/package of the corresponding type needs to be imported
      */
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -32,13 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.utils.StringUtils.*;
@@ -76,104 +70,104 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         supportsInheritance = true;
 
         languageSpecificPrimitives = new HashSet<String>(Arrays.asList(
-            "kotlin.Byte",
-            "kotlin.ByteArray",
-            "kotlin.Short",
-            "kotlin.Int",
-            "kotlin.Long",
-            "kotlin.Float",
-            "kotlin.Double",
-            "kotlin.Boolean",
-            "kotlin.Char",
-            "kotlin.String",
-            "kotlin.Array",
-            "kotlin.collections.List",
-            "kotlin.collections.Map",
-            "kotlin.collections.Set"
+                "kotlin.Byte",
+                "kotlin.ByteArray",
+                "kotlin.Short",
+                "kotlin.Int",
+                "kotlin.Long",
+                "kotlin.Float",
+                "kotlin.Double",
+                "kotlin.Boolean",
+                "kotlin.Char",
+                "kotlin.String",
+                "kotlin.Array",
+                "kotlin.collections.List",
+                "kotlin.collections.Map",
+                "kotlin.collections.Set"
         ));
 
         // this includes hard reserved words defined by https://github.com/JetBrains/kotlin/blob/master/core/descriptors/src/org/jetbrains/kotlin/renderer/KeywordStringsGenerated.java
         // as well as keywords from https://kotlinlang.org/docs/reference/keyword-reference.html
         reservedWords = new HashSet<String>(Arrays.asList(
-            "abstract",
-            "annotation",
-            "as",
-            "break",
-            "case",
-            "catch",
-            "class",
-            "companion",
-            "const",
-            "constructor",
-            "continue",
-            "crossinline",
-            "data",
-            "delegate",
-            "do",
-            "else",
-            "enum",
-            "external",
-            "false",
-            "final",
-            "finally",
-            "for",
-            "fun",
-            "if",
-            "in",
-            "infix",
-            "init",
-            "inline",
-            "inner",
-            "interface",
-            "internal",
-            "is",
-            "it",
-            "lateinit",
-            "lazy",
-            "noinline",
-            "null",
-            "object",
-            "open",
-            "operator",
-            "out",
-            "override",
-            "package",
-            "private",
-            "protected",
-            "public",
-            "reified",
-            "return",
-            "sealed",
-            "super",
-            "suspend",
-            "tailrec",
-            "this",
-            "throw",
-            "true",
-            "try",
-            "typealias",
-            "typeof",
-            "val",
-            "var",
-            "vararg",
-            "when",
-            "while"
+                "abstract",
+                "annotation",
+                "as",
+                "break",
+                "case",
+                "catch",
+                "class",
+                "companion",
+                "const",
+                "constructor",
+                "continue",
+                "crossinline",
+                "data",
+                "delegate",
+                "do",
+                "else",
+                "enum",
+                "external",
+                "false",
+                "final",
+                "finally",
+                "for",
+                "fun",
+                "if",
+                "in",
+                "infix",
+                "init",
+                "inline",
+                "inner",
+                "interface",
+                "internal",
+                "is",
+                "it",
+                "lateinit",
+                "lazy",
+                "noinline",
+                "null",
+                "object",
+                "open",
+                "operator",
+                "out",
+                "override",
+                "package",
+                "private",
+                "protected",
+                "public",
+                "reified",
+                "return",
+                "sealed",
+                "super",
+                "suspend",
+                "tailrec",
+                "this",
+                "throw",
+                "true",
+                "try",
+                "typealias",
+                "typeof",
+                "val",
+                "var",
+                "vararg",
+                "when",
+                "while"
         ));
 
         defaultIncludes = new HashSet<String>(Arrays.asList(
-            "kotlin.Byte",
-            "kotlin.ByteArray",
-            "kotlin.Short",
-            "kotlin.Int",
-            "kotlin.Long",
-            "kotlin.Float",
-            "kotlin.Double",
-            "kotlin.Boolean",
-            "kotlin.Char",
-            "kotlin.Array",
-            "kotlin.collections.List",
-            "kotlin.collections.Set",
-            "kotlin.collections.Map"
+                "kotlin.Byte",
+                "kotlin.ByteArray",
+                "kotlin.Short",
+                "kotlin.Int",
+                "kotlin.Long",
+                "kotlin.Float",
+                "kotlin.Double",
+                "kotlin.Boolean",
+                "kotlin.Char",
+                "kotlin.Array",
+                "kotlin.collections.List",
+                "kotlin.collections.Set",
+                "kotlin.collections.Map"
         ));
 
         typeMapping = new HashMap<String, String>();
@@ -312,7 +306,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * returns the OpenAPI type for the property
      *
      * @param p OpenAPI property object
-     *
      * @return string presentation of the type
      **/
     @Override
@@ -335,7 +328,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Output the type declaration of the property
      *
      * @param p OpenAPI Property object
-     *
      * @return a string presentation of the property type
      */
     @Override
@@ -384,8 +376,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
         super.processOpts();
 
         if (StringUtils.isEmpty(System.getenv("KOTLIN_POST_PROCESS_FILE"))) {
-            LOGGER.info(
-                "Environment variable KOTLIN_POST_PROCESS_FILE not defined so the Kotlin code may not be properly formatted. To define it, try 'export KOTLIN_POST_PROCESS_FILE=\"/usr/local/bin/ktlint -F\"' (Linux/Mac)");
+            LOGGER.info("Environment variable KOTLIN_POST_PROCESS_FILE not defined so the Kotlin code may not be properly formatted. To define it, try 'export KOTLIN_POST_PROCESS_FILE=\"/usr/local/bin/ktlint -F\"' (Linux/Mac)");
             LOGGER.info("NOTE: To enable file post-processing, 'enablePostProcessFile' must be set to `true` (--enable-post-process-file for CLI).");
         }
 
@@ -408,12 +399,10 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
             this.setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
-            if (!additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE)) {
+            if (!additionalProperties.containsKey(CodegenConstants.MODEL_PACKAGE))
                 this.setModelPackage(packageName + ".models");
-            }
-            if (!additionalProperties.containsKey(CodegenConstants.API_PACKAGE)) {
+            if (!additionalProperties.containsKey(CodegenConstants.API_PACKAGE))
                 this.setApiPackage(packageName + ".apis");
-            }
         } else {
             additionalProperties.put(CodegenConstants.PACKAGE_NAME, packageName);
         }
@@ -470,12 +459,10 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
     }
 
     private boolean getBooleanOption(String key) {
-        Object booleanValue = additionalProperties.get(key);
+        final Object booleanValue = additionalProperties.get(key);
         if (booleanValue instanceof Boolean) {
-            System.out.println("##### BOOLEAN");
             return (Boolean) booleanValue;
         } else if (booleanValue instanceof String) {
-            System.out.println("##### STRING");
             return Boolean.parseBoolean((String) booleanValue);
         }
         return false;
@@ -546,7 +533,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      *
      * @param value    enum variable name
      * @param datatype data type
-     *
      * @return the sanitized variable name for enum
      */
     @Override
@@ -609,7 +595,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Return the fully-qualified "Model" name for import
      *
      * @param name the name of the "Model"
-     *
      * @return the fully-qualified "Model" name for import
      */
     @Override
@@ -628,7 +613,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * In case the name belongs to the TypeSystem it won't be renamed.
      *
      * @param name the name of the model
-     *
      * @return capitalized model name
      */
     @Override
@@ -682,15 +666,13 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Return the operation ID (method name)
      *
      * @param operationId operation ID
-     *
      * @return the sanitized method name
      */
     @Override
     public String toOperationId(String operationId) {
         // throw exception if method name is empty
-        if (StringUtils.isEmpty(operationId)) {
+        if (StringUtils.isEmpty(operationId))
             throw new RuntimeException("Empty method/operation name (operationId) not allowed");
-        }
 
         operationId = camelize(sanitizeName(operationId), true);
 
@@ -720,7 +702,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Provides a strongly typed declaration for simple arrays of some type and arrays of arrays of some type.
      *
      * @param arr Array schema
-     *
      * @return type declaration of array
      */
     private String getArrayTypeDeclaration(ArraySchema arr) {
@@ -743,7 +724,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Sanitize against Kotlin specific naming conventions, which may differ from those required by {@link DefaultCodegen#sanitizeName}.
      *
      * @param name string to be sanitize
-     *
      * @return sanitized string
      */
     private String sanitizeKotlinSpecificNames(final String name) {
@@ -812,7 +792,6 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      * Check the type to see if it needs import the library/module/package
      *
      * @param type name of the type
-     *
      * @return true if the library/module/package of the corresponding type needs to be imported
      */
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -460,12 +460,14 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
     private boolean getBooleanOption(String key) {
         final Object booleanValue = additionalProperties.get(key);
+        Boolean result = Boolean.FALSE;
         if (booleanValue instanceof Boolean) {
-            return (Boolean) booleanValue;
+            result = (Boolean) booleanValue;
         } else if (booleanValue instanceof String) {
-            return Boolean.parseBoolean((String) booleanValue);
+            result = Boolean.parseBoolean((String) booleanValue);
         }
-        return false;
+        additionalProperties.put(key, result);
+        return result;
     }
 
     public void setArtifactId(String artifactId) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -1,5 +1,6 @@
 package org.openapitools.codegen.kotlin;
 
+import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.languages.AbstractKotlinCodegen;
 import org.testng.Assert;
@@ -53,7 +54,7 @@ public class AbstractKotlinCodegenTest {
     }
 
     @Test
-    public void toEnumValue(){
+    public void toEnumValue() {
         assertEquals(codegen.toEnumValue("1", "kotlin.Int"), "1");
         assertEquals(codegen.toEnumValue("1", "kotlin.Double"), "1.0");
         assertEquals(codegen.toEnumValue("1.3", "kotlin.Double"), "1.3");
@@ -81,14 +82,14 @@ public class AbstractKotlinCodegenTest {
     }
 
     @Test
-    public void isDataTypeString(){
+    public void isDataTypeString() {
         assertFalse(codegen.isDataTypeString("kotlin.Int"));
         assertTrue(codegen.isDataTypeString("kotlin.String"));
         assertTrue(codegen.isDataTypeString("String"));
     }
 
     @Test
-    public void toModelNameShouldUseProvidedMapping()  {
+    public void toModelNameShouldUseProvidedMapping() {
         codegen.importMapping().put("json_myclass", "com.test.MyClass");
         assertEquals("com.test.MyClass", codegen.toModelName("json_myclass"));
     }
@@ -155,5 +156,45 @@ public class AbstractKotlinCodegenTest {
         Assert.assertEquals(codegen.apiTestFileFolder(), "/User/open/api/tools/test/folder/org/openapitools/codegen/api".replace('/', File.separatorChar));
     }
 
+    @Test
+    public void processOptsBooleanTrueFromString() {
+        codegen.additionalProperties().put(CodegenConstants.SERIALIZABLE_MODEL, "true");
+        codegen.processOpts();
+        Assert.assertTrue((boolean) codegen.additionalProperties().get(CodegenConstants.SERIALIZABLE_MODEL));
+    }
 
+    @Test
+    public void processOptsBooleanTrueFromBoolean() {
+        codegen.additionalProperties().put(CodegenConstants.SERIALIZABLE_MODEL, true);
+        codegen.processOpts();
+        Assert.assertTrue((boolean) codegen.additionalProperties().get(CodegenConstants.SERIALIZABLE_MODEL));
+    }
+
+    @Test
+    public void processOptsBooleanFalseFromString() {
+        codegen.additionalProperties().put(CodegenConstants.SERIALIZABLE_MODEL, "false");
+        codegen.processOpts();
+        Assert.assertFalse((boolean) codegen.additionalProperties().get(CodegenConstants.SERIALIZABLE_MODEL));
+    }
+
+    @Test
+    public void processOptsBooleanFalseFromBoolean() {
+        codegen.additionalProperties().put(CodegenConstants.SERIALIZABLE_MODEL, false);
+        codegen.processOpts();
+        Assert.assertFalse((boolean) codegen.additionalProperties().get(CodegenConstants.SERIALIZABLE_MODEL));
+    }
+
+    @Test
+    public void processOptsBooleanFalseFromGarbage() {
+        codegen.additionalProperties().put(CodegenConstants.SERIALIZABLE_MODEL, "blibb");
+        codegen.processOpts();
+        Assert.assertFalse((boolean) codegen.additionalProperties().get(CodegenConstants.SERIALIZABLE_MODEL));
+    }
+
+    @Test
+    public void processOptsBooleanFalseFromNumeric() {
+        codegen.additionalProperties().put(CodegenConstants.SERIALIZABLE_MODEL, 42);
+        codegen.processOpts();
+        Assert.assertFalse((boolean) codegen.additionalProperties().get(CodegenConstants.SERIALIZABLE_MODEL));
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -193,7 +193,7 @@ public class AbstractKotlinCodegenTest {
 
     @Test
     public void processOptsBooleanFalseFromNumeric() {
-        codegen.additionalProperties().put(CodegenConstants.SERIALIZABLE_MODEL, 42);
+        codegen.additionalProperties().put(CodegenConstants.SERIALIZABLE_MODEL, 42L);
         codegen.processOpts();
         Assert.assertFalse((boolean) codegen.additionalProperties().get(CodegenConstants.SERIALIZABLE_MODEL));
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This change will prevent a ClassCastException during execution of the generator maven plugin. 

When executed as maven plugin, boolean config options have the type java.lang.Boolean. When executed as CLI generator boolean config options have the type java.lang.String. Before this fix, only the latter case could be handled properly and the first case caused a ClassCastException.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language. @wing328 
