### PR TITLE
Typescript refactor: Platform select for browser and node

### DIFF
--- a/bin/typescript.sh
+++ b/bin/typescript.sh
@@ -28,10 +28,10 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 echo "Creating default (fetch) client!"
-ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript -o samples/client/petstore/typescript/builds/default $@"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript -o samples/client/petstore/typescript/builds/default --additional-properties=platform=node $@"
 
 java $JAVA_OPTS -jar $executable $ags
 echo "Creating jquery client!"
-ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml  -g typescript -o samples/client/petstore/typescript/builds/jquery --additional-properties=framework=jquery,fileContentDataType=Blob $@"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml  -g typescript -o samples/client/petstore/typescript/builds/jquery --additional-properties=framework=jquery $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/typescript.sh
+++ b/bin/typescript.sh
@@ -28,10 +28,10 @@ fi
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -XX:MaxPermSize=256M -Xmx1024M -DloggerPath=conf/log4j.properties"
 echo "Creating default (fetch) client!"
-ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript -o samples/client/petstore/typescript/builds/default --additional-properties=platform=node $@"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g typescript -o samples/client/petstore/typescript/builds/default --additional-properties=platform=node,npmName=ts-petstore-client $@"
 
 java $JAVA_OPTS -jar $executable $ags
 echo "Creating jquery client!"
-ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml  -g typescript -o samples/client/petstore/typescript/builds/jquery --additional-properties=framework=jquery $@"
+ags="generate -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml  -g typescript -o samples/client/petstore/typescript/builds/jquery --additional-properties=framework=jquery,npmName=ts-petstore-client $@"
 
 java $JAVA_OPTS -jar $executable $ags

--- a/bin/utils/ensure-up-to-date
+++ b/bin/utils/ensure-up-to-date
@@ -73,6 +73,7 @@ declare -a scripts=(
 "./bin/java-play-framework-petstore-server-all.sh"
 "./bin/elm-petstore-all.sh"
 "./bin/meta-codegen.sh"
+"./bin/typescript.sh"
 # OTHERS
 "./bin/utils/export_docs_generators.sh"
 "./bin/utils/copy-to-website.sh"

--- a/docs/generators/typescript.md
+++ b/docs/generators/typescript.md
@@ -13,4 +13,5 @@ sidebar_label: typescript
 |supportsES6|Generate code that conforms to ES6.| |false|
 |fileContentDataType|Specifies the type to use for the content of a file - i.e. Blob (Browser) / Buffer (node)| |Buffer|
 |useRxJS|Enable this to internally use rxjs observables. If disabled, a stub is used instead. This is required for the 'angular' framework.| |false|
+|platform|Specifies the platform the code should run on. The default is 'node' for the 'request' framework and 'browser' otherwise.| |null|
 |framework|Specify the framework which should be used in the client code.|<dl><dt>**fetch-api**</dt><dd>fetch-api</dd><dt>**jquery**</dt><dd>jquery</dd><dl>|fetch-api|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -707,12 +707,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
             setModelPropertyNaming((String) additionalProperties.get(CodegenConstants.MODEL_PROPERTY_NAMING));
         }
 
-        if (additionalProperties.containsKey(CodegenConstants.SUPPORTS_ES6)) {
-            // convert to boolean
-            additionalProperties.put(CodegenConstants.SUPPORTS_ES6,
-                Boolean.valueOf(additionalProperties.get(CodegenConstants.SUPPORTS_ES6).toString())
-            );
-        }
+        convertPropertyToBooleanAndWriteBack(CodegenConstants.SUPPORTS_ES6);
 
         // change package names
         apiPackage = this.apiPackage + ".apis";
@@ -745,12 +740,7 @@ public class TypeScriptClientCodegen extends DefaultCodegen implements CodegenCo
 
         additionalProperties.putIfAbsent(FILE_CONTENT_DATA_TYPE, propPlatform.equals("node") ? "Buffer" : "Blob");
 
-        boolean useRxJS = false;
-        if (additionalProperties.containsKey(USE_RXJS_SWITCH)) {
-            // convert to boolean
-            useRxJS = Boolean.valueOf(additionalProperties.get(USE_RXJS_SWITCH).toString());
-            additionalProperties.put(USE_RXJS_SWITCH, useRxJS);
-        }
+        final boolean useRxJS = convertPropertyToBooleanAndWriteBack(USE_RXJS_SWITCH);
         if (!useRxJS) {
           supportingFiles.add(new SupportingFile("rxjsStub.mustache", "", "rxjsStub.ts"));
         }

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -2,7 +2,11 @@
 import { BaseAPIRequestFactory, RequiredError } from './baseapi';
 import {Configuration} from '../configuration';
 import { RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
+{{#platforms}}
+{{#node}}
 import * as FormData from "form-data";
+{{/node}}
+{{/platforms}}
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {isCodeInRange} from '../util';

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -88,7 +88,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
              localVarFormParams.append('{{baseName}}', {{paramName}} as any);
              {{/isFile}}
              {{#isFile}}
-             localVarFormParams.append('{{baseName}}', {{paramName}}.data, { "filename": {{paramName}}.name });
+             localVarFormParams.append('{{baseName}}', {{paramName}}.data, {{paramName}}.name);
              {{/isFile}}  
         }
         {{/isListContainer}}

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -1,5 +1,9 @@
+{{#platforms}}
+{{#node}}
 // TODO: evaluate if we can easily get rid of this library
 import * as FormData from "form-data";
+{{/node}}
+{{/platforms}}
 // typings of url-parse are incorrect...
 // @ts-ignore 
 import * as URLParse from "url-parse";

--- a/modules/openapi-generator/src/main/resources/typescript/http/jquery.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/jquery.mustache
@@ -4,7 +4,6 @@ import { from, Observable } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../r
 e6p.polyfill();
 import * as $ from 'jquery';
 import * as FormData from "form-data";
-import { resolve } from 'dns';
 
 export class JQueryHttpLibrary implements HttpLibrary {
 

--- a/modules/openapi-generator/src/main/resources/typescript/http/jquery.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/jquery.mustache
@@ -3,7 +3,11 @@ import * as e6p from 'es6-promise'
 import { from, Observable } from {{#useRxJS}}'rxjs'{{/useRxJS}}{{^useRxJS}}'../rxjsStub'{{/useRxJS}};
 e6p.polyfill();
 import * as $ from 'jquery';
+{{#platforms}}
+{{#node}}
 import * as FormData from "form-data";
+{{/node}}
+{{/platforms}}
 
 export class JQueryHttpLibrary implements HttpLibrary {
 

--- a/modules/openapi-generator/src/main/resources/typescript/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/package.mustache
@@ -18,8 +18,6 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "es6-promise": "^4.2.4",
-    "@types/node": "*",
     {{#frameworks}}
     {{#fetch-api}}
     "isomorphic-fetch": "^2.2.1",
@@ -30,11 +28,17 @@
     "jquery": "^3.4.1",
     {{/jquery}}
     {{/frameworks}}
-    "btoa": "^1.2.1",
+    {{#platforms}}
+    {{#node}}
+    "@types/node": "*",
     "form-data": "^2.5.0",
+    {{/node}}
+    {{/platforms}}
     {{#useRxJS}}
       "rxjs": "^6.4.0",
     {{/useRxJS}}
+    "btoa": "^1.2.1",
+    "es6-promise": "^4.2.4",
     "url-parse": "^1.4.3"
   },
   "devDependencies": {

--- a/modules/openapi-generator/src/main/resources/typescript/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/package.mustache
@@ -1,5 +1,5 @@
 {
-  "name": "ts-petstore-client",
+  "name": "{{npmName}}",
   "version": "1.0.0",
   "description": "OpenAPI client for {{npmName}}",
   "author": "OpenAPI-Generator Contributors",
@@ -7,8 +7,7 @@
     "fetch",
     "typescript",
     "openapi-client",
-    "openapi-generator",
-    "{{npmName}}"
+    "openapi-generator"
   ],
   "license": "Unlicense",
   "main": "./dist/index.js",

--- a/samples/client/petstore/typescript/builds/default/.openapi-generator/VERSION
+++ b/samples/client/petstore/typescript/builds/default/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-unset
+4.2.0-SNAPSHOT

--- a/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -365,7 +365,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         }
         if (file !== undefined) {
         // TODO: replace .append with .set
-             localVarFormParams.append('file', file.data, { "filename": file.name });
+             localVarFormParams.append('file', file.data, file.name);
         }
 		requestContext.setBody(localVarFormParams);
 

--- a/samples/client/petstore/typescript/builds/default/package.json
+++ b/samples/client/petstore/typescript/builds/default/package.json
@@ -1,14 +1,13 @@
 {
   "name": "ts-petstore-client",
   "version": "1.0.0",
-  "description": "OpenAPI client for ",
+  "description": "OpenAPI client for ts-petstore-client",
   "author": "OpenAPI-Generator Contributors",
   "keywords": [
     "fetch",
     "typescript",
     "openapi-client",
-    "openapi-generator",
-    ""
+    "openapi-generator"
   ],
   "license": "Unlicense",
   "main": "./dist/index.js",

--- a/samples/client/petstore/typescript/builds/default/package.json
+++ b/samples/client/petstore/typescript/builds/default/package.json
@@ -18,12 +18,12 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "es6-promise": "^4.2.4",
-    "@types/node": "*",
     "isomorphic-fetch": "^2.2.1",
     "@types/isomorphic-fetch": "0.0.34",
-    "btoa": "^1.2.1",
+    "@types/node": "*",
     "form-data": "^2.5.0",
+    "btoa": "^1.2.1",
+    "es6-promise": "^4.2.4",
     "url-parse": "^1.4.3"
   },
   "devDependencies": {

--- a/samples/client/petstore/typescript/builds/jquery/.openapi-generator/VERSION
+++ b/samples/client/petstore/typescript/builds/jquery/.openapi-generator/VERSION
@@ -1,1 +1,1 @@
-unset
+4.2.0-SNAPSHOT

--- a/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -365,7 +365,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
         }
         if (file !== undefined) {
         // TODO: replace .append with .set
-             localVarFormParams.append('file', file.data, { "filename": file.name });
+             localVarFormParams.append('file', file.data, file.name);
         }
 		requestContext.setBody(localVarFormParams);
 

--- a/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -2,7 +2,6 @@
 import { BaseAPIRequestFactory, RequiredError } from './baseapi';
 import {Configuration} from '../configuration';
 import { RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {isCodeInRange} from '../util';

--- a/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/StoreApi.ts
@@ -2,7 +2,6 @@
 import { BaseAPIRequestFactory, RequiredError } from './baseapi';
 import {Configuration} from '../configuration';
 import { RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {isCodeInRange} from '../util';

--- a/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
+++ b/samples/client/petstore/typescript/builds/jquery/apis/UserApi.ts
@@ -2,7 +2,6 @@
 import { BaseAPIRequestFactory, RequiredError } from './baseapi';
 import {Configuration} from '../configuration';
 import { RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http';
-import * as FormData from "form-data";
 import {ObjectSerializer} from '../models/ObjectSerializer';
 import {ApiException} from './exception';
 import {isCodeInRange} from '../util';

--- a/samples/client/petstore/typescript/builds/jquery/http/http.ts
+++ b/samples/client/petstore/typescript/builds/jquery/http/http.ts
@@ -1,5 +1,3 @@
-// TODO: evaluate if we can easily get rid of this library
-import * as FormData from "form-data";
 // typings of url-parse are incorrect...
 // @ts-ignore 
 import * as URLParse from "url-parse";

--- a/samples/client/petstore/typescript/builds/jquery/http/jquery.ts
+++ b/samples/client/petstore/typescript/builds/jquery/http/jquery.ts
@@ -3,8 +3,6 @@ import * as e6p from 'es6-promise'
 import { from, Observable } from '../rxjsStub';
 e6p.polyfill();
 import * as $ from 'jquery';
-import * as FormData from "form-data";
-import { resolve } from 'dns';
 
 export class JQueryHttpLibrary implements HttpLibrary {
 

--- a/samples/client/petstore/typescript/builds/jquery/package-lock.json
+++ b/samples/client/petstore/typescript/builds/jquery/package-lock.json
@@ -12,71 +12,25 @@
         "@types/sizzle": "*"
       }
     },
-    "@types/node": {
-      "version": "12.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
-      "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w=="
-    },
     "@types/sizzle": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
       "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "btoa": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
       "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "es6-promise": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
       "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
     },
-    "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "jquery": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
-    },
-    "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
-    },
-    "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-      "requires": {
-        "mime-db": "1.40.0"
-      }
     },
     "querystringify": {
       "version": "2.1.1",

--- a/samples/client/petstore/typescript/builds/jquery/package.json
+++ b/samples/client/petstore/typescript/builds/jquery/package.json
@@ -18,12 +18,10 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "es6-promise": "^4.2.4",
-    "@types/node": "*",
     "@types/jquery": "^3.3.29",
     "jquery": "^3.4.1",
     "btoa": "^1.2.1",
-    "form-data": "^2.5.0",
+    "es6-promise": "^4.2.4",
     "url-parse": "^1.4.3"
   },
   "devDependencies": {

--- a/samples/client/petstore/typescript/builds/jquery/package.json
+++ b/samples/client/petstore/typescript/builds/jquery/package.json
@@ -1,14 +1,13 @@
 {
   "name": "ts-petstore-client",
   "version": "1.0.0",
-  "description": "OpenAPI client for ",
+  "description": "OpenAPI client for ts-petstore-client",
   "author": "OpenAPI-Generator Contributors",
   "keywords": [
     "fetch",
     "typescript",
     "openapi-client",
-    "openapi-generator",
-    ""
+    "openapi-generator"
   ],
   "license": "Unlicense",
   "main": "./dist/index.js",

--- a/samples/client/petstore/typescript/tests/jquery/package-lock.json
+++ b/samples/client/petstore/typescript/tests/jquery/package-lock.json
@@ -4679,10 +4679,8 @@
       "version": "file:../../builds/jquery",
       "requires": {
         "@types/jquery": "^3.3.29",
-        "@types/node": "*",
         "btoa": "^1.2.1",
         "es6-promise": "^4.2.4",
-        "form-data": "^2.5.0",
         "jquery": "^3.4.1",
         "url-parse": "^1.4.3"
       },

--- a/samples/client/petstore/typescript/tests/jquery/test/http/jquery.test.ts
+++ b/samples/client/petstore/typescript/tests/jquery/test/http/jquery.test.ts
@@ -2,8 +2,6 @@ declare var QUnit: any;
 
 import * as petstore from "ts-petstore-client";
 
-import * as FormData from "form-data";
-
 let libs: { [key: string]: petstore.http.HttpLibrary } = {
     "jquery": new petstore.http.JQueryHttpLibrary()
 }


### PR DESCRIPTION
This adds a new option to select the platform as node or browser.
When no platform is selected, a default is chosen by the framework option and likewise the file data type option is implied by the platform.

I did not have time to overhaul the tests, so I currently left the *default* sample build as node version and the *jquery* sample build as browser, as the latter uses proper e2e tests.

This PR assumes that my [previous PR](https://github.com/OpenAPITools/openapi-generator/pull/4424) is merged, so currently those commits are listed as well.

I also included some other minor improvements and fixes.

Cf. #802 
CC @TiFu 