### PR TITLE
[ci] Removes elm from ensure-up-to-date

### DIFF
--- a/bin/utils/ensure-up-to-date
+++ b/bin/utils/ensure-up-to-date
@@ -68,7 +68,7 @@ declare -a scripts=(
 "./bin/dart-petstore.sh"
 "./bin/dart2-petstore.sh"
 "./bin/java-play-framework-petstore-server-all.sh"
-"./bin/elm-petstore-all.sh"
+#"./bin/elm-petstore-all.sh"
 "./bin/meta-codegen.sh"
 # OTHERS
 "./bin/utils/export_docs_generators.sh"


### PR DESCRIPTION
bin/elm-petstore-all.sh invokes elm-petstore.sh and
elm-0.18-petstore.sh. Both of these define `ELM_POST_PROCESS_FILE` for
post-processing the generated files. If a user doesn't have elm-format
installed, they may not realize that ensure-up-to-date has failed which
causes CI to fail due to differences in the ELM generated outputs.

This confusion can lead to a lot of downtime for contributors. For
example, I encountered this while adding feature set information to all
generators. I thought I had introduced the error and spent too long
looking through my changeset and re-running `ensure-up-to-date`
in the background before noticing the failed output. I was able to
generate proper output by installing elm-format. With 80+ languages/frameworks
and a rule for contributors to unblock CI by re-generating any failed
samples, it's not feasible (in some cases, not possible) to ask
contributors to install tooling specific post-processors. We'll have to
rely on elm contributors to run the script manually.

Ideally, elm generator templates should be updated to have properly
formatted outputs as a default.

We may want to consider documenting standards of what we put in the
scripts under bin/*sh and bin/utils/ensure-up-to-date, one of those
standards being that we omit toolchain specific post-processors.

cc @OpenAPITools/generator-core-team 
cc @eriktim 

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
