### PR TITLE
feat(dart-dio): correctly handle Map<String, Object>, List<Object> using JsonObject

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -80,6 +80,7 @@ public class DartDioClientCodegen extends DartClientCodegen {
 
         importMapping.put("BuiltList", "package:built_collection/built_collection.dart");
         importMapping.put("BuiltMap", "package:built_collection/built_collection.dart");
+        importMapping.put("JsonObject", "package:built_value/json_object.dart");
         importMapping.put("Uint8List", "dart:typed_data");
     }
 
@@ -127,6 +128,13 @@ public class DartDioClientCodegen extends DartClientCodegen {
             name = escapeReservedWord(name);
         }
         return name;
+    }
+
+    @Override
+    protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Schema schema) {
+        //super.addAdditionPropertiesToCodeGenModel(codegenModel, schema);
+        codegenModel.additionalPropertiesType = getSchemaType(ModelUtils.getAdditionalProperties(schema));
+        addImport(codegenModel, codegenModel.additionalPropertiesType);
     }
 
     @Override
@@ -230,9 +238,16 @@ public class DartDioClientCodegen extends DartClientCodegen {
             //Updates any List properties on a model to a BuiltList. This happens in post processing rather
             //than type mapping as we only want this to apply to models, not every other class.
             if ("List".equals(property.baseType)) {
-                property.setDatatype(property.dataType.replaceAll(property.baseType, "BuiltList"));
+                property.setDatatype(
+                    property.dataType.replaceAll(property.baseType, "BuiltList"));
                 property.setBaseType("BuiltList");
                 model.imports.add("BuiltList");
+                if ("Object".equals(property.items.baseType)) {
+                    property.setDatatype(
+                        property.dataType.replaceAll("Object", "JsonObject"));
+                    property.items.setDatatype("JsonObject");
+                    model.imports.add("JsonObject");
+                }
             }
         }
         if (property.isMapContainer) {
@@ -242,6 +257,11 @@ public class DartDioClientCodegen extends DartClientCodegen {
                 property.setDatatype(property.dataType.replaceAll(property.baseType, "BuiltMap"));
                 property.setBaseType("BuiltMap");
                 model.imports.add("BuiltMap");
+                if ("Object".equals(property.items.baseType)) {
+                    property.setDatatype(property.dataType.replaceAll("Object", "JsonObject"));
+                    property.items.setDatatype("JsonObject");
+                    model.imports.add("JsonObject");
+                }
             }
         }
 

--- a/modules/openapi-generator/src/main/resources/dart-dio/serializers.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/serializers.mustache
@@ -2,6 +2,7 @@ library serializers;
 
 import 'package:built_value/serializer.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:built_value/json_object.dart';
 import 'package:built_value/standard_json_plugin.dart';
 
 {{#models}}{{#model}}import 'package:{{pubName}}/model/{{classFilename}}.dart';


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

https://github.com/google/built_value.dart/issues/134

`dart-dio` generator does not handle `Map<String, dynamic>` properly. This PR fixes this issue using `JsonObject`. 

- `Map<String, Object>` should be `BuiltMap<String,JsonObject>`
- `List<Object>` should be `BuiltList<JsonObject>`

```yaml
  Test:
    properties:
      objectMap:
        type: object
        additionalProperties:
          type: object
      objectList:
        type: array
        items:
          type: object
```

```dart
  @nullable
  @BuiltValueField(wireName: 'objectMap')
  BuiltMap<String, JsonObject> get objectMap;

  @nullable
  @BuiltValueField(wireName: 'objectList')
  BuiltList<JsonObject> get objectList;
```


<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


CC: @ircecho @swipesight @jaumard @nickmeinhold @athornz
