### PR TITLE
Revert "Simpler timeout with QTimer::singleShot (#4430)"

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.cpp.mustache
@@ -8,7 +8,6 @@
 #include <QFileInfo>
 #include <QBuffer>
 #include <QtGlobal>
-#include <QTimer>
 
 #include "{{prefix}}HttpRequest.h"
 
@@ -48,15 +47,23 @@ void {{prefix}}HttpRequestInput::add_file(QString variable_name, QString local_f
 
 
 {{prefix}}HttpRequestWorker::{{prefix}}HttpRequestWorker(QObject *parent)
-    : QObject(parent), manager(nullptr), _timeOut(0)
+    : QObject(parent), manager(nullptr)
 {
     qsrand(QDateTime::currentDateTime().toTime_t());
+    timeout = 0;
+    timer = new QTimer();
     manager = new QNetworkAccessManager(this);
     workingDirectory = QDir::currentPath();    
     connect(manager, &QNetworkAccessManager::finished, this, &{{prefix}}HttpRequestWorker::on_manager_finished);
 }
 
 {{prefix}}HttpRequestWorker::~{{prefix}}HttpRequestWorker() {
+    if(timer != nullptr){
+        if(timer->isActive()){
+            timer->stop();
+        }
+        timer->deleteLater();
+    }
     for (const auto & item: multiPartFields) {
         if(item != nullptr) {
             delete item;
@@ -90,8 +97,8 @@ QByteArray *{{prefix}}HttpRequestWorker::getMultiPartField(const QString &fieldn
     return nullptr;
 }
 
-void {{prefix}}HttpRequestWorker::setTimeOut(int timeOut){
-    _timeOut = _timeOut;
+void {{prefix}}HttpRequestWorker::setTimeOut(int tout){
+    timeout = tout;
 }
 
 void {{prefix}}HttpRequestWorker::setWorkingDirectory(const QString &path){
@@ -351,8 +358,11 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
         buffer->setParent(reply);
 #endif
     }
-    if(_timeOut > 0){
-        QTimer::singleShot(_timeOut, [=](){ on_manager_timeout(reply); });
+    if(timeout > 0){
+        timer->setSingleShot(true);
+        timer->setInterval(timeout);
+        connect(timer, &QTimer::timeout, this, [=](){ on_manager_timeout(reply); });
+        timer->start();
     }
 }
 
@@ -365,7 +375,6 @@ void {{prefix}}HttpRequestWorker::on_manager_finished(QNetworkReply *reply) {
             headers.insert(item.first, item.second);
         }
     }
-    disconnect(this, nullptr, nullptr, nullptr);
     reply->deleteLater();
     process_form_response();
     emit on_execution_finished(this);
@@ -375,6 +384,7 @@ void {{prefix}}HttpRequestWorker::on_manager_timeout(QNetworkReply *reply) {
     error_type = QNetworkReply::TimeoutError;
     response = "";
     error_str = "Timed out waiting for response";
+    disconnect(manager, nullptr, nullptr, nullptr);
     reply->abort();
     reply->deleteLater();
     emit on_execution_finished(this);

--- a/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt5-client/HttpRequest.h.mustache
@@ -10,9 +10,11 @@
 
 #include <QObject>
 #include <QString>
+#include <QTimer>
 #include <QMap>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+
 
 #include "{{prefix}}HttpFileElement.h"
 
@@ -50,6 +52,7 @@ public:
     QByteArray response;
     QNetworkReply::NetworkError error_type;
     QString error_str;
+    QTimer *timer;
     explicit {{prefix}}HttpRequestWorker(QObject *parent = nullptr);
     virtual ~{{prefix}}HttpRequestWorker();
 
@@ -70,7 +73,7 @@ private:
     QMap<QString, {{prefix}}HttpFileElement> files;
     QMap<QString, QByteArray*> multiPartFields;
     QString workingDirectory;
-    int _timeOut;
+    int timeout;
     void on_manager_timeout(QNetworkReply *reply);
     void process_form_response();    
 private slots:

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.cpp
@@ -19,7 +19,6 @@
 #include <QFileInfo>
 #include <QBuffer>
 #include <QtGlobal>
-#include <QTimer>
 
 #include "PFXHttpRequest.h"
 
@@ -57,15 +56,23 @@ void PFXHttpRequestInput::add_file(QString variable_name, QString local_filename
 
 
 PFXHttpRequestWorker::PFXHttpRequestWorker(QObject *parent)
-    : QObject(parent), manager(nullptr), _timeOut(0)
+    : QObject(parent), manager(nullptr)
 {
     qsrand(QDateTime::currentDateTime().toTime_t());
+    timeout = 0;
+    timer = new QTimer();
     manager = new QNetworkAccessManager(this);
     workingDirectory = QDir::currentPath();    
     connect(manager, &QNetworkAccessManager::finished, this, &PFXHttpRequestWorker::on_manager_finished);
 }
 
 PFXHttpRequestWorker::~PFXHttpRequestWorker() {
+    if(timer != nullptr){
+        if(timer->isActive()){
+            timer->stop();
+        }
+        timer->deleteLater();
+    }
     for (const auto & item: multiPartFields) {
         if(item != nullptr) {
             delete item;
@@ -99,8 +106,8 @@ QByteArray *PFXHttpRequestWorker::getMultiPartField(const QString &fieldname){
     return nullptr;
 }
 
-void PFXHttpRequestWorker::setTimeOut(int timeOut){
-    _timeOut = _timeOut;
+void PFXHttpRequestWorker::setTimeOut(int tout){
+    timeout = tout;
 }
 
 void PFXHttpRequestWorker::setWorkingDirectory(const QString &path){
@@ -360,8 +367,11 @@ void PFXHttpRequestWorker::execute(PFXHttpRequestInput *input) {
         buffer->setParent(reply);
 #endif
     }
-    if(_timeOut > 0){
-        QTimer::singleShot(_timeOut, [=](){ on_manager_timeout(reply); });
+    if(timeout > 0){
+        timer->setSingleShot(true);
+        timer->setInterval(timeout);
+        connect(timer, &QTimer::timeout, this, [=](){ on_manager_timeout(reply); });
+        timer->start();
     }
 }
 

--- a/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
+++ b/samples/client/petstore/cpp-qt5/client/PFXHttpRequest.h
@@ -21,9 +21,11 @@
 
 #include <QObject>
 #include <QString>
+#include <QTimer>
 #include <QMap>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+
 
 #include "PFXHttpFileElement.h"
 
@@ -59,6 +61,7 @@ public:
     QByteArray response;
     QNetworkReply::NetworkError error_type;
     QString error_str;
+    QTimer *timer;
     explicit PFXHttpRequestWorker(QObject *parent = nullptr);
     virtual ~PFXHttpRequestWorker();
 
@@ -79,7 +82,7 @@ private:
     QMap<QString, PFXHttpFileElement> files;
     QMap<QString, QByteArray*> multiPartFields;
     QString workingDirectory;
-    int _timeOut;
+    int timeout;
     void on_manager_timeout(QNetworkReply *reply);
     void process_form_response();    
 private slots:


### PR DESCRIPTION
This reverts commit d0b2465b89d5e3336b99ca0bb35405e025907b0b.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@MartinDelille @ravinikam @muttleyxd @stkrwork 