### PR TITLE
Fix oneOf schema properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1899,6 +1899,13 @@ public class DefaultCodegen implements CodegenConfig {
             }
             addVars(m, unaliasPropertySchema(properties), required, unaliasPropertySchema(allProperties), allRequired);
 
+            // Composed Schema can have properties on its own
+            if (properties.isEmpty()) {
+                if (composed.getProperties() != null) {
+                    addVars(m, unaliasPropertySchema(composed.getProperties()), schema.getRequired(), null, null);
+                }
+            }
+
             // end of code block for composed schema
         } else {
             m.dataType = getSchemaType(schema);


### PR DESCRIPTION
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

fix #4515 

Given the following schema, `Area` should have two properties fields `tacs` and `areaCode`. The generated model `Area` shouldn't really care if they are defined as `oneOf`. It is up to the validation logic to validate that.

```yaml
    Area:
      type: object
      oneOf:
        - required:
          - tacs
        - required:
          - areaCode
      properties:
        tacs:
          type: array
          items:
            $ref: '#/components/schemas/Tac'
          minItems: 1
        areaCode:
            $ref: '#/components/schemas/AreaCode'
```


cc
@wing328
@jimschubert
@cbornet
@ackintosh
@jmini
@etherealjoy
