### PR TITLE
cpp-qt5-client: remove host since it is not well handled

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCppCodegen.java
@@ -300,11 +300,16 @@ abstract public class AbstractCppCodegen extends DefaultCodegen implements Codeg
         URL url = URLPathUtils.getServerURL(openAPI, serverVariableOverrides());
         String port = URLPathUtils.getPort(url, "");
         String host = url.getHost();
+        String scheme = url.getProtocol();
+
         if(!port.isEmpty()) {
             this.additionalProperties.put("serverPort", port);
         }
         if(!host.isEmpty()) {
             this.additionalProperties.put("serverHost", host);
+        }
+        if(!scheme.isEmpty()) {
+            this.additionalProperties.put("scheme", scheme);
         }
     }
     

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -9,49 +9,36 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
-{{classname}}::{{classname}}() : basePath("{{{basePathWithoutHost}}}"),
-    host("{{#serverHost}}{{#scheme}}{{scheme}}://{{/scheme}}{{serverHost}}{{#serverPort}}:{{serverPort}}{{/serverPort}}{{/serverHost}}"),
-    timeout(0){
-
+{{classname}}::{{classname}}(const QString& basePath, const int timeOut) :
+    _basePath(basePath),
+    _timeOut(timeOut) {
 }
 
 {{classname}}::~{{classname}}() {
-
-}
-
-{{classname}}::{{classname}}(const QString& host, const QString& basePath, const int tout) {
-    this->host = host;
-    this->basePath = basePath;
-    this->timeout = tout;
 }
 
 void {{classname}}::setBasePath(const QString& basePath){
-    this->basePath = basePath;
+    _basePath = basePath;
 }
 
-void {{classname}}::setHost(const QString& host){
-    this->host = host;
-}
-
-void {{classname}}::setApiTimeOutMs(const int tout){
-    timeout = tout;
+void {{classname}}::setTimeOut(const int timeOut){
+    _timeOut = timeOut;
 }
 
 void {{classname}}::setWorkingDirectory(const QString& path){
-    workingDirectory = path;
+    _workingDirectory = path;
 }
 
 void {{classname}}::addHeaders(const QString& key, const QString& value){
     defaultHeaders.insert(key, value);
 }
 
-
 {{#operations}}
 {{#operation}}
 void
 {{classname}}::{{nickname}}({{#allParams}}const {{{dataType}}}& {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("{{{path}}}");
+    fullPath.append(_basePath).append("{{{path}}}");
     {{#pathParams}}
     QString {{paramName}}PathParam("{");
     {{paramName}}PathParam.append("{{baseName}}").append("}");
@@ -107,8 +94,8 @@ void
     }
     {{/collectionFormat}}{{/queryParams}}
     {{prefix}}HttpRequestWorker *worker = new {{prefix}}HttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     {{prefix}}HttpRequestInput input(fullPath, "{{httpMethod}}");
     {{#formParams}}{{^isFile}}
     input.add_var("{{baseName}}", ::{{cppNamespace}}::toStringValue({{paramName}}));{{/isFile}}{{#isFile}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-body.mustache
@@ -9,12 +9,27 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
-{{classname}}::{{classname}}(const QString& basePath, const int timeOut) :
+{{classname}}::{{classname}}(const QString &scheme, const QString &host, int port, const QString& basePath, const int timeOut) :
+    _scheme(scheme),
+    _host(host),
+    _port(port),
     _basePath(basePath),
     _timeOut(timeOut) {
 }
 
 {{classname}}::~{{classname}}() {
+}
+
+void {{classname}}::setScheme(const QString& scheme){
+    _scheme = scheme;
+}
+
+void {{classname}}::setHost(const QString& host){
+    _host = host;
+}
+
+void {{classname}}::setPort(int port){
+    _port = port;
 }
 
 void {{classname}}::setBasePath(const QString& basePath){
@@ -37,8 +52,12 @@ void {{classname}}::addHeaders(const QString& key, const QString& value){
 {{#operation}}
 void
 {{classname}}::{{nickname}}({{#allParams}}const {{{dataType}}}& {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
-    QString fullPath;
-    fullPath.append(_basePath).append("{{{path}}}");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("{{{path}}}");
     {{#pathParams}}
     QString {{paramName}}PathParam("{");
     {{paramName}}PathParam.append("{{baseName}}").append("}");

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -17,23 +17,20 @@ class {{classname}}: public QObject {
     Q_OBJECT
 
 public:
-    {{classname}}();
-    {{classname}}(const QString& host, const QString& basePath, const int toutMs = 0);
+    {{classname}}(const QString& basePath = "{{basePath}}", const int timeOut = 0);
     ~{{classname}}();
 
     void setBasePath(const QString& basePath);
-    void setHost(const QString& host);
-    void setApiTimeOutMs(const int tout);
+    void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString& path);
     void addHeaders(const QString& key, const QString& value);
 
     {{#operations}}{{#operation}}void {{nickname}}({{#allParams}}const {{{dataType}}}& {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
     {{/operation}}{{/operations}}
 private:
-    QString basePath;
-    QString host;
-    QString workingDirectory;
-    int timeout;
+    QString _basePath;
+    int _timeOut;
+    QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
     {{#operations}}{{#operation}}void {{nickname}}Callback ({{prefix}}HttpRequestWorker * worker);
     {{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/api-header.mustache
@@ -17,9 +17,12 @@ class {{classname}}: public QObject {
     Q_OBJECT
 
 public:
-    {{classname}}(const QString& basePath = "{{basePath}}", const int timeOut = 0);
+    {{classname}}(const QString &scheme = "{{scheme}}", const QString &host = "{{serverHost}}", int port = {{#serverPort}}{{serverPort}}{{/serverPort}}{{^serverPort}}0{{/serverPort}}, const QString& basePath = "{{basePathWithoutHost}}", const int timeOut = 0);
     ~{{classname}}();
 
+    void setScheme(const QString &scheme);
+    void setHost(const QString &host);
+    void setPort(int port);
     void setBasePath(const QString& basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString& path);
@@ -28,8 +31,8 @@ public:
     {{#operations}}{{#operation}}void {{nickname}}({{#allParams}}const {{{dataType}}}& {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
     {{/operation}}{{/operations}}
 private:
-    QString _basePath;
-    int _timeOut;
+    QString _scheme, _host, _basePath;
+    int _port, _timeOut;
     QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
     {{#operations}}{{#operation}}void {{nickname}}Callback ({{prefix}}HttpRequestWorker * worker);

--- a/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.cpp
@@ -14,7 +14,6 @@ PFXPet PetApiTests::createRandomPet() {
 
 void PetApiTests::findPetsByStatusTest() {
     PFXPetApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool petFound = false;
 
@@ -34,7 +33,6 @@ void PetApiTests::findPetsByStatusTest() {
 
 void PetApiTests::createAndGetPetTest() {
     PFXPetApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool petCreated = false;
 
@@ -65,12 +63,10 @@ void PetApiTests::createAndGetPetTest() {
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(petFetched, "didn't finish within timeout");
-
 }
 
 void PetApiTests::updatePetTest() {
     PFXPetApi api;
-    api.setHost(PetStoreHost);
 
     PFXPet pet = createRandomPet();
     PFXPet petToCheck;
@@ -134,7 +130,6 @@ void PetApiTests::updatePetTest() {
 
 void PetApiTests::updatePetWithFormTest() {
     PFXPetApi api;
-    api.setHost(PetStoreHost);
 
     PFXPet pet = createRandomPet();
     PFXPet petToCheck;

--- a/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.h
+++ b/samples/client/petstore/cpp-qt5/PetStore/PetApiTests.h
@@ -14,6 +14,4 @@ private slots:
     void createAndGetPetTest();
     void updatePetTest();
     void updatePetWithFormTest();
-private:
-    const QString PetStoreHost = QStringLiteral("http://petstore.swagger.io");
 };

--- a/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.cpp
@@ -6,7 +6,6 @@
 
 void StoreApiTests::placeOrderTest() {
     PFXStoreApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool orderPlaced = false;
 
@@ -33,12 +32,10 @@ void StoreApiTests::placeOrderTest() {
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(orderPlaced, "didn't finish within timeout");
-
 }
 
 void StoreApiTests::getOrderByIdTest() {
     PFXStoreApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool orderFetched = false;
 
@@ -54,12 +51,10 @@ void StoreApiTests::getOrderByIdTest() {
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(orderFetched, "didn't finish within timeout");
-
 }
 
 void StoreApiTests::getInventoryTest() {
     PFXStoreApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool inventoryFetched = false;
 
@@ -75,5 +70,4 @@ void StoreApiTests::getInventoryTest() {
     QTimer::singleShot(14000, &loop, &QEventLoop::quit);
     loop.exec();
     QVERIFY2(inventoryFetched, "didn't finish within timeout");
-
 }

--- a/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.h
+++ b/samples/client/petstore/cpp-qt5/PetStore/StoreApiTests.h
@@ -11,6 +11,4 @@ private slots:
     void placeOrderTest();
     void getOrderByIdTest();
     void getInventoryTest();
-private:
-    const QString PetStoreHost = QStringLiteral("http://petstore.swagger.io");
 };

--- a/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.cpp
+++ b/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.cpp
@@ -19,7 +19,6 @@ PFXUser UserApiTests::createRandomUser() {
 
 void UserApiTests::createUserTest(){
     PFXUserApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userCreated = false;
 
@@ -36,7 +35,6 @@ void UserApiTests::createUserTest(){
 
 void UserApiTests::createUsersWithArrayInputTest(){
     PFXUserApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool usersCreated = false;
 
@@ -57,7 +55,6 @@ void UserApiTests::createUsersWithArrayInputTest(){
 
 void UserApiTests::createUsersWithListInputTest(){
     PFXUserApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool usersCreated = false;
 
@@ -82,7 +79,6 @@ void UserApiTests::createUsersWithListInputTest(){
 
 void UserApiTests::deleteUserTest(){
     PFXUserApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userDeleted = false;
 
@@ -99,7 +95,6 @@ void UserApiTests::deleteUserTest(){
 
 void UserApiTests::getUserByNameTest(){
     PFXUserApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userFetched = false;
 
@@ -118,7 +113,6 @@ void UserApiTests::getUserByNameTest(){
 
 void UserApiTests::loginUserTest(){
     PFXUserApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userLogged = false;
 
@@ -136,7 +130,6 @@ void UserApiTests::loginUserTest(){
 
 void UserApiTests::logoutUserTest(){
     PFXUserApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userLoggedOut = false;
 
@@ -153,7 +146,6 @@ void UserApiTests::logoutUserTest(){
 
 void UserApiTests::updateUserTest(){
     PFXUserApi api;
-    api.setHost(PetStoreHost);
     QEventLoop loop;
     bool userUpdated = false;
 

--- a/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.h
+++ b/samples/client/petstore/cpp-qt5/PetStore/UserApiTests.h
@@ -18,6 +18,4 @@ private slots:
     void loginUserTest();
     void logoutUserTest();
     void updateUserTest();
-private:
-    const QString PetStoreHost = QStringLiteral("http://petstore.swagger.io");
 };

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
@@ -374,6 +374,7 @@ void PFXHttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
             headers.insert(item.first, item.second);
         }
     }
+    disconnect(this, nullptr, nullptr, nullptr);
     reply->deleteLater();
     process_form_response();
     emit on_execution_finished(this);
@@ -383,7 +384,6 @@ void PFXHttpRequestWorker::on_manager_timeout(QNetworkReply *reply) {
     error_type = QNetworkReply::TimeoutError;
     response = "";
     error_str = "Timed out waiting for response";
-    disconnect(manager, nullptr, nullptr, nullptr);
     reply->abort();
     reply->deleteLater();
     emit on_execution_finished(this);

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
@@ -374,7 +374,6 @@ void PFXHttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
             headers.insert(item.first, item.second);
         }
     }
-    disconnect(this, nullptr, nullptr, nullptr);
     reply->deleteLater();
     process_form_response();
     emit on_execution_finished(this);
@@ -384,6 +383,7 @@ void PFXHttpRequestWorker::on_manager_timeout(QNetworkReply *reply) {
     error_type = QNetworkReply::TimeoutError;
     response = "";
     error_str = "Timed out waiting for response";
+    disconnect(manager, nullptr, nullptr, nullptr);
     reply->abort();
     reply->deleteLater();
     emit on_execution_finished(this);

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
@@ -18,12 +18,27 @@
 
 namespace test_namespace {
 
-PFXPetApi::PFXPetApi(const QString& basePath, const int timeOut) :
+PFXPetApi::PFXPetApi(const QString &scheme, const QString &host, int port, const QString& basePath, const int timeOut) :
+    _scheme(scheme),
+    _host(host),
+    _port(port),
     _basePath(basePath),
     _timeOut(timeOut) {
 }
 
 PFXPetApi::~PFXPetApi() {
+}
+
+void PFXPetApi::setScheme(const QString& scheme){
+    _scheme = scheme;
+}
+
+void PFXPetApi::setHost(const QString& host){
+    _host = host;
+}
+
+void PFXPetApi::setPort(int port){
+    _port = port;
 }
 
 void PFXPetApi::setBasePath(const QString& basePath){
@@ -44,8 +59,12 @@ void PFXPetApi::addHeaders(const QString& key, const QString& value){
 
 void
 PFXPetApi::addPet(const PFXPet& body) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/pet");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/pet");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
@@ -94,8 +113,12 @@ PFXPetApi::addPetCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXPetApi::deletePet(const qint64& pet_id, const QString& api_key) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/pet/{petId}");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/pet/{petId}");
     QString pet_idPathParam("{");
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
@@ -147,8 +170,12 @@ PFXPetApi::deletePetCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXPetApi::findPetsByStatus(const QList<QString>& status) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/pet/findByStatus");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/pet/findByStatus");
     
     if (status.size() > 0) {
       if (QString("csv").indexOf("multi") == 0) {
@@ -244,8 +271,12 @@ PFXPetApi::findPetsByStatusCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXPetApi::findPetsByTags(const QList<QString>& tags) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/pet/findByTags");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/pet/findByTags");
     
     if (tags.size() > 0) {
       if (QString("csv").indexOf("multi") == 0) {
@@ -341,8 +372,12 @@ PFXPetApi::findPetsByTagsCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXPetApi::getPetById(const qint64& pet_id) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/pet/{petId}");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/pet/{petId}");
     QString pet_idPathParam("{");
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
@@ -392,8 +427,12 @@ PFXPetApi::getPetByIdCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXPetApi::updatePet(const PFXPet& body) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/pet");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/pet");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
@@ -442,8 +481,12 @@ PFXPetApi::updatePetCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXPetApi::updatePetWithForm(const qint64& pet_id, const QString& name, const QString& status) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/pet/{petId}");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/pet/{petId}");
     QString pet_idPathParam("{");
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
@@ -494,8 +537,12 @@ PFXPetApi::updatePetWithFormCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXPetApi::uploadFile(const qint64& pet_id, const QString& additional_metadata, const PFXHttpFileElement& file) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/pet/{petId}/uploadImage");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/pet/{petId}/uploadImage");
     QString pet_idPathParam("{");
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.cpp
@@ -18,51 +18,38 @@
 
 namespace test_namespace {
 
-PFXPetApi::PFXPetApi() : basePath("/v2"),
-    host("petstore.swagger.io"),
-    timeout(0){
-
+PFXPetApi::PFXPetApi(const QString& basePath, const int timeOut) :
+    _basePath(basePath),
+    _timeOut(timeOut) {
 }
 
 PFXPetApi::~PFXPetApi() {
-
-}
-
-PFXPetApi::PFXPetApi(const QString& host, const QString& basePath, const int tout) {
-    this->host = host;
-    this->basePath = basePath;
-    this->timeout = tout;
 }
 
 void PFXPetApi::setBasePath(const QString& basePath){
-    this->basePath = basePath;
+    _basePath = basePath;
 }
 
-void PFXPetApi::setHost(const QString& host){
-    this->host = host;
-}
-
-void PFXPetApi::setApiTimeOutMs(const int tout){
-    timeout = tout;
+void PFXPetApi::setTimeOut(const int timeOut){
+    _timeOut = timeOut;
 }
 
 void PFXPetApi::setWorkingDirectory(const QString& path){
-    workingDirectory = path;
+    _workingDirectory = path;
 }
 
 void PFXPetApi::addHeaders(const QString& key, const QString& value){
     defaultHeaders.insert(key, value);
 }
 
-
 void
 PFXPetApi::addPet(const PFXPet& body) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/pet");
+    fullPath.append(_basePath).append("/pet");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
     
     
@@ -108,14 +95,14 @@ PFXPetApi::addPetCallback(PFXHttpRequestWorker * worker) {
 void
 PFXPetApi::deletePet(const qint64& pet_id, const QString& api_key) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/pet/{petId}");
+    fullPath.append(_basePath).append("/pet/{petId}");
     QString pet_idPathParam("{");
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "DELETE");
     
 
@@ -161,7 +148,7 @@ PFXPetApi::deletePetCallback(PFXHttpRequestWorker * worker) {
 void
 PFXPetApi::findPetsByStatus(const QList<QString>& status) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/pet/findByStatus");
+    fullPath.append(_basePath).append("/pet/findByStatus");
     
     if (status.size() > 0) {
       if (QString("csv").indexOf("multi") == 0) {
@@ -204,8 +191,8 @@ PFXPetApi::findPetsByStatus(const QList<QString>& status) {
     }
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
     
 
@@ -258,7 +245,7 @@ PFXPetApi::findPetsByStatusCallback(PFXHttpRequestWorker * worker) {
 void
 PFXPetApi::findPetsByTags(const QList<QString>& tags) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/pet/findByTags");
+    fullPath.append(_basePath).append("/pet/findByTags");
     
     if (tags.size() > 0) {
       if (QString("csv").indexOf("multi") == 0) {
@@ -301,8 +288,8 @@ PFXPetApi::findPetsByTags(const QList<QString>& tags) {
     }
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
     
 
@@ -355,14 +342,14 @@ PFXPetApi::findPetsByTagsCallback(PFXHttpRequestWorker * worker) {
 void
 PFXPetApi::getPetById(const qint64& pet_id) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/pet/{petId}");
+    fullPath.append(_basePath).append("/pet/{petId}");
     QString pet_idPathParam("{");
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
     
 
@@ -406,11 +393,11 @@ PFXPetApi::getPetByIdCallback(PFXHttpRequestWorker * worker) {
 void
 PFXPetApi::updatePet(const PFXPet& body) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/pet");
+    fullPath.append(_basePath).append("/pet");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "PUT");
     
     
@@ -456,14 +443,14 @@ PFXPetApi::updatePetCallback(PFXHttpRequestWorker * worker) {
 void
 PFXPetApi::updatePetWithForm(const qint64& pet_id, const QString& name, const QString& status) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/pet/{petId}");
+    fullPath.append(_basePath).append("/pet/{petId}");
     QString pet_idPathParam("{");
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
     
     input.add_var("name", ::test_namespace::toStringValue(name));
@@ -508,14 +495,14 @@ PFXPetApi::updatePetWithFormCallback(PFXHttpRequestWorker * worker) {
 void
 PFXPetApi::uploadFile(const qint64& pet_id, const QString& additional_metadata, const PFXHttpFileElement& file) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/pet/{petId}/uploadImage");
+    fullPath.append(_basePath).append("/pet/{petId}/uploadImage");
     QString pet_idPathParam("{");
     pet_idPathParam.append("petId").append("}");
     fullPath.replace(pet_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(pet_id)));
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
     
     input.add_var("additionalMetadata", ::test_namespace::toStringValue(additional_metadata));

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -28,9 +28,12 @@ class PFXPetApi: public QObject {
     Q_OBJECT
 
 public:
-    PFXPetApi(const QString& basePath = "http://petstore.swagger.io/v2", const int timeOut = 0);
+    PFXPetApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 8080, const QString& basePath = "/v2", const int timeOut = 0);
     ~PFXPetApi();
 
+    void setScheme(const QString &scheme);
+    void setHost(const QString &host);
+    void setPort(int port);
     void setBasePath(const QString& basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString& path);
@@ -46,8 +49,8 @@ public:
     void uploadFile(const qint64& pet_id, const QString& additional_metadata, const PFXHttpFileElement& file);
     
 private:
-    QString _basePath;
-    int _timeOut;
+    QString _scheme, _host, _basePath;
+    int _port, _timeOut;
     QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
     void addPetCallback (PFXHttpRequestWorker * worker);

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -28,13 +28,11 @@ class PFXPetApi: public QObject {
     Q_OBJECT
 
 public:
-    PFXPetApi();
-    PFXPetApi(const QString& host, const QString& basePath, const int toutMs = 0);
+    PFXPetApi(const QString& basePath = "http://petstore.swagger.io/v2", const int timeOut = 0);
     ~PFXPetApi();
 
     void setBasePath(const QString& basePath);
-    void setHost(const QString& host);
-    void setApiTimeOutMs(const int tout);
+    void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString& path);
     void addHeaders(const QString& key, const QString& value);
 
@@ -48,10 +46,9 @@ public:
     void uploadFile(const qint64& pet_id, const QString& additional_metadata, const PFXHttpFileElement& file);
     
 private:
-    QString basePath;
-    QString host;
-    QString workingDirectory;
-    int timeout;
+    QString _basePath;
+    int _timeOut;
+    QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
     void addPetCallback (PFXHttpRequestWorker * worker);
     void deletePetCallback (PFXHttpRequestWorker * worker);

--- a/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXPetApi.h
@@ -28,7 +28,7 @@ class PFXPetApi: public QObject {
     Q_OBJECT
 
 public:
-    PFXPetApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 8080, const QString& basePath = "/v2", const int timeOut = 0);
+    PFXPetApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 0, const QString& basePath = "/v2", const int timeOut = 0);
     ~PFXPetApi();
 
     void setScheme(const QString &scheme);

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -18,12 +18,27 @@
 
 namespace test_namespace {
 
-PFXStoreApi::PFXStoreApi(const QString& basePath, const int timeOut) :
+PFXStoreApi::PFXStoreApi(const QString &scheme, const QString &host, int port, const QString& basePath, const int timeOut) :
+    _scheme(scheme),
+    _host(host),
+    _port(port),
     _basePath(basePath),
     _timeOut(timeOut) {
 }
 
 PFXStoreApi::~PFXStoreApi() {
+}
+
+void PFXStoreApi::setScheme(const QString& scheme){
+    _scheme = scheme;
+}
+
+void PFXStoreApi::setHost(const QString& host){
+    _host = host;
+}
+
+void PFXStoreApi::setPort(int port){
+    _port = port;
 }
 
 void PFXStoreApi::setBasePath(const QString& basePath){
@@ -44,8 +59,12 @@ void PFXStoreApi::addHeaders(const QString& key, const QString& value){
 
 void
 PFXStoreApi::deleteOrder(const QString& order_id) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/store/order/{orderId}");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/store/order/{orderId}");
     QString order_idPathParam("{");
     order_idPathParam.append("orderId").append("}");
     fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
@@ -94,8 +113,12 @@ PFXStoreApi::deleteOrderCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXStoreApi::getInventory() {
-    QString fullPath;
-    fullPath.append(_basePath).append("/store/inventory");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/store/inventory");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
@@ -151,8 +174,12 @@ PFXStoreApi::getInventoryCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXStoreApi::getOrderById(const qint64& order_id) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/store/order/{orderId}");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/store/order/{orderId}");
     QString order_idPathParam("{");
     order_idPathParam.append("orderId").append("}");
     fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
@@ -202,8 +229,12 @@ PFXStoreApi::getOrderByIdCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXStoreApi::placeOrder(const PFXOrder& body) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/store/order");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/store/order");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.cpp
@@ -18,54 +18,41 @@
 
 namespace test_namespace {
 
-PFXStoreApi::PFXStoreApi() : basePath("/v2"),
-    host("petstore.swagger.io"),
-    timeout(0){
-
+PFXStoreApi::PFXStoreApi(const QString& basePath, const int timeOut) :
+    _basePath(basePath),
+    _timeOut(timeOut) {
 }
 
 PFXStoreApi::~PFXStoreApi() {
-
-}
-
-PFXStoreApi::PFXStoreApi(const QString& host, const QString& basePath, const int tout) {
-    this->host = host;
-    this->basePath = basePath;
-    this->timeout = tout;
 }
 
 void PFXStoreApi::setBasePath(const QString& basePath){
-    this->basePath = basePath;
+    _basePath = basePath;
 }
 
-void PFXStoreApi::setHost(const QString& host){
-    this->host = host;
-}
-
-void PFXStoreApi::setApiTimeOutMs(const int tout){
-    timeout = tout;
+void PFXStoreApi::setTimeOut(const int timeOut){
+    _timeOut = timeOut;
 }
 
 void PFXStoreApi::setWorkingDirectory(const QString& path){
-    workingDirectory = path;
+    _workingDirectory = path;
 }
 
 void PFXStoreApi::addHeaders(const QString& key, const QString& value){
     defaultHeaders.insert(key, value);
 }
 
-
 void
 PFXStoreApi::deleteOrder(const QString& order_id) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/store/order/{orderId}");
+    fullPath.append(_basePath).append("/store/order/{orderId}");
     QString order_idPathParam("{");
     order_idPathParam.append("orderId").append("}");
     fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "DELETE");
     
 
@@ -108,11 +95,11 @@ PFXStoreApi::deleteOrderCallback(PFXHttpRequestWorker * worker) {
 void
 PFXStoreApi::getInventory() {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/store/inventory");
+    fullPath.append(_basePath).append("/store/inventory");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
     
 
@@ -165,14 +152,14 @@ PFXStoreApi::getInventoryCallback(PFXHttpRequestWorker * worker) {
 void
 PFXStoreApi::getOrderById(const qint64& order_id) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/store/order/{orderId}");
+    fullPath.append(_basePath).append("/store/order/{orderId}");
     QString order_idPathParam("{");
     order_idPathParam.append("orderId").append("}");
     fullPath.replace(order_idPathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(order_id)));
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
     
 
@@ -216,11 +203,11 @@ PFXStoreApi::getOrderByIdCallback(PFXHttpRequestWorker * worker) {
 void
 PFXStoreApi::placeOrder(const PFXOrder& body) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/store/order");
+    fullPath.append(_basePath).append("/store/order");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
     
     

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -27,13 +27,11 @@ class PFXStoreApi: public QObject {
     Q_OBJECT
 
 public:
-    PFXStoreApi();
-    PFXStoreApi(const QString& host, const QString& basePath, const int toutMs = 0);
+    PFXStoreApi(const QString& basePath = "http://petstore.swagger.io/v2", const int timeOut = 0);
     ~PFXStoreApi();
 
     void setBasePath(const QString& basePath);
-    void setHost(const QString& host);
-    void setApiTimeOutMs(const int tout);
+    void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString& path);
     void addHeaders(const QString& key, const QString& value);
 
@@ -43,10 +41,9 @@ public:
     void placeOrder(const PFXOrder& body);
     
 private:
-    QString basePath;
-    QString host;
-    QString workingDirectory;
-    int timeout;
+    QString _basePath;
+    int _timeOut;
+    QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
     void deleteOrderCallback (PFXHttpRequestWorker * worker);
     void getInventoryCallback (PFXHttpRequestWorker * worker);

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -27,7 +27,7 @@ class PFXStoreApi: public QObject {
     Q_OBJECT
 
 public:
-    PFXStoreApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 8080, const QString& basePath = "/v2", const int timeOut = 0);
+    PFXStoreApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 0, const QString& basePath = "/v2", const int timeOut = 0);
     ~PFXStoreApi();
 
     void setScheme(const QString &scheme);

--- a/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXStoreApi.h
@@ -27,9 +27,12 @@ class PFXStoreApi: public QObject {
     Q_OBJECT
 
 public:
-    PFXStoreApi(const QString& basePath = "http://petstore.swagger.io/v2", const int timeOut = 0);
+    PFXStoreApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 8080, const QString& basePath = "/v2", const int timeOut = 0);
     ~PFXStoreApi();
 
+    void setScheme(const QString &scheme);
+    void setHost(const QString &host);
+    void setPort(int port);
     void setBasePath(const QString& basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString& path);
@@ -41,8 +44,8 @@ public:
     void placeOrder(const PFXOrder& body);
     
 private:
-    QString _basePath;
-    int _timeOut;
+    QString _scheme, _host, _basePath;
+    int _port, _timeOut;
     QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
     void deleteOrderCallback (PFXHttpRequestWorker * worker);

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -18,12 +18,27 @@
 
 namespace test_namespace {
 
-PFXUserApi::PFXUserApi(const QString& basePath, const int timeOut) :
+PFXUserApi::PFXUserApi(const QString &scheme, const QString &host, int port, const QString& basePath, const int timeOut) :
+    _scheme(scheme),
+    _host(host),
+    _port(port),
     _basePath(basePath),
     _timeOut(timeOut) {
 }
 
 PFXUserApi::~PFXUserApi() {
+}
+
+void PFXUserApi::setScheme(const QString& scheme){
+    _scheme = scheme;
+}
+
+void PFXUserApi::setHost(const QString& host){
+    _host = host;
+}
+
+void PFXUserApi::setPort(int port){
+    _port = port;
 }
 
 void PFXUserApi::setBasePath(const QString& basePath){
@@ -44,8 +59,12 @@ void PFXUserApi::addHeaders(const QString& key, const QString& value){
 
 void
 PFXUserApi::createUser(const PFXUser& body) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/user");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/user");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
@@ -94,8 +113,12 @@ PFXUserApi::createUserCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXUserApi::createUsersWithArrayInput(const QList<PFXUser>& body) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/user/createWithArray");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/user/createWithArray");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
@@ -145,8 +168,12 @@ PFXUserApi::createUsersWithArrayInputCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXUserApi::createUsersWithListInput(const QList<PFXUser>& body) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/user/createWithList");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/user/createWithList");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
@@ -196,8 +223,12 @@ PFXUserApi::createUsersWithListInputCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXUserApi::deleteUser(const QString& username) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/user/{username}");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/user/{username}");
     QString usernamePathParam("{");
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
@@ -246,8 +277,12 @@ PFXUserApi::deleteUserCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXUserApi::getUserByName(const QString& username) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/user/{username}");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/user/{username}");
     QString usernamePathParam("{");
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
@@ -297,8 +332,12 @@ PFXUserApi::getUserByNameCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXUserApi::loginUser(const QString& username, const QString& password) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/user/login");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/user/login");
     
     if (fullPath.indexOf("?") > 0)
       fullPath.append("&");
@@ -362,8 +401,12 @@ PFXUserApi::loginUserCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXUserApi::logoutUser() {
-    QString fullPath;
-    fullPath.append(_basePath).append("/user/logout");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/user/logout");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
     worker->setTimeOut(_timeOut);
@@ -409,8 +452,12 @@ PFXUserApi::logoutUserCallback(PFXHttpRequestWorker * worker) {
 
 void
 PFXUserApi::updateUser(const QString& username, const PFXUser& body) {
-    QString fullPath;
-    fullPath.append(_basePath).append("/user/{username}");
+    QString fullPath = QString("%0://%1%2%3%4")
+        .arg(_scheme)
+        .arg(_host)
+        .arg(_port ? ":" + QString::number(_port) : "")
+        .arg(_basePath)
+        .arg("/user/{username}");
     QString usernamePathParam("{");
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.cpp
@@ -18,51 +18,38 @@
 
 namespace test_namespace {
 
-PFXUserApi::PFXUserApi() : basePath("/v2"),
-    host("petstore.swagger.io"),
-    timeout(0){
-
+PFXUserApi::PFXUserApi(const QString& basePath, const int timeOut) :
+    _basePath(basePath),
+    _timeOut(timeOut) {
 }
 
 PFXUserApi::~PFXUserApi() {
-
-}
-
-PFXUserApi::PFXUserApi(const QString& host, const QString& basePath, const int tout) {
-    this->host = host;
-    this->basePath = basePath;
-    this->timeout = tout;
 }
 
 void PFXUserApi::setBasePath(const QString& basePath){
-    this->basePath = basePath;
+    _basePath = basePath;
 }
 
-void PFXUserApi::setHost(const QString& host){
-    this->host = host;
-}
-
-void PFXUserApi::setApiTimeOutMs(const int tout){
-    timeout = tout;
+void PFXUserApi::setTimeOut(const int timeOut){
+    _timeOut = timeOut;
 }
 
 void PFXUserApi::setWorkingDirectory(const QString& path){
-    workingDirectory = path;
+    _workingDirectory = path;
 }
 
 void PFXUserApi::addHeaders(const QString& key, const QString& value){
     defaultHeaders.insert(key, value);
 }
 
-
 void
 PFXUserApi::createUser(const PFXUser& body) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/user");
+    fullPath.append(_basePath).append("/user");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
     
     
@@ -108,11 +95,11 @@ PFXUserApi::createUserCallback(PFXHttpRequestWorker * worker) {
 void
 PFXUserApi::createUsersWithArrayInput(const QList<PFXUser>& body) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/user/createWithArray");
+    fullPath.append(_basePath).append("/user/createWithArray");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
     
     
@@ -159,11 +146,11 @@ PFXUserApi::createUsersWithArrayInputCallback(PFXHttpRequestWorker * worker) {
 void
 PFXUserApi::createUsersWithListInput(const QList<PFXUser>& body) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/user/createWithList");
+    fullPath.append(_basePath).append("/user/createWithList");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "POST");
     
     
@@ -210,14 +197,14 @@ PFXUserApi::createUsersWithListInputCallback(PFXHttpRequestWorker * worker) {
 void
 PFXUserApi::deleteUser(const QString& username) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/user/{username}");
+    fullPath.append(_basePath).append("/user/{username}");
     QString usernamePathParam("{");
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "DELETE");
     
 
@@ -260,14 +247,14 @@ PFXUserApi::deleteUserCallback(PFXHttpRequestWorker * worker) {
 void
 PFXUserApi::getUserByName(const QString& username) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/user/{username}");
+    fullPath.append(_basePath).append("/user/{username}");
     QString usernamePathParam("{");
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
     
 
@@ -311,7 +298,7 @@ PFXUserApi::getUserByNameCallback(PFXHttpRequestWorker * worker) {
 void
 PFXUserApi::loginUser(const QString& username, const QString& password) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/user/login");
+    fullPath.append(_basePath).append("/user/login");
     
     if (fullPath.indexOf("?") > 0)
       fullPath.append("&");
@@ -330,8 +317,8 @@ PFXUserApi::loginUser(const QString& username, const QString& password) {
         .append(QUrl::toPercentEncoding(::test_namespace::toStringValue(password)));
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
     
 
@@ -376,11 +363,11 @@ PFXUserApi::loginUserCallback(PFXHttpRequestWorker * worker) {
 void
 PFXUserApi::logoutUser() {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/user/logout");
+    fullPath.append(_basePath).append("/user/logout");
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "GET");
     
 
@@ -423,14 +410,14 @@ PFXUserApi::logoutUserCallback(PFXHttpRequestWorker * worker) {
 void
 PFXUserApi::updateUser(const QString& username, const PFXUser& body) {
     QString fullPath;
-    fullPath.append(this->host).append(this->basePath).append("/user/{username}");
+    fullPath.append(_basePath).append("/user/{username}");
     QString usernamePathParam("{");
     usernamePathParam.append("username").append("}");
     fullPath.replace(usernamePathParam, QUrl::toPercentEncoding(::test_namespace::toStringValue(username)));
     
     PFXHttpRequestWorker *worker = new PFXHttpRequestWorker(this);
-    worker->setTimeOut(timeout);
-    worker->setWorkingDirectory(workingDirectory);    
+    worker->setTimeOut(_timeOut);
+    worker->setWorkingDirectory(_workingDirectory);
     PFXHttpRequestInput input(fullPath, "PUT");
     
     

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -27,7 +27,7 @@ class PFXUserApi: public QObject {
     Q_OBJECT
 
 public:
-    PFXUserApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 8080, const QString& basePath = "/v2", const int timeOut = 0);
+    PFXUserApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 0, const QString& basePath = "/v2", const int timeOut = 0);
     ~PFXUserApi();
 
     void setScheme(const QString &scheme);

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -27,9 +27,12 @@ class PFXUserApi: public QObject {
     Q_OBJECT
 
 public:
-    PFXUserApi(const QString& basePath = "http://petstore.swagger.io/v2", const int timeOut = 0);
+    PFXUserApi(const QString &scheme = "http", const QString &host = "petstore.swagger.io", int port = 8080, const QString& basePath = "/v2", const int timeOut = 0);
     ~PFXUserApi();
 
+    void setScheme(const QString &scheme);
+    void setHost(const QString &host);
+    void setPort(int port);
     void setBasePath(const QString& basePath);
     void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString& path);
@@ -45,8 +48,8 @@ public:
     void updateUser(const QString& username, const PFXUser& body);
     
 private:
-    QString _basePath;
-    int _timeOut;
+    QString _scheme, _host, _basePath;
+    int _port, _timeOut;
     QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
     void createUserCallback (PFXHttpRequestWorker * worker);

--- a/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXUserApi.h
@@ -27,13 +27,11 @@ class PFXUserApi: public QObject {
     Q_OBJECT
 
 public:
-    PFXUserApi();
-    PFXUserApi(const QString& host, const QString& basePath, const int toutMs = 0);
+    PFXUserApi(const QString& basePath = "http://petstore.swagger.io/v2", const int timeOut = 0);
     ~PFXUserApi();
 
     void setBasePath(const QString& basePath);
-    void setHost(const QString& host);
-    void setApiTimeOutMs(const int tout);
+    void setTimeOut(const int timeOut);
     void setWorkingDirectory(const QString& path);
     void addHeaders(const QString& key, const QString& value);
 
@@ -47,10 +45,9 @@ public:
     void updateUser(const QString& username, const PFXUser& body);
     
 private:
-    QString basePath;
-    QString host;
-    QString workingDirectory;
-    int timeout;
+    QString _basePath;
+    int _timeOut;
+    QString _workingDirectory;
     QMap<QString, QString> defaultHeaders;
     void createUserCallback (PFXHttpRequestWorker * worker);
     void createUsersWithArrayInputCallback (PFXHttpRequestWorker * worker);


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR replace part of the job done here: #3688 

Now that the base path is well handled, the API class can use the one provided in the API description.

There was previously a mismatch between host and base path as mentionned here: #3399

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ravinikam @stkrwork @etherealjoy @muttleyxd