### PR TITLE
Add support for dumping request and response in Go generated clients

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -11,6 +11,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -161,7 +162,25 @@ func parameterToJson(obj interface{}) (string, error) {
 
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
-	return c.cfg.HTTPClient.Do(request)
+	if c.cfg.Debug {
+	        dump, err := httputil.DumpRequestOut(request, true)
+		if err != nil {
+		        return nil, err
+		}
+		fmt.Println(string(dump))
+	}
+
+	resp, err := c.cfg.HTTPClient.Do(request)
+
+	if c.cfg.Debug {
+		dump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return resp, err
+		}
+		fmt.Println(string(dump))
+	}
+
+	return resp, err
 }
 
 // ChangeBasePath changes base path to allow switching to mocks

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
@@ -167,7 +168,7 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		if err != nil {
 		        return nil, err
 		}
-		fmt.Println(string(dump))
+		log.Printf("\n%s\n", string(dump))
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)
@@ -177,7 +178,7 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		if err != nil {
 			return resp, err
 		}
-		fmt.Println(string(dump))
+		log.Printf("\n%s\n", string(dump))
 	}
 
 	return resp, err

--- a/modules/openapi-generator/src/main/resources/go/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/go/configuration.mustache
@@ -48,6 +48,7 @@ type Configuration struct {
 	Scheme        string            `json:"scheme,omitempty"`
 	DefaultHeader map[string]string `json:"defaultHeader,omitempty"`
 	UserAgent     string            `json:"userAgent,omitempty"`
+	Debug         bool              `json:"debug,omitempty"`
 	HTTPClient    *http.Client
 }
 
@@ -57,6 +58,7 @@ func NewConfiguration() *Configuration {
 		BasePath:      "{{{basePath}}}",
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{packageVersion}}}/go{{/httpUserAgent}}",
+		Debug:         false,
 	}
 	return cfg
 }

--- a/samples/client/petstore/go/go-petstore-withXml/client.go
+++ b/samples/client/petstore/go/go-petstore-withXml/client.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
@@ -179,7 +180,7 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		if err != nil {
 		        return nil, err
 		}
-		fmt.Println(string(dump))
+		log.Printf("\n%s\n", string(dump))
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)
@@ -189,7 +190,7 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		if err != nil {
 			return resp, err
 		}
-		fmt.Println(string(dump))
+		log.Printf("\n%s\n", string(dump))
 	}
 
 	return resp, err

--- a/samples/client/petstore/go/go-petstore-withXml/client.go
+++ b/samples/client/petstore/go/go-petstore-withXml/client.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -173,7 +174,25 @@ func parameterToJson(obj interface{}) (string, error) {
 
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
-	return c.cfg.HTTPClient.Do(request)
+	if c.cfg.Debug {
+	        dump, err := httputil.DumpRequestOut(request, true)
+		if err != nil {
+		        return nil, err
+		}
+		fmt.Println(string(dump))
+	}
+
+	resp, err := c.cfg.HTTPClient.Do(request)
+
+	if c.cfg.Debug {
+		dump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return resp, err
+		}
+		fmt.Println(string(dump))
+	}
+
+	return resp, err
 }
 
 // ChangeBasePath changes base path to allow switching to mocks

--- a/samples/client/petstore/go/go-petstore-withXml/configuration.go
+++ b/samples/client/petstore/go/go-petstore-withXml/configuration.go
@@ -57,6 +57,7 @@ type Configuration struct {
 	Scheme        string            `json:"scheme,omitempty"`
 	DefaultHeader map[string]string `json:"defaultHeader,omitempty"`
 	UserAgent     string            `json:"userAgent,omitempty"`
+	Debug         bool              `json:"debug,omitempty"`
 	HTTPClient    *http.Client
 }
 
@@ -66,6 +67,7 @@ func NewConfiguration() *Configuration {
 		BasePath:      "http://petstore.swagger.io:80/v2",
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "OpenAPI-Generator/1.0.0/go",
+		Debug:         false,
 	}
 	return cfg
 }

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"mime/multipart"
 	"net/http"
 	"net/http/httputil"
@@ -178,7 +179,7 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		if err != nil {
 		        return nil, err
 		}
-		fmt.Println(string(dump))
+		log.Printf("\n%s\n", string(dump))
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)
@@ -188,7 +189,7 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		if err != nil {
 			return resp, err
 		}
-		fmt.Println(string(dump))
+		log.Printf("\n%s\n", string(dump))
 	}
 
 	return resp, err

--- a/samples/client/petstore/go/go-petstore/client.go
+++ b/samples/client/petstore/go/go-petstore/client.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -172,7 +173,25 @@ func parameterToJson(obj interface{}) (string, error) {
 
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
-	return c.cfg.HTTPClient.Do(request)
+	if c.cfg.Debug {
+	        dump, err := httputil.DumpRequestOut(request, true)
+		if err != nil {
+		        return nil, err
+		}
+		fmt.Println(string(dump))
+	}
+
+	resp, err := c.cfg.HTTPClient.Do(request)
+
+	if c.cfg.Debug {
+		dump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return resp, err
+		}
+		fmt.Println(string(dump))
+	}
+
+	return resp, err
 }
 
 // ChangeBasePath changes base path to allow switching to mocks

--- a/samples/client/petstore/go/go-petstore/configuration.go
+++ b/samples/client/petstore/go/go-petstore/configuration.go
@@ -56,6 +56,7 @@ type Configuration struct {
 	Scheme        string            `json:"scheme,omitempty"`
 	DefaultHeader map[string]string `json:"defaultHeader,omitempty"`
 	UserAgent     string            `json:"userAgent,omitempty"`
+	Debug         bool              `json:"debug,omitempty"`
 	HTTPClient    *http.Client
 }
 
@@ -65,6 +66,7 @@ func NewConfiguration() *Configuration {
 		BasePath:      "http://petstore.swagger.io:80/v2",
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "OpenAPI-Generator/1.0.0/go",
+		Debug:         false,
 	}
 	return cfg
 }


### PR DESCRIPTION
The following change adds a new configuration setting, which
controls whether clients want to dump the HTTP request and response.

Useful when debugging API calls and clients.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
