### PR TITLE
[BUG][Python-Flask] controller parameter may not be sanitized

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFlaskConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFlaskConnexionServerCodegen.java
@@ -59,6 +59,6 @@ public class PythonFlaskConnexionServerCodegen extends PythonAbstractConnexionSe
     public String toParamName(String name) {
         // Connexion is broken and does not sanitize the parameter names.
         // Since Connexion does no sanitization we cannot do it here sadly.
-        return toVarName(name);
+        return name;
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFlaskConnexionServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFlaskConnexionServerCodegen.java
@@ -54,4 +54,11 @@ public class PythonFlaskConnexionServerCodegen extends PythonAbstractConnexionSe
         supportingFiles.add(new SupportingFile("__init__.mustache", packagePath(), "__init__.py"));
         testPackage = packageName + "." + testPackage;
     }
+
+    @Override
+    public String toParamName(String name) {
+        // Connexion is broken and does not sanitize the parameter names.
+        // Since Connexion does no sanitization we cannot do it here sadly.
+        return toVarName(name);
+    }
 }

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
@@ -137,6 +137,8 @@ class ApiClient {
           return client.delete(url, headers: headerParams);
         case "PATCH":
           return client.patch(url, headers: headerParams, body: msgBody);
+        case "HEAD":
+          return client.head(url, headers: headerParams);
         default:
           return client.get(url, headers: headerParams);
       }

--- a/samples/client/petstore/go-experimental/go-petstore/client.go
+++ b/samples/client/petstore/go-experimental/go-petstore/client.go
@@ -350,6 +350,9 @@ func (c *APIClient) prepareRequest(
 }
 
 func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err error) {
+	if len(b) == 0 {
+		return nil
+	}
 	if s, ok := v.(*string); ok {
 		*s = string(b)
 		return nil

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -353,6 +353,9 @@ func (c *APIClient) prepareRequest(
 }
 
 func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err error) {
+	if len(b) == 0 {
+		return nil
+	}
 	if s, ok := v.(*string); ok {
 		*s = string(b)
 		return nil


### PR DESCRIPTION
Parameters in python are written snake_case. If there is a get-parameter for a request which is in random-case it will be snake-cased. That does not work with connexion since it searches for a parameter which is not sanitized.

This bug exists since  2019-01-11 when the python generators got reworked and cleaned up.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@Jyhess 
