### PR TITLE
[kotlin][client] improve nonpublic api

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiAbstractions.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/ApiAbstractions.kt.mustache
@@ -1,6 +1,6 @@
 package {{packageName}}.infrastructure
 
-typealias MultiValueMap = MutableMap<String,List<String>>
+{{#nonPublicApi}}internal {{/nonPublicApi}}typealias MultiValueMap = MutableMap<String,List<String>>
 
 {{#nonPublicApi}}internal {{/nonPublicApi}}fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/ApiAbstractions.kt
@@ -1,6 +1,6 @@
 package org.openapitools.client.infrastructure
 
-typealias MultiValueMap = MutableMap<String,List<String>>
+internal typealias MultiValueMap = MutableMap<String,List<String>>
 
 internal fun collectionDelimiter(collectionFormat: String) = when(collectionFormat) {
     "csv" -> ","


### PR DESCRIPTION
When using non public api, there is one typealias in ApiAbstractions that is still public.
This PR fixes that https://github.com/OpenAPITools/openapi-generator/issues/4477.

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10)
