### PR TITLE
#4241, #4236 Add cutom Json serializer and proxy settings to config

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/ApiClient.mustache
@@ -248,7 +248,7 @@ namespace {{packageName}}.Client
             RestRequest request = new RestRequest(Method(method))
             {
                 Resource = path,
-                JsonSerializer = new CustomJsonCodec(configuration)
+                JsonSerializer = new CustomJsonCodec(configuration.SerializerSettings,configuration)
             };
 
             if (options.PathParameters != null)
@@ -380,7 +380,10 @@ namespace {{packageName}}.Client
 
         private {{#supportsAsync}}async Task<ApiResponse<T>>{{/supportsAsync}}{{^supportsAsync}}ApiResponse<T>{{/supportsAsync}} Exec<T>(RestRequest req, IReadableConfiguration configuration)
         {
-            RestClient client = new RestClient(_baseUrl);
+            RestClient client = new RestClient(_baseUrl)
+			{
+				Proxy = configuration.Proxy
+			};
 
             client.ClearHandlers();
             var existingDeserializer = req.JsonSerializer as IDeserializer;

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/Configuration.mustache
@@ -8,7 +8,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace {{packageName}}.Client
 {
@@ -223,6 +225,13 @@ namespace {{packageName}}.Client
         /// <value>The access token.</value>
         public virtual string AccessToken { get; set; }
 
+
+        /// <inheritdoc />
+        public JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings();
+
+        /// <inheritdoc />
+        public WebProxy Proxy { get; set; }
+
         /// <summary>
         /// Gets or sets the temporary folder path to store the files downloaded from the server.
         /// </summary>
@@ -408,7 +417,9 @@ namespace {{packageName}}.Client
                 Password = second.Password ?? first.Password,
                 AccessToken = second.AccessToken ?? first.AccessToken,
                 TempFolderPath = second.TempFolderPath ?? first.TempFolderPath,
-                DateTimeFormat = second.DateTimeFormat ?? first.DateTimeFormat
+                DateTimeFormat = second.DateTimeFormat ?? first.DateTimeFormat,
+				Proxy = second.Proxy ?? first.Proxy,
+                SerializerSettings = second.SerializerSettings ?? first.SerializerSettings
             };
             return config;
         }

--- a/modules/openapi-generator/src/main/resources/csharp-netcore/IReadableConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-netcore/IReadableConfiguration.mustache
@@ -2,6 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
+using Newtonsoft.Json;
 
 namespace {{packageName}}.Client
 {
@@ -89,5 +91,15 @@ namespace {{packageName}}.Client
         /// <param name="apiKeyIdentifier">API key identifier (authentication scheme).</param>
         /// <returns>API key with prefix.</returns>
         string GetApiKeyWithPrefix(string apiKeyIdentifier);
+		
+		/// <summary>
+		/// Gets the json serializer settings
+		/// </summary>
+		JsonSerializerSettings SerializerSettings { get; }
+		
+		/// <summary>
+		/// Gets the proxy
+		/// </summary>
+		WebProxy Proxy { get; }
     }
 }


### PR DESCRIPTION
**#4236 Add proxy settings to config**
This was needed because in net-core 2x its not possible to set a global proxy.

#4241 Add json serializer settings to config
This was needed to change the serializer settings. In my case i wanted to ignore null entries.


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
