### PR TITLE
[Python] Use Python 2.6 compatible dict definition

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -231,12 +231,12 @@ class ApiClient(object):
             # and attributes which value is not None.
             # Convert attribute name to json key in
             # model definition for request.
-            obj_dict = {obj.attribute_map[attr]: getattr(obj, attr)
-                        for attr, _ in six.iteritems(obj.openapi_types)
-                        if getattr(obj, attr) is not None}
+            obj_dict = dict([(obj.attribute_map[attr], getattr(obj, attr))
+                             for attr, _ in six.iteritems(obj.openapi_types)
+                             if getattr(obj, attr) is not None])
 
-        return {key: self.sanitize_for_serialization(val)
-                for key, val in six.iteritems(obj_dict)}
+        return dict([(key, self.sanitize_for_serialization(val))
+                     for key, val in six.iteritems(obj_dict)])
 
     def deserialize(self, response, response_type):
         """Deserializes response into an object.
@@ -279,8 +279,8 @@ class ApiClient(object):
 
             if klass.startswith('dict('):
                 sub_kls = re.match(r'dict\(([^,]*), (.*)\)', klass).group(2)
-                return {k: self.__deserialize(v, sub_kls)
-                        for k, v in six.iteritems(data)}
+                return dict([(k, self.__deserialize(v, sub_kls))
+                             for k, v in six.iteritems(data)])
 
             # convert str to class
             if klass in self.NATIVE_TYPES_MAPPING:

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -224,12 +224,12 @@ class ApiClient(object):
             # and attributes which value is not None.
             # Convert attribute name to json key in
             # model definition for request.
-            obj_dict = {obj.attribute_map[attr]: getattr(obj, attr)
-                        for attr, _ in six.iteritems(obj.openapi_types)
-                        if getattr(obj, attr) is not None}
+            obj_dict = dict([(obj.attribute_map[attr], getattr(obj, attr))
+                             for attr, _ in six.iteritems(obj.openapi_types)
+                             if getattr(obj, attr) is not None])
 
-        return {key: self.sanitize_for_serialization(val)
-                for key, val in six.iteritems(obj_dict)}
+        return dict([(key, self.sanitize_for_serialization(val))
+                     for key, val in six.iteritems(obj_dict)])
 
     def deserialize(self, response, response_type):
         """Deserializes response into an object.
@@ -272,8 +272,8 @@ class ApiClient(object):
 
             if klass.startswith('dict('):
                 sub_kls = re.match(r'dict\(([^,]*), (.*)\)', klass).group(2)
-                return {k: self.__deserialize(v, sub_kls)
-                        for k, v in six.iteritems(data)}
+                return dict([(k, self.__deserialize(v, sub_kls))
+                             for k, v in six.iteritems(data)])
 
             # convert str to class
             if klass in self.NATIVE_TYPES_MAPPING:

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -226,12 +226,12 @@ class ApiClient(object):
             # and attributes which value is not None.
             # Convert attribute name to json key in
             # model definition for request.
-            obj_dict = {obj.attribute_map[attr]: getattr(obj, attr)
-                        for attr, _ in six.iteritems(obj.openapi_types)
-                        if getattr(obj, attr) is not None}
+            obj_dict = dict([(obj.attribute_map[attr], getattr(obj, attr))
+                             for attr, _ in six.iteritems(obj.openapi_types)
+                             if getattr(obj, attr) is not None])
 
-        return {key: self.sanitize_for_serialization(val)
-                for key, val in six.iteritems(obj_dict)}
+        return dict([(key, self.sanitize_for_serialization(val))
+                     for key, val in six.iteritems(obj_dict)])
 
     def deserialize(self, response, response_type):
         """Deserializes response into an object.
@@ -274,8 +274,8 @@ class ApiClient(object):
 
             if klass.startswith('dict('):
                 sub_kls = re.match(r'dict\(([^,]*), (.*)\)', klass).group(2)
-                return {k: self.__deserialize(v, sub_kls)
-                        for k, v in six.iteritems(data)}
+                return dict([(k, self.__deserialize(v, sub_kls))
+                             for k, v in six.iteritems(data)])
 
             # convert str to class
             if klass in self.NATIVE_TYPES_MAPPING:

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -224,12 +224,12 @@ class ApiClient(object):
             # and attributes which value is not None.
             # Convert attribute name to json key in
             # model definition for request.
-            obj_dict = {obj.attribute_map[attr]: getattr(obj, attr)
-                        for attr, _ in six.iteritems(obj.openapi_types)
-                        if getattr(obj, attr) is not None}
+            obj_dict = dict([(obj.attribute_map[attr], getattr(obj, attr))
+                             for attr, _ in six.iteritems(obj.openapi_types)
+                             if getattr(obj, attr) is not None])
 
-        return {key: self.sanitize_for_serialization(val)
-                for key, val in six.iteritems(obj_dict)}
+        return dict([(key, self.sanitize_for_serialization(val))
+                     for key, val in six.iteritems(obj_dict)])
 
     def deserialize(self, response, response_type):
         """Deserializes response into an object.
@@ -272,8 +272,8 @@ class ApiClient(object):
 
             if klass.startswith('dict('):
                 sub_kls = re.match(r'dict\(([^,]*), (.*)\)', klass).group(2)
-                return {k: self.__deserialize(v, sub_kls)
-                        for k, v in six.iteritems(data)}
+                return dict([(k, self.__deserialize(v, sub_kls))
+                             for k, v in six.iteritems(data)])
 
             # convert str to class
             if klass in self.NATIVE_TYPES_MAPPING:


### PR DESCRIPTION
This changes the generated client to use a Python 2.6 compatible dictionary definition, which allows the client (on at least some APIs) to work on Python 2.6

This work was contributed by @nick-slack at @Metaswitch.

## Python Technical Committee

@taxpon, @frol, @mbohlool, @cbornet, @kenjones-cisco, @tomplus, @Jyhess, @slash-arun

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.