### PR TITLE
Simpler timeout with QTimer::singleShot

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -8,6 +8,7 @@
 #include <QFileInfo>
 #include <QBuffer>
 #include <QtGlobal>
+#include <QTimer>
 
 #include "{{prefix}}HttpRequest.h"
 
@@ -47,23 +48,15 @@ void {{prefix}}HttpRequestInput::add_file(QString variable_name, QString local_f
 
 
 {{prefix}}HttpRequestWorker::{{prefix}}HttpRequestWorker(QObject *parent)
-    : QObject(parent), manager(nullptr)
+    : QObject(parent), manager(nullptr), _timeOut(0)
 {
     qsrand(QDateTime::currentDateTime().toTime_t());
-    timeout = 0;
-    timer = new QTimer();
     manager = new QNetworkAccessManager(this);
     workingDirectory = QDir::currentPath();    
     connect(manager, &QNetworkAccessManager::finished, this, &{{prefix}}HttpRequestWorker::on_manager_finished);
 }
 
 {{prefix}}HttpRequestWorker::~{{prefix}}HttpRequestWorker() {
-    if(timer != nullptr){
-        if(timer->isActive()){
-            timer->stop();
-        }
-        timer->deleteLater();
-    }
     for (const auto & item: multiPartFields) {
         if(item != nullptr) {
             delete item;
@@ -97,8 +90,8 @@ QByteArray *{{prefix}}HttpRequestWorker::getMultiPartField(const QString &fieldn
     return nullptr;
 }
 
-void {{prefix}}HttpRequestWorker::setTimeOut(int tout){
-    timeout = tout;
+void {{prefix}}HttpRequestWorker::setTimeOut(int timeOut){
+    _timeOut = _timeOut;
 }
 
 void {{prefix}}HttpRequestWorker::setWorkingDirectory(const QString &path){
@@ -358,11 +351,8 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
         buffer->setParent(reply);
 #endif
     }
-    if(timeout > 0){
-        timer->setSingleShot(true);
-        timer->setInterval(timeout);
-        connect(timer, &QTimer::timeout, this, [=](){ on_manager_timeout(reply); });
-        timer->start();
+    if(_timeOut > 0){
+        QTimer::singleShot(_timeOut, [=](){ on_manager_timeout(reply); });
     }
 }
 
@@ -375,6 +365,7 @@ void {{prefix}}HttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
             headers.insert(item.first, item.second);
         }
     }
+    disconnect(this, nullptr, nullptr, nullptr);
     reply->deleteLater();
     process_form_response();
     emit on_execution_finished(this);
@@ -384,7 +375,6 @@ void {{prefix}}HttpRequestWorker::on_manager_timeout(QNetworkReply *reply) {
     error_type = QNetworkReply::TimeoutError;
     response = "";
     error_str = "Timed out waiting for response";
-    disconnect(manager, nullptr, nullptr, nullptr);
     reply->abort();
     reply->deleteLater();
     emit on_execution_finished(this);

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
@@ -10,11 +10,9 @@
 
 #include <QObject>
 #include <QString>
-#include <QTimer>
 #include <QMap>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
-
 
 #include "{{prefix}}HttpFileElement.h"
 
@@ -52,7 +50,6 @@ public:
     QByteArray response;
     QNetworkReply::NetworkError error_type;
     QString error_str;
-    QTimer *timer;
     explicit {{prefix}}HttpRequestWorker(QObject *parent = nullptr);
     virtual ~{{prefix}}HttpRequestWorker();
 
@@ -73,7 +70,7 @@ private:
     QMap<QString, {{prefix}}HttpFileElement> files;
     QMap<QString, QByteArray*> multiPartFields;
     QString workingDirectory;
-    int timeout;
+    int _timeOut;
     void on_manager_timeout(QNetworkReply *reply);
     void process_form_response();    
 private slots:

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
@@ -21,11 +21,9 @@
 
 #include <QObject>
 #include <QString>
-#include <QTimer>
 #include <QMap>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
-
 
 #include "PFXHttpFileElement.h"
 
@@ -61,7 +59,6 @@ public:
     QByteArray response;
     QNetworkReply::NetworkError error_type;
     QString error_str;
-    QTimer *timer;
     explicit PFXHttpRequestWorker(QObject *parent = nullptr);
     virtual ~PFXHttpRequestWorker();
 
@@ -82,7 +79,7 @@ private:
     QMap<QString, PFXHttpFileElement> files;
     QMap<QString, QByteArray*> multiPartFields;
     QString workingDirectory;
-    int timeout;
+    int _timeOut;
     void on_manager_timeout(QNetworkReply *reply);
     void process_form_response();    
 private slots:


### PR DESCRIPTION
This PR replace part of the job done here: #3688

The idea is to simplify the timer management by replacing the `QTimer` instance by a call to the `QTimer::singleShot()` static method`.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- x ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ravinikam @stkrwork @etherealjoy @muttleyxd