### PR TITLE
[go-server] Add featureCORS option

### DIFF
--- a/docs/generators/go-server.md
+++ b/docs/generators/go-server.md
@@ -10,3 +10,4 @@ sidebar_label: go-server
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |sourceFolder|source folder for generated code| |go|
 |serverPort|The network port the generated server binds to| |8080|
+|featureCORS|Enable Cross-Origin Resource Sharing middleware| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -39,6 +39,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
     protected int serverPort = 8080;
     protected String projectName = "openapi-server";
     protected String sourceFolder = "go";
+    protected Boolean corsFeatureEnabled = false;
 
 
     public GoServerCodegen() {
@@ -54,6 +55,11 @@ public class GoServerCodegen extends AbstractGoCodegen {
         optServerPort.setType("int");
         optServerPort.defaultValue(Integer.toString(serverPort));
         cliOptions.add(optServerPort);
+
+        CliOption optFeatureCORS = new CliOption("featureCORS", "Enable Cross-Origin Resource Sharing middleware");
+        optFeatureCORS.setType("bool");
+        optFeatureCORS.defaultValue(corsFeatureEnabled.toString());
+        cliOptions.add(optFeatureCORS);
 
         /*
          * Models.  You can write model files using the modelTemplateFiles map.
@@ -140,6 +146,12 @@ public class GoServerCodegen extends AbstractGoCodegen {
             this.setServerPort((int) additionalProperties.get("serverPort"));
         } else {
             additionalProperties.put("serverPort", serverPort);
+        }
+
+        if (additionalProperties.containsKey("featureCORS")) {
+            this.setFeatureCORS(convertPropertyToBooleanAndWriteBack("featureCORS"));
+        } else {
+            additionalProperties.put("featureCORS", corsFeatureEnabled);
         }
 
         modelPackage = packageName;
@@ -262,5 +274,9 @@ public class GoServerCodegen extends AbstractGoCodegen {
 
     public void setServerPort(int serverPort) {
         this.serverPort = serverPort;
+    } 
+
+    public void setFeatureCORS(Boolean featureCORS) {
+        this.corsFeatureEnabled = featureCORS;
     } 
 }

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+{{#featureCORS}}
 
+	"github.com/gorilla/handlers"{{/featureCORS}}
 	"github.com/gorilla/mux"
 )
 
@@ -34,7 +36,8 @@ func NewRouter(routers ...Router) *mux.Router {
 		for _, route := range api.Routes() {
 			var handler http.Handler
 			handler = route.HandlerFunc
-			handler = Logger(handler, route.Name)
+			handler = Logger(handler, route.Name){{#featureCORS}}
+			handler = handlers.CORS()(handler){{/featureCORS}}
 
 			router.
 				Methods(route.Method).


### PR DESCRIPTION
Add a Go server configuration option of "featureCORS" that defaults to false. When set to true the Go server routers will be generated with Cross-Origin Resource Sharing middleware through gorilla mux.

https://www.gorillatoolkit.org/pkg/handlers#CORS

Accepting cross origin requests is something that I needed in my project. I accomplished it with a custom template, but just in case anyone else would like this feature I put up this PR.

@antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
