### PR TITLE
[PHP] Support referenced enums

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -58,6 +58,7 @@ public class CodegenProperty implements Cloneable {
             isBoolean, isDate, isDateTime, isUuid, isUri, isEmail, isFreeFormObject;
     public boolean isListContainer, isMapContainer;
     public boolean isEnum;
+    public String referencedEnumType;
     public boolean isReadOnly;
     public boolean isWriteOnly;
     public boolean isNullable;
@@ -435,6 +436,7 @@ public class CodegenProperty implements Cloneable {
             hasMoreNonReadOnly,
             isContainer,
             isEnum,
+            referencedEnumType,
             isPrimitiveType,
             isModel,
             isReadOnly,
@@ -533,6 +535,7 @@ public class CodegenProperty implements Cloneable {
             Objects.equals(isModel, other.isModel) &&
             Objects.equals(isContainer, other.isContainer) &&
             Objects.equals(isEnum, other.isEnum) &&
+            Objects.equals(referencedEnumType, other.referencedEnumType) &&
             Objects.equals(isReadOnly, other.isReadOnly) &&
             Objects.equals(isWriteOnly, other.isWriteOnly) &&
             Objects.equals(isNullable, other.isNullable) &&
@@ -657,6 +660,7 @@ public class CodegenProperty implements Cloneable {
                 ", isListContainer=" + isListContainer +
                 ", isMapContainer=" + isMapContainer +
                 ", isEnum=" + isEnum +
+                ", referencedEnumType=" + referencedEnumType +
                 ", isReadOnly=" + isReadOnly +
                 ", isWriteOnly=" + isWriteOnly +
                 ", isNullable=" + isNullable +

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2233,19 +2233,23 @@ public class DefaultCodegen implements CodegenConfig {
 
         Schema referencedSchema = ModelUtils.getReferencedSchema(this.openAPI, p);
 
-        //Referenced enum case:
-        if (referencedSchema.getEnum() != null && !referencedSchema.getEnum().isEmpty()) {
-            List<Object> _enum = referencedSchema.getEnum();
+        if (referencedSchema != p) {
+            //Referenced enum case:
+            if (referencedSchema.getEnum() != null && !referencedSchema.getEnum().isEmpty()) {
+                List<Object> _enum = referencedSchema.getEnum();
 
-            Map<String, Object> allowableValues = new HashMap<String, Object>();
-            allowableValues.put("values", _enum);
-            if (allowableValues.size() > 0) {
-                property.allowableValues = allowableValues;
+                property.referencedEnumType = getTypeDeclaration(referencedSchema);
+
+                Map<String, Object> allowableValues = new HashMap<String, Object>();
+                allowableValues.put("values", _enum);
+                if (allowableValues.size() > 0) {
+                    property.allowableValues = allowableValues;
+                }
             }
-        }
 
-        if (referencedSchema.getNullable() != null) {
-            property.isNullable = referencedSchema.getNullable();
+            if (referencedSchema.getNullable() != null) {
+                property.isNullable = referencedSchema.getNullable();
+            }
         }
 
         property.dataType = getTypeDeclaration(p);

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -15,7 +15,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
       * @var string[]
       */
     protected static $openAPITypes = [
-        {{#vars}}'{{name}}' => '{{{dataType}}}'{{#hasMore}},
+        {{#vars}}'{{name}}' => '{{#referencedEnumType}}{{{referencedEnumType}}}{{/referencedEnumType}}{{^referencedEnumType}}{{{dataType}}}{{/referencedEnumType}}'{{#hasMore}},
         {{/hasMore}}{{/vars}}
     ];
 
@@ -202,6 +202,16 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
 
         {{/isContainer}}
         {{/isEnum}}
+        {{#referencedEnumType}}
+            ${{name}}AllowedValues = {{{dataType}}}::getAllowableEnumValues();
+            if (!is_null($this->container['{{name}}']) && !in_array($this->container['{{name}}'], ${{name}}AllowedValues}}, true)) {
+                $invalidProperties[] = sprintf(
+                    "invalid value for '{{name}}', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                );
+            }
+
+        {{/referencedEnumType}}
         {{#hasValidation}}
         {{#maxLength}}
         if ({{^required}}!is_null($this->container['{{name}}']) && {{/required}}(mb_strlen($this->container['{{name}}']) > {{maxLength}})) {
@@ -276,7 +286,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
     /**
      * Sets {{name}}
      *
-     * @param {{dataType}}{{^required}}|null{{/required}} ${{name}}{{#description}} {{{description}}}{{/description}}{{^description}} {{{name}}}{{/description}}
+     * @param {{#referencedEnumType}}{{referencedEnumType}}{{/referencedEnumType}}{{^referencedEnumType}}{{dataType}}{{/referencedEnumType}}{{^required}}|null{{/required}} ${{name}}{{#description}} {{{description}}}{{/description}}{{^description}} {{{name}}}{{/description}}
      *
      * @return $this
      */
@@ -305,6 +315,17 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}{{^pa
         }
         {{/isContainer}}
         {{/isEnum}}
+        {{#referencedEnumType}}
+        $allowedValues = ${{{dataType}}}::getAllowableEnumValues();
+        if ({{^required}}!is_null(${{name}}) && {{/required}}!in_array(${{{name}}}, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for '{{name}}', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        {{/referencedEnumType}}
         {{#hasValidation}}
         {{#maxLength}}
         if ({{^required}}!is_null(${{name}}) && {{/required}}(mb_strlen(${{name}}) > {{maxLength}})) {

--- a/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/openapi3/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -61,10 +61,10 @@ class EnumTest implements ModelInterface, ArrayAccess
         'enum_string_required' => 'string',
         'enum_integer' => 'int',
         'enum_number' => 'double',
-        'outer_enum' => '\OpenAPI\Client\Model\OuterEnum',
-        'outer_enum_integer' => '\OpenAPI\Client\Model\OuterEnumInteger',
-        'outer_enum_default_value' => '\OpenAPI\Client\Model\OuterEnumDefaultValue',
-        'outer_enum_integer_default_value' => '\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue'
+        'outer_enum' => 'string',
+        'outer_enum_integer' => 'int',
+        'outer_enum_default_value' => 'string',
+        'outer_enum_integer_default_value' => 'int'
     ];
 
     /**
@@ -330,6 +330,38 @@ class EnumTest implements ModelInterface, ArrayAccess
             );
         }
 
+            $outer_enumAllowedValues = \OpenAPI\Client\Model\OuterEnum::getAllowableEnumValues();
+            if (!is_null($this->container['outer_enum']) && !in_array($this->container['outer_enum'], $outer_enumAllowedValues}}, true)) {
+                $invalidProperties[] = sprintf(
+                    "invalid value for 'outer_enum', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                );
+            }
+
+            $outer_enum_integerAllowedValues = \OpenAPI\Client\Model\OuterEnumInteger::getAllowableEnumValues();
+            if (!is_null($this->container['outer_enum_integer']) && !in_array($this->container['outer_enum_integer'], $outer_enum_integerAllowedValues}}, true)) {
+                $invalidProperties[] = sprintf(
+                    "invalid value for 'outer_enum_integer', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                );
+            }
+
+            $outer_enum_default_valueAllowedValues = \OpenAPI\Client\Model\OuterEnumDefaultValue::getAllowableEnumValues();
+            if (!is_null($this->container['outer_enum_default_value']) && !in_array($this->container['outer_enum_default_value'], $outer_enum_default_valueAllowedValues}}, true)) {
+                $invalidProperties[] = sprintf(
+                    "invalid value for 'outer_enum_default_value', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                );
+            }
+
+            $outer_enum_integer_default_valueAllowedValues = \OpenAPI\Client\Model\OuterEnumIntegerDefaultValue::getAllowableEnumValues();
+            if (!is_null($this->container['outer_enum_integer_default_value']) && !in_array($this->container['outer_enum_integer_default_value'], $outer_enum_integer_default_valueAllowedValues}}, true)) {
+                $invalidProperties[] = sprintf(
+                    "invalid value for 'outer_enum_integer_default_value', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                );
+            }
+
         return $invalidProperties;
     }
 
@@ -490,12 +522,21 @@ class EnumTest implements ModelInterface, ArrayAccess
     /**
      * Sets outer_enum
      *
-     * @param \OpenAPI\Client\Model\OuterEnum|null $outer_enum outer_enum
+     * @param string|null $outer_enum outer_enum
      *
      * @return $this
      */
     public function setOuterEnum($outer_enum)
     {
+        $allowedValues = $\OpenAPI\Client\Model\OuterEnum::getAllowableEnumValues();
+        if (!is_null($outer_enum) && !in_array($outer_enum, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'outer_enum', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
         $this->container['outer_enum'] = $outer_enum;
 
         return $this;
@@ -514,12 +555,21 @@ class EnumTest implements ModelInterface, ArrayAccess
     /**
      * Sets outer_enum_integer
      *
-     * @param \OpenAPI\Client\Model\OuterEnumInteger|null $outer_enum_integer outer_enum_integer
+     * @param int|null $outer_enum_integer outer_enum_integer
      *
      * @return $this
      */
     public function setOuterEnumInteger($outer_enum_integer)
     {
+        $allowedValues = $\OpenAPI\Client\Model\OuterEnumInteger::getAllowableEnumValues();
+        if (!is_null($outer_enum_integer) && !in_array($outer_enum_integer, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'outer_enum_integer', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
         $this->container['outer_enum_integer'] = $outer_enum_integer;
 
         return $this;
@@ -538,12 +588,21 @@ class EnumTest implements ModelInterface, ArrayAccess
     /**
      * Sets outer_enum_default_value
      *
-     * @param \OpenAPI\Client\Model\OuterEnumDefaultValue|null $outer_enum_default_value outer_enum_default_value
+     * @param string|null $outer_enum_default_value outer_enum_default_value
      *
      * @return $this
      */
     public function setOuterEnumDefaultValue($outer_enum_default_value)
     {
+        $allowedValues = $\OpenAPI\Client\Model\OuterEnumDefaultValue::getAllowableEnumValues();
+        if (!is_null($outer_enum_default_value) && !in_array($outer_enum_default_value, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'outer_enum_default_value', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
         $this->container['outer_enum_default_value'] = $outer_enum_default_value;
 
         return $this;
@@ -562,12 +621,21 @@ class EnumTest implements ModelInterface, ArrayAccess
     /**
      * Sets outer_enum_integer_default_value
      *
-     * @param \OpenAPI\Client\Model\OuterEnumIntegerDefaultValue|null $outer_enum_integer_default_value outer_enum_integer_default_value
+     * @param int|null $outer_enum_integer_default_value outer_enum_integer_default_value
      *
      * @return $this
      */
     public function setOuterEnumIntegerDefaultValue($outer_enum_integer_default_value)
     {
+        $allowedValues = $\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue::getAllowableEnumValues();
+        if (!is_null($outer_enum_integer_default_value) && !in_array($outer_enum_integer_default_value, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value for 'outer_enum_integer_default_value', must be one of '%s'",
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
         $this->container['outer_enum_integer_default_value'] = $outer_enum_integer_default_value;
 
         return $this;


### PR DESCRIPTION
Resolves issue #4328 and allows reusing enums in definitions consumed by
PHP applications.

Without this change, referenced enums are unusable in PHP (and possibly
other languages which don't have native enums). This is because the
setter for such a property would expect an instnace of the external enum
class as the value, and that class has no state (and was therefore a
meaningless value).

On properties which reference enum schemas, we now set `referencedEnumType`
which contains the data type of the enum value. This allows languages
which don't have native enums to handle referenced enums correctly.

I adjusted the PHP model template to make use of this new variable, so
that it now generates very similar code for referenced enums as it does
for inline ones: the setter accepts a primitive type and validates the
value. The only difference is that the allowed values are stored in the
external enum class rather than inline on the model.