### PR TITLE
Use non-batch mode in ensure-up-to-date

### DIFF
--- a/CI/circle_parallel.sh
+++ b/CI/circle_parallel.sh
@@ -28,7 +28,7 @@ elif [ "$NODE_INDEX" = "2" ]; then
     git checkout -- .
 
     # look for outdated samples
-    ./bin/utils/ensure-up-to-date --batch
+    ./bin/utils/ensure-up-to-date
   fi
 #elif [ "$NODE_INDEX" = "3" ]; then
   echo "Running node $NODE_INDEX to test haskell"

--- a/samples/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
+++ b/samples/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
@@ -137,6 +137,8 @@ class ApiClient {
           return client.delete(url, headers: headerParams);
         case "PATCH":
           return client.patch(url, headers: headerParams, body: msgBody);
+        case "HEAD":
+          return client.head(url, headers: headerParams);
         default:
           return client.get(url, headers: headerParams);
       }

--- a/samples/client/petstore/go-experimental/go-petstore/client.go
+++ b/samples/client/petstore/go-experimental/go-petstore/client.go
@@ -350,6 +350,9 @@ func (c *APIClient) prepareRequest(
 }
 
 func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err error) {
+	if len(b) == 0 {
+		return nil
+	}
 	if s, ok := v.(*string); ok {
 		*s = string(b)
 		return nil

--- a/samples/openapi3/client/petstore/go/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/client.go
@@ -353,6 +353,9 @@ func (c *APIClient) prepareRequest(
 }
 
 func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err error) {
+	if len(b) == 0 {
+		return nil
+	}
 	if s, ok := v.(*string); ok {
 		*s = string(b)
 		return nil


### PR DESCRIPTION
Use non-batch mode in ensure-up-to-date as batch mode doesn't cover everything in the non-batch mode.

cc @jimschubert 

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
