### PR TITLE
[core] Fix system properties being immutable

### DIFF
--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/WorkflowSettings.java
@@ -103,7 +103,9 @@ public class WorkflowSettings {
         builder.strictSpecBehavior = copy.isStrictSpecBehavior();
         builder.templatingEngineName = copy.getTemplatingEngineName();
         builder.ignoreFileOverride = copy.getIgnoreFileOverride();
-        builder.systemProperties = ImmutableMap.copyOf(copy.getSystemProperties());
+
+        // this, and any other collections, must be mutable in the builder.
+        builder.systemProperties = new HashMap<>(copy.getSystemProperties());
 
         // force builder "with" methods to invoke side effects
         builder.withTemplateDir(copy.getTemplateDir());
@@ -272,6 +274,8 @@ public class WorkflowSettings {
         private String templateDir;
         private String templatingEngineName = DEFAULT_TEMPLATING_ENGINE_NAME;
         private String ignoreFileOverride;
+
+        // NOTE: All collections must be mutable in the builder, and copied to a new immutable collection in .build()
         private Map<String, String> systemProperties = new HashMap<>();;
 
         private Builder() {

--- a/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/config/WorkflowSettingsTest.java
+++ b/modules/openapi-generator-core/src/test/java/org/openapitools/codegen/config/WorkflowSettingsTest.java
@@ -19,6 +19,7 @@ package org.openapitools.codegen.config;
 import org.testng.annotations.Test;
 
 import java.nio.file.Paths;
+import java.util.Map;
 
 import static org.testng.Assert.*;
 
@@ -46,6 +47,25 @@ public class WorkflowSettingsTest {
         assertFalse(settings.isEnablePostProcessFile());
         assertFalse(settings.isEnableMinimalUpdate());
         assertTrue(settings.isStrictSpecBehavior());
+    }
+
+    @Test
+    public void newBuilderFromCopyShouldMutateSystemProperties(){
+        WorkflowSettings original = WorkflowSettings.newBuilder()
+                .withOutputDir("output")
+                .withVerbose(true)
+                .withSkipOverwrite(false)
+                .withSystemProperty("first", "1st")
+                .build();
+
+        WorkflowSettings modified = WorkflowSettings.newBuilder(original)
+                .withSystemProperty("second", "2nd")
+                .build();
+
+        Map<String, String> properties = modified.getSystemProperties();
+        assertEquals(properties.size(), 2, "System Properties map should allow mutation when invoked via copy constructor");
+        assertEquals(properties.getOrDefault("first", ""), "1st");
+        assertEquals(properties.getOrDefault("second", ""), "2nd");
     }
 
     private void assertOnChangesToDefaults(WorkflowSettings defaults) {

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/README.md
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/README.md
@@ -11,6 +11,7 @@ gradle openApiGenerate
 gradle openApiMeta
 gradle openApiValidate
 gradle buildGoSdk
+gradle buildDotnetSdk
 gradle generateGoWithInvalidSpec
 ```
 

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/build.gradle
@@ -65,6 +65,20 @@ task buildGoSdk(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTas
     ]
 }
 
+task buildDotnetSdk(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask){
+    generatorName = "csharp-netcore"
+    inputSpec = "$rootDir/petstore-v3.0.yaml".toString()
+    additionalProperties = [
+            packageGuid: "{321C8C3F-0156-40C1-AE42-D59761FB9B6C}",
+            useCompareNetObjects: "true"
+    ]
+    outputDir = "$buildDir/csharp-netcore".toString()
+    systemProperties = [
+            models: "",
+            apis  : "",
+    ]
+}
+
 task generateGoWithInvalidSpec(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask){
     validateSpec = true
     generatorName = "go"


### PR DESCRIPTION
When WorkflowSettings was constructed from an existing instance, as is
the case when we deserialize from an external configuration file, it
would result in an error:

```
Caused by: java.lang.UnsupportedOperationException
        at com.google.common.collect.ImmutableMap.put(ImmutableMap.java:450)
        at org.openapitools.codegen.config.WorkflowSettings$Builder.withSystemProperty(WorkflowSettings.java:465)
```

This was due to an error in `newBuilder(WorkflowSettings copy)` which
assigned builder.systemProperties with an immutable map. This is
incorrect because everything in the builder should be mutable until
.build() is invoked.

see #3815

I'm tagging with Gradle Plugin because this is where it was noticed. This likely affects CLI/Maven plugin as well for version 4.1.1 through 4.2.0.

cc @OpenAPITools/generator-core-team 

To test, build locally, then:

```bash
cd modules/openapi-generator-gradle-plugin
./gradlew publishToMavenLocal
cd samples/local-spec
gradle -PopenApiGeneratorVersion=4.2.1-SNAPSHOT buildDotnetSdk
```

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
