### PR TITLE
Add nonDiscriminatorVars to CodegenModel and use it instead of vars…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -54,6 +54,7 @@ public class CodegenModel {
     public List<CodegenProperty> readOnlyVars = new ArrayList<CodegenProperty>(); // a list of read-only properties
     public List<CodegenProperty> readWriteVars = new ArrayList<CodegenProperty>(); // a list of properties for read, write
     public List<CodegenProperty> parentVars = new ArrayList<CodegenProperty>();
+    public List<CodegenProperty> nonDiscriminatorVars = new ArrayList<CodegenProperty>(); // properties other than the discriminator (without parent's properties)
     public Map<String, Object> allowableValues;
 
     // Sorted sets of required parameters.
@@ -61,7 +62,8 @@ public class CodegenModel {
     public Set<String> allMandatory = new TreeSet<String>(); // with parent's required properties
 
     public Set<String> imports = new TreeSet<String>();
-    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, isNullable, hasRequired, hasOptional, isArrayModel, hasChildren, isMapModel;
+    public boolean hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, isNullable, hasRequired, hasOptional,
+            isArrayModel, hasChildren, isMapModel, hasNonDiscriminatorVars;
     public boolean hasOnlyReadOnly = true; // true if all properties are read-only
     public ExternalDocumentation externalDocumentation;
 
@@ -582,6 +584,18 @@ public class CodegenModel {
                 }
             }
         }
+    }
+
+    /**
+     * Copy vars to nonDiscriminatorVars, except the discriminator
+     */
+    public void populateNonDiscriminatorVars() {
+        for (CodegenProperty var : vars) {
+            if (!var.name.equals(getDiscriminatorName())) {
+                nonDiscriminatorVars.add(var);
+            }
+        }
+        hasNonDiscriminatorVars = !nonDiscriminatorVars.isEmpty();
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1943,6 +1943,8 @@ public class DefaultCodegen implements CodegenConfig {
         // remove duplicated properties
         m.removeAllDuplicatedProperty();
 
+        m.populateNonDiscriminatorVars();
+
         // post process model properties
         if (m.vars != null) {
             for (CodegenProperty prop : m.vars) {

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -8,7 +8,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}
   private static final long serialVersionUID = 1L;
 
 {{/serializableModel}}
-  {{#vars}}
+  {{#nonDiscriminatorVars}}
     {{#isEnum}}
     {{^isContainer}}
 {{>enumClass}}
@@ -34,8 +34,8 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}
   private {{>nullableDataType}} {{name}}{{#isNullable}} = JsonNullable.undefined(){{/isNullable}}{{^isNullable}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/isNullable}};
   {{/isContainer}}
 
-  {{/vars}}
-  {{#vars}}
+  {{/nonDiscriminatorVars}}
+  {{#nonDiscriminatorVars}}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     this.{{name}} = {{#isNullable}}JsonNullable.of({{name}}){{/isNullable}}{{^isNullable}}{{name}}{{/isNullable}};
     return this;
@@ -92,7 +92,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}
     this.{{name}} = {{name}};
   }
 
-  {{/vars}}
+  {{/nonDiscriminatorVars}}
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -101,17 +101,17 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
-    }{{#hasVars}}
+    }{{#hasNonDiscriminatorVars}}
     {{classname}} {{classVarName}} = ({{classname}}) o;
-    return {{#vars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
-        {{/hasMore}}{{/vars}}{{#parent}} &&
-        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
-    return true;{{/hasVars}}
+    return {{#nonDiscriminatorVars}}Objects.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
+        {{/hasMore}}{{/nonDiscriminatorVars}}{{#parent}} &&
+        super.equals(o){{/parent}};{{/hasNonDiscriminatorVars}}{{^hasNonDiscriminatorVars}}
+    return true;{{/hasNonDiscriminatorVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
+    return Objects.hash({{#nonDiscriminatorVars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/nonDiscriminatorVars}}{{#parent}}{{#hasNonDiscriminatorVars}}, {{/hasNonDiscriminatorVars}}super.hashCode(){{/parent}});
   }
 
   @Override
@@ -119,8 +119,8 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}}{{^parent}}
     StringBuilder sb = new StringBuilder();
     sb.append("class {{classname}} {\n");
     {{#parent}}sb.append("    ").append(toIndentedString(super.toString())).append("\n");{{/parent}}
-    {{#vars}}sb.append("    {{name}}: ").append(toIndentedString({{name}})).append("\n");
-    {{/vars}}sb.append("}");
+    {{#nonDiscriminatorVars}}sb.append("    {{name}}: ").append(toIndentedString({{name}})).append("\n");
+    {{/nonDiscriminatorVars}}sb.append("}");
     return sb.toString();
   }
 

--- a/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/spring-mvc-j8-async/src/main/java/org/openapitools/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/spring-mvc-j8-localdatetime/src/main/java/org/openapitools/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/spring-mvc/src/main/java/org/openapitools/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Animal.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/Animal.java
@@ -22,32 +22,8 @@ import javax.validation.constraints.*;
 })
 
 public class Animal   {
-  @JsonProperty("className")
-  private String className;
-
   @JsonProperty("color")
   private String color = "red";
-
-  public Animal className(String className) {
-    this.className = className;
-    return this;
-  }
-
-  /**
-   * Get className
-   * @return className
-  */
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
-
-
-  public String getClassName() {
-    return className;
-  }
-
-  public void setClassName(String className) {
-    this.className = className;
-  }
 
   public Animal color(String color) {
     this.color = color;
@@ -79,13 +55,12 @@ public class Animal   {
       return false;
     }
     Animal animal = (Animal) o;
-    return Objects.equals(this.className, animal.className) &&
-        Objects.equals(this.color, animal.color);
+    return Objects.equals(this.color, animal.color);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(className, color);
+    return Objects.hash(color);
   }
 
   @Override
@@ -93,7 +68,6 @@ public class Animal   {
     StringBuilder sb = new StringBuilder();
     sb.append("class Animal {\n");
     
-    sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
     sb.append("}");
     return sb.toString();


### PR DESCRIPTION
…for JavaSpring. Fixes #3796

This may also be appropriate for other generators but I am only changing it for the JavaSpring template now. Ran bin/spring-all-petstore.sh and all the changes are expected.

### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)