### PR TITLE
fixup! Simpler timeout with QTimer::singleShot (#4430)

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -91,7 +91,7 @@ QByteArray *{{prefix}}HttpRequestWorker::getMultiPartField(const QString &fieldn
 }
 
 void {{prefix}}HttpRequestWorker::setTimeOut(int timeOut){
-    _timeOut = _timeOut;
+    _timeOut = timeOut;
 }
 
 void {{prefix}}HttpRequestWorker::setWorkingDirectory(const QString &path){

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -365,7 +365,6 @@ void {{prefix}}HttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
             headers.insert(item.first, item.second);
         }
     }
-    disconnect(this, nullptr, nullptr, nullptr);
     reply->deleteLater();
     process_form_response();
     emit on_execution_finished(this);
@@ -375,6 +374,7 @@ void {{prefix}}HttpRequestWorker::on_manager_timeout(QNetworkReply *reply) {
     error_type = QNetworkReply::TimeoutError;
     response = "";
     error_str = "Timed out waiting for response";
+    disconnect(manager, nullptr, nullptr, nullptr);
     reply->abort();
     reply->deleteLater();
     emit on_execution_finished(this);

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
@@ -100,7 +100,7 @@ QByteArray *PFXHttpRequestWorker::getMultiPartField(const QString &fieldname){
 }
 
 void PFXHttpRequestWorker::setTimeOut(int timeOut){
-    _timeOut = _timeOut;
+    _timeOut = timeOut;
 }
 
 void PFXHttpRequestWorker::setWorkingDirectory(const QString &path){

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
@@ -374,6 +374,7 @@ void PFXHttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
             headers.insert(item.first, item.second);
         }
     }
+    disconnect(this, nullptr, nullptr, nullptr);
     reply->deleteLater();
     process_form_response();
     emit on_execution_finished(this);
@@ -383,7 +384,6 @@ void PFXHttpRequestWorker::on_manager_timeout(QNetworkReply *reply) {
     error_type = QNetworkReply::TimeoutError;
     response = "";
     error_str = "Timed out waiting for response";
-    disconnect(manager, nullptr, nullptr, nullptr);
     reply->abort();
     reply->deleteLater();
     emit on_execution_finished(this);

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
@@ -374,7 +374,6 @@ void PFXHttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
             headers.insert(item.first, item.second);
         }
     }
-    disconnect(this, nullptr, nullptr, nullptr);
     reply->deleteLater();
     process_form_response();
     emit on_execution_finished(this);
@@ -384,6 +383,7 @@ void PFXHttpRequestWorker::on_manager_timeout(QNetworkReply *reply) {
     error_type = QNetworkReply::TimeoutError;
     response = "";
     error_str = "Timed out waiting for response";
+    disconnect(manager, nullptr, nullptr, nullptr);
     reply->abort();
     reply->deleteLater();
     emit on_execution_finished(this);


### PR DESCRIPTION
This fix the problem mentionned here: https://github.com/OpenAPITools/openapi-generator/pull/4430#issuecomment-552183699

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ravinikam @stkrwork @etherealjoy @muttleyxd