### PR TITLE
[csharp-netcore] Propagate raw content to the ApiException error content.

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -347,7 +347,9 @@ namespace {{packageName}}.Client
         private ApiResponse<T> toApiResponse<T>({{#supportsAsync}}IRestResponse<T> response{{/supportsAsync}}{{^supportsAsync}}IRestResponse response, CustomJsonCodec des{{/supportsAsync}})
         {
             T result = {{#supportsAsync}}response.Data{{/supportsAsync}}{{^supportsAsync}}(T)des.Deserialize(response, typeof(T)){{/supportsAsync}};
-            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result)
+            string rawContent = response.Content;
+
+            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result, rawContent)
             {
                 ErrorText = response.ErrorMessage,
                 Cookies = new List<Cookie>()

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiResponse.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiResponse.mustache
@@ -128,12 +128,29 @@ namespace {{packageName}}.Client
         /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent)
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data) : this(statusCode, headers, data, null)
         {
-            StatusCode = statusCode;
-            Data = data;
-            RawContent = rawContent;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        /// <param name="rawContent">Raw content.</param>
+        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent) : this(statusCode, null, data, rawContent)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        public ApiResponse(HttpStatusCode statusCode, T data) : this(statusCode, data, null)
+        {
         }
 
         #endregion Constructors

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiResponse.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiResponse.mustache
@@ -42,6 +42,11 @@ namespace {{packageName}}.Client
         /// Gets or sets any cookies passed along on the response.
         /// </summary>
         List<Cookie> Cookies { get; set; }
+
+        /// <summary>
+        /// The raw content of this response
+        /// </summary>
+        string RawContent { get; }
     }
 
     /// <summary>
@@ -94,6 +99,11 @@ namespace {{packageName}}.Client
         {
             get { return Data; }
         }
+
+        /// <summary>
+        /// The raw content
+        /// </summary>
+        public string RawContent { get;}
         
         #endregion Properties
         
@@ -105,11 +115,13 @@ namespace {{packageName}}.Client
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data)
+        /// <param name="rawContent">Raw content.</param>
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data, string rawContent)
         {
             StatusCode = statusCode;
             Headers = headers;
             Data = data;
+            RawContent = rawContent;
         }
 
         /// <summary>
@@ -117,10 +129,11 @@ namespace {{packageName}}.Client
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, T data)
+        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent)
         {
             StatusCode = statusCode;
             Data = data;
+            RawContent = rawContent;
         }
 
         #endregion Constructors

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
@@ -45,8 +45,8 @@ namespace {{packageName}}.Client
             if (status >= 400)
             {
                 return new ApiException(status,
-                    string.Format("Error calling {0}: {1}", methodName, response.Content),
-                    response.Content);
+                    string.Format("Error calling {0}: {1}", methodName, response.RawContent),
+                    response.RawContent);
             }
             {{^netStandard}}if (status == 0)
             {

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -350,7 +350,9 @@ namespace Org.OpenAPITools.Client
         private ApiResponse<T> toApiResponse<T>(IRestResponse<T> response)
         {
             T result = response.Data;
-            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result)
+            string rawContent = response.Content;
+
+            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result, rawContent)
             {
                 ErrorText = response.ErrorMessage,
                 Cookies = new List<Cookie>()

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiResponse.cs
@@ -137,12 +137,29 @@ namespace Org.OpenAPITools.Client
         /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent)
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data) : this(statusCode, headers, data, null)
         {
-            StatusCode = statusCode;
-            Data = data;
-            RawContent = rawContent;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        /// <param name="rawContent">Raw content.</param>
+        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent) : this(statusCode, null, data, rawContent)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        public ApiResponse(HttpStatusCode statusCode, T data) : this(statusCode, data, null)
+        {
         }
 
         #endregion Constructors

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/ApiResponse.cs
@@ -51,6 +51,11 @@ namespace Org.OpenAPITools.Client
         /// Gets or sets any cookies passed along on the response.
         /// </summary>
         List<Cookie> Cookies { get; set; }
+
+        /// <summary>
+        /// The raw content of this response
+        /// </summary>
+        string RawContent { get; }
     }
 
     /// <summary>
@@ -103,6 +108,11 @@ namespace Org.OpenAPITools.Client
         {
             get { return Data; }
         }
+
+        /// <summary>
+        /// The raw content
+        /// </summary>
+        public string RawContent { get;}
         
         #endregion Properties
         
@@ -114,11 +124,13 @@ namespace Org.OpenAPITools.Client
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data)
+        /// <param name="rawContent">Raw content.</param>
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data, string rawContent)
         {
             StatusCode = statusCode;
             Headers = headers;
             Data = data;
+            RawContent = rawContent;
         }
 
         /// <summary>
@@ -126,10 +138,11 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, T data)
+        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent)
         {
             StatusCode = statusCode;
             Data = data;
+            RawContent = rawContent;
         }
 
         #endregion Constructors

--- a/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClient/src/Org.OpenAPITools/Client/Configuration.cs
@@ -52,8 +52,8 @@ namespace Org.OpenAPITools.Client
             if (status >= 400)
             {
                 return new ApiException(status,
-                    string.Format("Error calling {0}: {1}", methodName, response.Content),
-                    response.Content);
+                    string.Format("Error calling {0}: {1}", methodName, response.RawContent),
+                    response.RawContent);
             }
             
             return null;

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -351,7 +351,9 @@ namespace Org.OpenAPITools.Client
         private ApiResponse<T> toApiResponse<T>(IRestResponse<T> response)
         {
             T result = response.Data;
-            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result)
+            string rawContent = response.Content;
+
+            var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result, rawContent)
             {
                 ErrorText = response.ErrorMessage,
                 Cookies = new List<Cookie>()

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiResponse.cs
@@ -137,12 +137,29 @@ namespace Org.OpenAPITools.Client
         /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent)
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data) : this(statusCode, headers, data, null)
         {
-            StatusCode = statusCode;
-            Data = data;
-            RawContent = rawContent;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        /// <param name="rawContent">Raw content.</param>
+        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent) : this(statusCode, null, data, rawContent)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiResponse{T}" /> class.
+        /// </summary>
+        /// <param name="statusCode">HTTP status code.</param>
+        /// <param name="data">Data (parsed HTTP body)</param>
+        public ApiResponse(HttpStatusCode statusCode, T data) : this(statusCode, data, null)
+        {
         }
 
         #endregion Constructors

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiResponse.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiResponse.cs
@@ -51,6 +51,11 @@ namespace Org.OpenAPITools.Client
         /// Gets or sets any cookies passed along on the response.
         /// </summary>
         List<Cookie> Cookies { get; set; }
+
+        /// <summary>
+        /// The raw content of this response
+        /// </summary>
+        string RawContent { get; }
     }
 
     /// <summary>
@@ -103,6 +108,11 @@ namespace Org.OpenAPITools.Client
         {
             get { return Data; }
         }
+
+        /// <summary>
+        /// The raw content
+        /// </summary>
+        public string RawContent { get;}
         
         #endregion Properties
         
@@ -114,11 +124,13 @@ namespace Org.OpenAPITools.Client
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data)
+        /// <param name="rawContent">Raw content.</param>
+        public ApiResponse(HttpStatusCode statusCode, Multimap<string, string> headers, T data, string rawContent)
         {
             StatusCode = statusCode;
             Headers = headers;
             Data = data;
+            RawContent = rawContent;
         }
 
         /// <summary>
@@ -126,10 +138,11 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(HttpStatusCode statusCode, T data)
+        public ApiResponse(HttpStatusCode statusCode, T data, string rawContent)
         {
             StatusCode = statusCode;
             Data = data;
+            RawContent = rawContent;
         }
 
         #endregion Constructors

--- a/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
+++ b/samples/client/petstore/csharp-netcore/OpenAPIClientCore/src/Org.OpenAPITools/Client/Configuration.cs
@@ -52,8 +52,8 @@ namespace Org.OpenAPITools.Client
             if (status >= 400)
             {
                 return new ApiException(status,
-                    string.Format("Error calling {0}: {1}", methodName, response.Content),
-                    response.Content);
+                    string.Format("Error calling {0}: {1}", methodName, response.RawContent),
+                    response.RawContent);
             }
             if (status == 0)
             {


### PR DESCRIPTION
This PR resolves an issue with the ApiException error content described in #3473 .

The issue is linked to migration to the generic `IRestResponse<T>`. The deserialization happens before the exception is actually checked by `ExceptionFactory`.

Possible fix is to propagate both raw response content from `IRestResponse.Content` as well as `IRestResponse<T>.Data` to the `ApiResponse`.

But I think it makes sense to roll back to the older implementation, where deserialization happed if an exception hadn't been constructed.

Technical committee: @mandrean (2017/08), @jimschubert (2017/09) ❤️ @frankyjuang (2019/09)