### PR TITLE
[PHP] Remove model prefix/suffix from inline enum var names

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -396,8 +396,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
         return toVarName(name);
     }
 
-    @Override
-    public String toModelName(String name) {
+    private String toGenericName(String name) {
         // remove [
         name = name.replaceAll("\\]", "");
 
@@ -418,6 +417,13 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
             LOGGER.warn(name + " (model name starts with number) cannot be used as model name. Renamed to " + camelize("model_" + name));
             name = "model_" + name; // e.g. 200Response => Model200Response (after camelize)
         }
+
+        return name;
+    }
+
+    @Override
+    public String toModelName(String name) {
+        name = toGenericName(name);
 
         // add prefix and/or suffic only if name does not start wth \ (e.g. \DateTime)
         if (!name.matches("^\\\\.*")) {
@@ -646,7 +652,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public String toEnumName(CodegenProperty property) {
-        String enumName = underscore(toModelName(property.name)).toUpperCase(Locale.ROOT);
+        String enumName = underscore(toGenericName(property.name)).toUpperCase(Locale.ROOT);
 
         // remove [] for array or map of enum
         enumName = enumName.replace("[]", "");


### PR DESCRIPTION
This resolves issue #4403.

On a model `Foo` with an inline enum `Bar` which has a possible string
value `baz`. we should generate a `FooDTO::BAR_BAZ` constant, not
`FooDTO::BAR_DTO_BAZ`.