### PR TITLE
[FIX][Haskell-servant] missing indent on the new feature pull request.

### DIFF
--- a/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
@@ -61,7 +61,7 @@ import           Servant.Client                     (ClientEnv, Scheme (Http), C
                                                      mkClientEnv, parseBaseUrl)
 import           Servant.Client.Core                (baseUrlPort, baseUrlHost)
 import           Servant.Client.Internal.HttpClient (ClientM (..))
-import           Servant.Server                     (Handler (..)){{#serveStatic}}
+import           Servant.Server                     (Handler (..), Application){{#serveStatic}}
 import           Servant.Server.StaticFiles         (serveDirectoryFileServer){{/serveStatic}}
 import           Web.FormUrlEncoded
 import           Web.HttpApiData

--- a/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
@@ -221,7 +221,7 @@ requestMiddlewareId a = a
 run{{title}}Server
   :: (MonadIO m, MonadThrow m)
   => Config -> {{title}}Backend (ExceptT ServerError IO) -> m ()
-run{{title}}MiddlewareServer config backend = run{{title}}MiddlewareServer config requestMiddlewareId backend
+run{{title}}Server config backend = run{{title}}MiddlewareServer config requestMiddlewareId backend
 
 -- | Run the {{title}} server at the provided host and port.
 run{{title}}MiddlewareServer

--- a/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
@@ -221,7 +221,7 @@ requestMiddlewareId a = a
 run{{title}}Server
   :: (MonadIO m, MonadThrow m)
   => Config -> {{title}}Backend (ExceptT ServerError IO) -> m ()
-  run{{title}}Server config backend = run{{title}}MiddlewareServer config requestMiddlewareId backend
+run{{title}}MiddlewareServer config backend = run{{title}}MiddlewareServer config requestMiddlewareId backend
 
 -- | Run the {{title}} server at the provided host and port.
 run{{title}}MiddlewareServer

--- a/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
+++ b/modules/openapi-generator/src/main/resources/haskell-servant/API.mustache
@@ -219,9 +219,9 @@ requestMiddlewareId a = a
 
 -- | Run the {{title}} server at the provided host and port.
 run{{title}}Server
-:: (MonadIO m, MonadThrow m)
-=> Config -> {{title}}Backend (ExceptT ServerError IO) -> m ()
-run{{title}}Server config backend = run{{title}}MiddlewareServer config requestMiddlewareId backend
+  :: (MonadIO m, MonadThrow m)
+  => Config -> {{title}}Backend (ExceptT ServerError IO) -> m ()
+  run{{title}}Server config backend = run{{title}}MiddlewareServer config requestMiddlewareId backend
 
 -- | Run the {{title}} server at the provided host and port.
 run{{title}}MiddlewareServer

--- a/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/API.hs
+++ b/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/API.hs
@@ -271,9 +271,9 @@ requestMiddlewareId a = a
 
 -- | Run the OpenAPIPetstore server at the provided host and port.
 runOpenAPIPetstoreServer
-:: (MonadIO m, MonadThrow m)
-=> Config -> OpenAPIPetstoreBackend (ExceptT ServerError IO) -> m ()
-runOpenAPIPetstoreServer config backend = runOpenAPIPetstoreMiddlewareServer config requestMiddlewareId backend
+  :: (MonadIO m, MonadThrow m)
+  => Config -> OpenAPIPetstoreBackend (ExceptT ServerError IO) -> m ()
+  runOpenAPIPetstoreServer config backend = runOpenAPIPetstoreMiddlewareServer config requestMiddlewareId backend
 
 -- | Run the OpenAPIPetstore server at the provided host and port.
 runOpenAPIPetstoreMiddlewareServer

--- a/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/API.hs
+++ b/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/API.hs
@@ -61,7 +61,7 @@ import           Servant.Client                     (ClientEnv, Scheme (Http), C
                                                      mkClientEnv, parseBaseUrl)
 import           Servant.Client.Core                (baseUrlPort, baseUrlHost)
 import           Servant.Client.Internal.HttpClient (ClientM (..))
-import           Servant.Server                     (Handler (..))
+import           Servant.Server                     (Handler (..), Application)
 import           Servant.Server.StaticFiles         (serveDirectoryFileServer)
 import           Web.FormUrlEncoded
 import           Web.HttpApiData

--- a/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/API.hs
+++ b/samples/server/petstore/haskell-servant/lib/OpenAPIPetstore/API.hs
@@ -273,7 +273,7 @@ requestMiddlewareId a = a
 runOpenAPIPetstoreServer
   :: (MonadIO m, MonadThrow m)
   => Config -> OpenAPIPetstoreBackend (ExceptT ServerError IO) -> m ()
-  runOpenAPIPetstoreServer config backend = runOpenAPIPetstoreMiddlewareServer config requestMiddlewareId backend
+runOpenAPIPetstoreServer config backend = runOpenAPIPetstoreMiddlewareServer config requestMiddlewareId backend
 
 -- | Run the OpenAPIPetstore server at the provided host and port.
 runOpenAPIPetstoreMiddlewareServer


### PR DESCRIPTION
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


I messed up the Pull-Request https://github.com/OpenAPITools/openapi-generator/pull/4056 
Here is the fix containing three indentations.
@jonschoning could you please apply this fix?