### PR TITLE
[typescript-fetch] Add (de)serializers for oneOfs

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -3,6 +3,10 @@ import {
     {{#imports}}
     {{{.}}},
     {{/imports}}
+    {{#oneOf}}
+    {{{.}}}FromJSONTyped,
+    {{{.}}}ToJSON,
+    {{/oneOf}}
 } from './';
 
 {{/hasImports}}
@@ -11,4 +15,49 @@ import {
  * {{{description}}}{{/description}}
  * @export
  */
-export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};
+export type {{classname}} = {{#discriminator}}{{#mappedModels}}{ {{discriminator.propertyName}}: '{{mappingName}}' } & {{modelName}}{{^-last}} | {{/-last}}{{/mappedModels}}{{/discriminator}}{{^discriminator}}{{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}}{{/discriminator}};
+
+export function {{classname}}FromJSON(json: any): {{classname}} {
+    return {{classname}}FromJSONTyped(json, false);
+}
+
+export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
+    if ((json === undefined) || (json === null)) {
+        return json;
+    }
+{{#discriminator}}
+    switch (json['{{discriminator.propertyName}}']) {
+{{#discriminator.mappedModels}}
+        case '{{mappingName}}':
+            return {...{{modelName}}FromJSONTyped(json, true), {{discriminator.propertyName}}: '{{mappingName}}'};
+{{/discriminator.mappedModels}}
+        default:
+            throw new Error(`No variant of {{classname}} exists with '{{discriminator.propertyName}}=${json['{{discriminator.propertyName}}']}'`);
+    }
+{{/discriminator}}
+{{^discriminator}}
+    return { {{#oneOf}}...{{{.}}}FromJSONTyped(json, true){{^-last}}, {{/-last}}{{/oneOf}} };
+{{/discriminator}}
+}
+
+export function {{classname}}ToJSON(value?: {{classname}} | null): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+{{#discriminator}}
+    switch (value['{{discriminator.propertyName}}']) {
+{{#discriminator.mappedModels}}
+        case '{{mappingName}}':
+            return {{modelName}}ToJSON(value);
+{{/discriminator.mappedModels}}
+        default:
+            throw new Error(`No variant of {{classname}} exists with '{{discriminator.propertyName}}=${value['{{discriminator.propertyName}}']}'`);
+    }
+{{/discriminator}}
+{{^discriminator}}
+    return { {{#oneOf}}...{{{.}}}ToJSON(value){{^-last}}, {{/-last}}{{/oneOf}} };
+{{/discriminator}}
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Using `oneOf`s with `typescript-fetch` results in union types, but lacks decoders and encoders for them. This PR patches that. I've also added support for the discriminator (resulting in tagged unions).

@wing328 Is there already a YAML available for testing oneOfs/allOfs/discriminators? Otherwise I would like to add a generic one.

cc @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @nicokoenig @topce @akehir