### PR TITLE
[Java] skip the test as async call may have finished

### DIFF
--- a/CI/samples.ci/client/petstore/java/test-manual/okhttp-gson/api/PetApiTest.java
+++ b/CI/samples.ci/client/petstore/java/test-manual/okhttp-gson/api/PetApiTest.java
@@ -128,8 +128,6 @@ public class PetApiTest {
                 //empty
             }
         });
-        // the API call should be executed asynchronously, so result should be empty at the moment
-        assertTrue(result.isEmpty());
 
         // wait for the asynchronous call to finish (at most 10 seconds)
         final int maxTry = 10;

--- a/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
+++ b/samples/client/petstore/java/okhttp-gson/src/test/java/org/openapitools/client/api/PetApiTest.java
@@ -128,8 +128,6 @@ public class PetApiTest {
                 //empty
             }
         });
-        // the API call should be executed asynchronously, so result should be empty at the moment
-        assertTrue(result.isEmpty());
 
         // wait for the asynchronous call to finish (at most 10 seconds)
         final int maxTry = 10;


### PR DESCRIPTION
Skip the getPetById result test as async call may have finished (to address the intermittent errors we're seeing with CircleCI build failure)

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
