### PR TITLE
Use bin/cpp-qt5-petstore.json

### DIFF
--- a/bin/cpp-qt5-petstore.json
+++ b/bin/cpp-qt5-petstore.json
@@ -1,0 +1,8 @@
+{
+  "inputSpec": "modules/openapi-generator/src/test/resources/2_0/petstore.yaml",
+  "outputDir": "samples/client/petstore/cpp-qt5",
+  "additionalProperties": {
+    "cppNamespace": "test_namespace",
+    "modelNamePrefix": "PFX"
+  }
+}

--- a/bin/cpp-qt5-petstore.sh
+++ b/bin/cpp-qt5-petstore.sh
@@ -30,8 +30,7 @@ export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
 args="generate -t modules/openapi-generator/src/main/resources/cpp-qt5-client \
       -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml \
       -g cpp-qt5-client \
-       --additional-properties=cppNamespace=test_namespace \
-       --additional-properties=modelNamePrefix=PFX \
-       -o samples/client/petstore/cpp-qt5 $@"
+      -c cpp-qt5-petstore.json \
+      $@"
 
 java $JAVA_OPTS -jar $executable $args


### PR DESCRIPTION
This PR use the new ``--config`` option in the `bin/cpp-qt5-petstore.sh` script.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@ravinikam @stkrwork @etherealjoy @muttleyxd @jimschubert 