### PR TITLE
[Java/Core] Adds properties to ComposedSchema models when they exist

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1787,6 +1787,17 @@ public class DefaultCodegen implements CodegenConfig {
             Map<String, Schema> allProperties = new LinkedHashMap<String, Schema>();
             List<String> allRequired = new ArrayList<String>();
 
+            // if schema has properties outside of allOf/oneOf/anyOf also add them to m
+            if (schema.getProperties() != null) {
+                addVars(m, unaliasPropertySchema(schema.getProperties()), schema.getRequired(), null, null);
+            }
+
+            // uncomment this when https://github.com/swagger-api/swagger-parser/issues/1252 is resolved
+            // if schema has additionalproperties outside of allOf/oneOf/anyOf also add it to m
+            // if (schema.getAdditionalProperties() != null) {
+            //     addAdditionPropertiesToCodeGenModel(m, schema);
+            // }
+
             // parent model
             final String parentName = ModelUtils.getParentName(composed, allDefinitions);
             final List<String> allParents = ModelUtils.getAllParentsName(composed, allDefinitions);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -269,6 +269,41 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testComposedSchemaOneOfWithProperties() {
+        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/oneOf.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+
+        final Schema schema = openAPI.getComponents().getSchemas().get("fruit");
+        codegen.setOpenAPI(openAPI);
+        CodegenModel fruit = codegen.fromModel("Fruit", schema);
+
+        Set<String> oneOf = new TreeSet<String>();
+        oneOf.add("Apple");
+        oneOf.add("Banana");
+        Assert.assertEquals(fruit.oneOf, oneOf);
+        Assert.assertEquals(fruit.optionalVars.size(), 3);
+        Assert.assertEquals(fruit.vars.size(), 3);
+        // make sure that fruit has the property color
+        boolean colorSeen = false;
+        for (CodegenProperty cp : fruit.vars) {
+            if (cp.name.equals("color")) {
+                colorSeen = true;
+                break;
+            }
+        }
+        Assert.assertTrue(colorSeen);
+        colorSeen = false;
+        for (CodegenProperty cp : fruit.optionalVars) {
+            if (cp.name.equals("color")) {
+                colorSeen = true;
+                break;
+            }
+        }
+        Assert.assertTrue(colorSeen);
+    }
+
+
+    @Test
     public void testEscapeText() {
         final DefaultCodegen codegen = new DefaultCodegen();
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -355,7 +355,6 @@ public class RubyClientCodegenTest {
         oneOf.add("Apple");
         oneOf.add("Banana");
         Assert.assertEquals(fruit.oneOf, oneOf);
-        // make sure that fruit has the property color
     }
 
     @Test(description = "test allOf (OAS3)")

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -355,6 +355,7 @@ public class RubyClientCodegenTest {
         oneOf.add("Apple");
         oneOf.add("Banana");
         Assert.assertEquals(fruit.oneOf, oneOf);
+        // make sure that fruit has the property color
     }
 
     @Test(description = "test allOf (OAS3)")

--- a/modules/openapi-generator/src/test/resources/3_0/oneOf.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/oneOf.yaml
@@ -22,6 +22,9 @@ components:
          oneOf:
             - $ref: '#/components/schemas/apple'
             - $ref: '#/components/schemas/banana'
+         # additionalProperties:
+         #    type: string
+         # uncomment this when https://github.com/swagger-api/swagger-parser/issues/1252 is resolved
       apple:
          title: apple
          type: object


### PR DESCRIPTION
This PR fixes this issue:
https://github.com/OpenAPITools/openapi-generator/issues/4515

Currently, when we process composedSchemas, we are not including any properties that are described in the `properties` section of that model's schema. An example is the below fruit model, which leaves out the color property when we ingest it and make a model.
```
openapi: 3.0.1
info:
   title: fruity
   version: 0.0.1
paths:
   /:
      get:
         responses:
            '200':
               description: desc
               content:
                  application/json:
                     schema:
                        $ref: '#/components/schemas/fruit'
components:
   schemas:
      fruit:
         title: fruit
         properties:
            color:
               type: string
         oneOf:
            - $ref: '#/components/schemas/apple'
            - $ref: '#/components/schemas/banana'
resolved
      apple:
         title: apple
         type: object
         properties:
            kind:
               type: string
      banana:
         title: banana
         type: object
         properties:
            count:
               type: number
```
This spec passes validation at: https://apitools.dev/swagger-parser/online/#

This PR fixes this issue, adding properties to the composed model.
We also add a test in DefaultCodegenTest.java where we check that the fruit model contains the color property.

This issue was also recently noticed and fixed in swagger-codegen at: https://github.com/swagger-api/swagger-codegen/pull/9827

Note: additional properties should also be allowed in composed schemas, but that feature is blocked by an upstream bug in swagger-parser. I've included a commented out additionalproperties property in the fruit spec, commented out code to process it in DefaultCodegen.java. Data in both locations links to the open swagger-parser issue which I created at: https://github.com/swagger-api/swagger-parser/issues/1252

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Java Technical Committee
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)

Core Team
@wing328 (2015/07) ❤️
@jimschubert (2016/05) ❤️
@cbornet (2016/05)
@ackintosh (2018/02) ❤️
@jmini (2018/04) ❤️
@etherealjoy (2019/06)
