### PR TITLE
[Python] conditionally set auth attributes

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -516,7 +516,8 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-
+        if self.configuration.security_schemes:
+            auth_settings = [value for value in auth_settings if value in self.configuration.security_schemes]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -516,11 +516,6 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-        if self.configuration.security_schemes:
-            auth_settings = [
-                value for value in auth_settings
-                if value in self.configuration.security_schemes
-            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -517,7 +517,10 @@ class ApiClient(object):
         if not auth_settings:
             return
         if self.configuration.security_schemes:
-            auth_settings = [value for value in auth_settings if value in self.configuration.security_schemes]
+            auth_settings = [
+                value for value in auth_settings
+                if value in self.configuration.security_schemes
+            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -519,9 +519,7 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if not auth_setting['value']:
-                    continue
-                elif auth_setting['in'] == 'cookie':
+                if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -23,10 +23,12 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the
-      OAS specification.
-      The dict value should be the value of the api key (i.e. the secret).
-    :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
+      Each entry in the dict specifies an API key. The dict key is the name
+      of the api key, as specified in the OAS specification.
+      The dict value is itself a dict that must have a 'value' entry.
+      The 'value' entry is required and specifies the api key secret.
+      The 'prefix' entry is optional and specifies an api key prefix when
+      generating the auth data.
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
@@ -43,15 +45,14 @@ class Configuration(object):
 
     You can programmatically set the cookie:
       conf = {{{packageName}}}.Configuration(
-        api_key={'JSESSIONID': 'abc123'}
-        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+        api_key={'JSESSIONID': {prefix='JSESSIONID=', value='abc123'}}
       )
     The following cookie will be added to the HTTP request:
        Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="{{{basePath}}}",
-                 api_key=None, api_key_prefix=None,
+                 api_key=None,
                  username=None, password=None,
                  access_token=None):
         """Constructor
@@ -67,11 +68,6 @@ class Configuration(object):
         if api_key:
             self.api_key = api_key
         """dict to store API key(s)
-        """
-        self.api_key_prefix = {}
-        if api_key_prefix:
-            self.api_key_prefix = api_key_prefix
-        """dict to store API prefix (e.g. Bearer)
         """
         self.refresh_api_key_hook = None
         """function hook to refresh API key if expired
@@ -248,11 +244,13 @@ class Configuration(object):
         """
         if self.refresh_api_key_hook is not None:
             self.refresh_api_key_hook(self)
-        key = self.api_key.get(identifier)
-        if key:
-            prefix = self.api_key_prefix.get(identifier)
-            if prefix:
-                return "%s%s" % (prefix, key)
+        key_entry = self.api_key.get(identifier)
+        if not isinstance(key_entry, dict):
+            raise Exception("The api_key attribute must be a dictionary")
+        if key_entry:
+            key = key_entry["value"]
+            if "prefix" in key_entry:
+                return "%s%s" % (key_entry["prefix"], key)
             else:
                 return key
 

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -22,11 +22,31 @@ class Configuration(object):
     Do not edit the class manually.
 
     :param host: Base url
-    :param api_key: Dict to store API key(s)
+    :param api_key: Dict to store API key(s).
+      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
+
+    :Example:
+
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          cookieAuth:         # name for the security scheme
+            type: apiKey
+            in: cookie
+            name: JSESSIONID  # cookie name
+
+    You can programmatically set the cookie:
+      conf = {{{packageName}}}.Configuration(
+        api_key={'JSESSIONID': 'abc123'}
+        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+      )
+    The following cookie will be added to the HTTP request:
+       Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="{{{basePath}}}",
@@ -231,7 +251,7 @@ class Configuration(object):
         if key:
             prefix = self.api_key_prefix.get(identifier)
             if prefix:
-                return "%s %s" % (prefix, key)
+                return "%s%s" % (prefix, key)
             else:
                 return key
 
@@ -258,7 +278,7 @@ class Configuration(object):
         auth = {}
 {{#authMethods}}
 {{#isApiKey}}
-        if self.api_key and '{{keyParamName}}' in self.api_key:
+        if '{{keyParamName}}' in self.api_key:
             auth['{{name}}'] = {
                 'type': 'api_key',
                 'in': {{#isKeyInCookie}}'cookie'{{/isKeyInCookie}}{{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{#isKeyInQuery}}'query'{{/isKeyInQuery}},

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -71,11 +71,6 @@ class Configuration(object):
         """
 {{/hasBearerMethods}}
 {{/hasOAuthMethods}}
-        self.security_schemes = None
-        """The security schemes to use when authenticating and authorizing the client.
-        While the OpenAPI specification may support multiple security schemes (e.g. OAuth2, basic),
-        the client may want to explicitly use a specific security scheme.
-        """
         self.logger = {}
         """Logging Settings
         """

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -30,7 +30,7 @@ class Configuration(object):
 
     def __init__(self, host="{{{basePath}}}",
                  api_key=None, api_key_prefix=None,
-                 username="", password=""):
+                 username=None, password=None):
         """Constructor
         """
         self.host = host
@@ -60,17 +60,22 @@ class Configuration(object):
         """Password for HTTP basic authentication
         """
 {{#hasOAuthMethods}}
-        self.access_token = ""
+        self.access_token = None
         """access token for OAuth/Bearer
         """
 {{/hasOAuthMethods}}
 {{^hasOAuthMethods}}
 {{#hasBearerMethods}}
-        self.access_token = ""
+        self.access_token = None
         """access token for OAuth/Bearer
         """
 {{/hasBearerMethods}}
 {{/hasOAuthMethods}}
+        self.security_schemes = None
+        """The security schemes to use when authenticating and authorizing the client.
+        While the OpenAPI specification may support multiple security schemes (e.g. OAuth2, basic),
+        the client may want to explicitly use a specific security scheme.
+        """
         self.logger = {}
         """Logging Settings
         """
@@ -256,51 +261,51 @@ class Configuration(object):
 
         :return: The Auth Settings information dict.
         """
-        return {
+        auth = {}
 {{#authMethods}}
 {{#isApiKey}}
-            '{{name}}':
-                {
-                    'type': 'api_key',
-                    'in': {{#isKeyInCookie}}'cookie'{{/isKeyInCookie}}{{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{#isKeyInQuery}}'query'{{/isKeyInQuery}},
-                    'key': '{{keyParamName}}',
-                    'value': self.get_api_key_with_prefix('{{keyParamName}}')
-                },
+        if self.api_key:
+            auth['{{name}}'] = {
+                'type': 'api_key',
+                'in': {{#isKeyInCookie}}'cookie'{{/isKeyInCookie}}{{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{#isKeyInQuery}}'query'{{/isKeyInQuery}},
+                'key': '{{keyParamName}}',
+                'value': self.get_api_key_with_prefix('{{keyParamName}}')
+            }
 {{/isApiKey}}
 {{#isBasic}}
   {{^isBasicBearer}}
-            '{{name}}':
-                {
-                    'type': 'basic',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': self.get_basic_auth_token()
-                },
+        if self.username and self.password:
+            auth['{{name}}'] = {
+                'type': 'basic',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': self.get_basic_auth_token()
+            }
   {{/isBasicBearer}}
   {{#isBasicBearer}}
-            '{{name}}':
-                {
-                    'type': 'bearer',
-                    'in': 'header',
-                    {{#bearerFormat}}
-                    'format': '{{{.}}}',
-                    {{/bearerFormat}}
-                    'key': 'Authorization',
-                    'value': 'Bearer ' + self.access_token
-                },
+        if self.access_token:
+            auth['{{name}}'] = {
+                'type': 'bearer',
+                'in': 'header',
+                {{#bearerFormat}}
+                'format': '{{{.}}}',
+                {{/bearerFormat}}
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
+            }
   {{/isBasicBearer}}
 {{/isBasic}}
 {{#isOAuth}}
-            '{{name}}':
-                {
-                    'type': 'oauth2',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': 'Bearer ' + self.access_token
-                },
+        if self.access_token:
+            auth['{{name}}'] = {
+                'type': 'oauth2',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
+            }
 {{/isOAuth}}
 {{/authMethods}}
-        }
+        return auth
 
     def to_debug_report(self):
         """Gets the essential information for debugging.

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -259,7 +259,7 @@ class Configuration(object):
         auth = {}
 {{#authMethods}}
 {{#isApiKey}}
-        if self.api_key:
+        if self.api_key and '{{keyParamName}}' in self.api_key:
             auth['{{name}}'] = {
                 'type': 'api_key',
                 'in': {{#isKeyInCookie}}'cookie'{{/isKeyInCookie}}{{#isKeyInHeader}}'header'{{/isKeyInHeader}}{{#isKeyInQuery}}'query'{{/isKeyInQuery}},

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -26,11 +26,13 @@ class Configuration(object):
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
+    :param access_token: The OAuth2 access token
     """
 
     def __init__(self, host="{{{basePath}}}",
                  api_key=None, api_key_prefix=None,
-                 username=None, password=None):
+                 username=None, password=None,
+                 access_token=None):
         """Constructor
         """
         self.host = host
@@ -59,18 +61,9 @@ class Configuration(object):
         self.password = password
         """Password for HTTP basic authentication
         """
-{{#hasOAuthMethods}}
-        self.access_token = None
+        self.access_token = access_token
         """access token for OAuth/Bearer
         """
-{{/hasOAuthMethods}}
-{{^hasOAuthMethods}}
-{{#hasBearerMethods}}
-        self.access_token = None
-        """access token for OAuth/Bearer
-        """
-{{/hasBearerMethods}}
-{{/hasOAuthMethods}}
         self.logger = {}
         """Logging Settings
         """
@@ -269,7 +262,7 @@ class Configuration(object):
 {{/isApiKey}}
 {{#isBasic}}
   {{^isBasicBearer}}
-        if self.username and self.password:
+        if self.username is not None and self.password is not None:
             auth['{{name}}'] = {
                 'type': 'basic',
                 'in': 'header',
@@ -278,7 +271,7 @@ class Configuration(object):
             }
   {{/isBasicBearer}}
   {{#isBasicBearer}}
-        if self.access_token:
+        if self.access_token is not None:
             auth['{{name}}'] = {
                 'type': 'bearer',
                 'in': 'header',
@@ -291,7 +284,7 @@ class Configuration(object):
   {{/isBasicBearer}}
 {{/isBasic}}
 {{#isOAuth}}
-        if self.access_token:
+        if self.access_token is not None:
             auth['{{name}}'] = {
                 'type': 'oauth2',
                 'in': 'header',

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -240,8 +240,14 @@ class Configuration(object):
 
         :return: The token for basic HTTP authentication.
         """
+        username = ""
+        if self.username is not None:
+            username = self.username
+        password = ""
+        if self.password is not None:
+            password = self.password
         return urllib3.util.make_headers(
-            basic_auth=self.username + ':' + self.password
+            basic_auth=username + ':' + password
         ).get('authorization')
 
     def auth_settings(self):

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -23,7 +23,8 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict key should be the name of the api key, as specified in the
+      OAS specification.
       The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
@@ -529,9 +529,7 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if not auth_setting['value']:
-                    continue
-                elif auth_setting['in'] == 'cookie':
+                if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
@@ -526,11 +526,6 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-        if self.configuration.security_schemes:
-            auth_settings = [
-                value for value in auth_settings
-                if value in self.configuration.security_schemes
-            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
@@ -526,7 +526,8 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-
+        if self.configuration.security_schemes:
+            auth_settings = [value for value in auth_settings if value in self.configuration.security_schemes]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/python-experimental/api_client.mustache
@@ -527,7 +527,10 @@ class ApiClient(object):
         if not auth_settings:
             return
         if self.configuration.security_schemes:
-            auth_settings = [value for value in auth_settings if value in self.configuration.security_schemes]
+            auth_settings = [
+                value for value in auth_settings
+                if value in self.configuration.security_schemes
+            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -509,7 +509,11 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-
+        if self.configuration.security_schemes:
+            auth_settings = [
+                value for value in auth_settings
+                if value in self.configuration.security_schemes
+            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -512,9 +512,7 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if not auth_setting['value']:
-                    continue
-                elif auth_setting['in'] == 'cookie':
+                if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']

--- a/samples/client/petstore/python-asyncio/petstore_api/api_client.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/api_client.py
@@ -509,11 +509,6 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-        if self.configuration.security_schemes:
-            auth_settings = [
-                value for value in auth_settings
-                if value in self.configuration.security_schemes
-            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -242,14 +242,14 @@ class Configuration(object):
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if self.api_key:
+        if self.api_key and 'api_key' in self.api_key:
             auth['api_key'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'api_key',
                 'value': self.get_api_key_with_prefix('api_key')
             }
-        if self.api_key:
+        if self.api_key and 'api_key_query' in self.api_key:
             auth['api_key_query'] = {
                 'type': 'api_key',
                 'in': 'query',

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -31,11 +31,13 @@ class Configuration(object):
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
+    :param access_token: The OAuth2 access token
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
-                 username=None, password=None):
+                 username=None, password=None,
+                 access_token=None):
         """Constructor
         """
         self.host = host
@@ -64,7 +66,7 @@ class Configuration(object):
         self.password = password
         """Password for HTTP basic authentication
         """
-        self.access_token = None
+        self.access_token = access_token
         """access token for OAuth/Bearer
         """
         self.logger = {}
@@ -256,14 +258,14 @@ class Configuration(object):
                 'key': 'api_key_query',
                 'value': self.get_api_key_with_prefix('api_key_query')
             }
-        if self.username and self.password:
+        if self.username is not None and self.password is not None:
             auth['http_basic_test'] = {
                 'type': 'basic',
                 'in': 'header',
                 'key': 'Authorization',
                 'value': self.get_basic_auth_token()
             }
-        if self.access_token:
+        if self.access_token is not None:
             auth['petstore_auth'] = {
                 'type': 'oauth2',
                 'in': 'header',

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -67,11 +67,6 @@ class Configuration(object):
         self.access_token = None
         """access token for OAuth/Bearer
         """
-        self.security_schemes = None
-        """The security schemes to use when authenticating and authorizing the client.
-        While the OpenAPI specification may support multiple security schemes (e.g. OAuth2, basic),
-        the client may want to explicitly use a specific security scheme.
-        """
         self.logger = {}
         """Logging Settings
         """

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -234,8 +234,14 @@ class Configuration(object):
 
         :return: The token for basic HTTP authentication.
         """
+        username = ""
+        if self.username is not None:
+            username = self.username
+        password = ""
+        if self.password is not None:
+            password = self.password
         return urllib3.util.make_headers(
-            basic_auth=self.username + ':' + self.password
+            basic_auth=username + ':' + password
         ).get('authorization')
 
     def auth_settings(self):

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -35,7 +35,7 @@ class Configuration(object):
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
-                 username="", password=""):
+                 username=None, password=None):
         """Constructor
         """
         self.host = host
@@ -64,8 +64,13 @@ class Configuration(object):
         self.password = password
         """Password for HTTP basic authentication
         """
-        self.access_token = ""
+        self.access_token = None
         """access token for OAuth/Bearer
+        """
+        self.security_schemes = None
+        """The security schemes to use when authenticating and authorizing the client.
+        While the OpenAPI specification may support multiple security schemes (e.g. OAuth2, basic),
+        the client may want to explicitly use a specific security scheme.
         """
         self.logger = {}
         """Logging Settings
@@ -241,36 +246,36 @@ class Configuration(object):
 
         :return: The Auth Settings information dict.
         """
-        return {
-            'api_key':
-                {
-                    'type': 'api_key',
-                    'in': 'header',
-                    'key': 'api_key',
-                    'value': self.get_api_key_with_prefix('api_key')
-                },
-            'api_key_query':
-                {
-                    'type': 'api_key',
-                    'in': 'query',
-                    'key': 'api_key_query',
-                    'value': self.get_api_key_with_prefix('api_key_query')
-                },
-            'http_basic_test':
-                {
-                    'type': 'basic',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': self.get_basic_auth_token()
-                },
-            'petstore_auth':
-                {
-                    'type': 'oauth2',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': 'Bearer ' + self.access_token
-                },
-        }
+        auth = {}
+        if self.api_key:
+            auth['api_key'] = {
+                'type': 'api_key',
+                'in': 'header',
+                'key': 'api_key',
+                'value': self.get_api_key_with_prefix('api_key')
+            }
+        if self.api_key:
+            auth['api_key_query'] = {
+                'type': 'api_key',
+                'in': 'query',
+                'key': 'api_key_query',
+                'value': self.get_api_key_with_prefix('api_key_query')
+            }
+        if self.username and self.password:
+            auth['http_basic_test'] = {
+                'type': 'basic',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': self.get_basic_auth_token()
+            }
+        if self.access_token:
+            auth['petstore_auth'] = {
+                'type': 'oauth2',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
+            }
+        return auth
 
     def to_debug_report(self):
         """Gets the essential information for debugging.

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -27,11 +27,31 @@ class Configuration(object):
     Do not edit the class manually.
 
     :param host: Base url
-    :param api_key: Dict to store API key(s)
+    :param api_key: Dict to store API key(s).
+      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
+
+    :Example:
+
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          cookieAuth:         # name for the security scheme
+            type: apiKey
+            in: cookie
+            name: JSESSIONID  # cookie name
+
+    You can programmatically set the cookie:
+      conf = petstore_api.Configuration(
+        api_key={'JSESSIONID': 'abc123'}
+        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+      )
+    The following cookie will be added to the HTTP request:
+       Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
@@ -225,7 +245,7 @@ class Configuration(object):
         if key:
             prefix = self.api_key_prefix.get(identifier)
             if prefix:
-                return "%s %s" % (prefix, key)
+                return "%s%s" % (prefix, key)
             else:
                 return key
 
@@ -250,14 +270,14 @@ class Configuration(object):
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if self.api_key and 'api_key' in self.api_key:
+        if 'api_key' in self.api_key:
             auth['api_key'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'api_key',
                 'value': self.get_api_key_with_prefix('api_key')
             }
-        if self.api_key and 'api_key_query' in self.api_key:
+        if 'api_key_query' in self.api_key:
             auth['api_key_query'] = {
                 'type': 'api_key',
                 'in': 'query',

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -28,10 +28,12 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the
-      OAS specification.
-      The dict value should be the value of the api key (i.e. the secret).
-    :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
+      Each entry in the dict specifies an API key. The dict key is the name
+      of the api key, as specified in the OAS specification.
+      The dict value is itself a dict that must have a 'value' entry.
+      The 'value' entry is required and specifies the api key secret.
+      The 'prefix' entry is optional and specifies an api key prefix when
+      generating the auth data.
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
@@ -48,15 +50,14 @@ class Configuration(object):
 
     You can programmatically set the cookie:
       conf = petstore_api.Configuration(
-        api_key={'JSESSIONID': 'abc123'}
-        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+        api_key={'JSESSIONID': {prefix='JSESSIONID=', value='abc123'}}
       )
     The following cookie will be added to the HTTP request:
        Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
-                 api_key=None, api_key_prefix=None,
+                 api_key=None,
                  username=None, password=None,
                  access_token=None):
         """Constructor
@@ -72,11 +73,6 @@ class Configuration(object):
         if api_key:
             self.api_key = api_key
         """dict to store API key(s)
-        """
-        self.api_key_prefix = {}
-        if api_key_prefix:
-            self.api_key_prefix = api_key_prefix
-        """dict to store API prefix (e.g. Bearer)
         """
         self.refresh_api_key_hook = None
         """function hook to refresh API key if expired
@@ -242,11 +238,13 @@ class Configuration(object):
         """
         if self.refresh_api_key_hook is not None:
             self.refresh_api_key_hook(self)
-        key = self.api_key.get(identifier)
-        if key:
-            prefix = self.api_key_prefix.get(identifier)
-            if prefix:
-                return "%s%s" % (prefix, key)
+        key_entry = self.api_key.get(identifier)
+        if not isinstance(key_entry, dict):
+            raise Exception("The api_key attribute must be a dictionary")
+        if key_entry:
+            key = key_entry["value"]
+            if "prefix" in key_entry:
+                return "%s%s" % (key_entry["prefix"], key)
             else:
                 return key
 

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -28,7 +28,8 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict key should be the name of the api key, as specified in the
+      OAS specification.
       The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication

--- a/samples/client/petstore/python-experimental/petstore_api/api_client.py
+++ b/samples/client/petstore/python-experimental/petstore_api/api_client.py
@@ -519,7 +519,8 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-
+        if self.configuration.security_schemes:
+            auth_settings = [value for value in auth_settings if value in self.configuration.security_schemes]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/samples/client/petstore/python-experimental/petstore_api/api_client.py
+++ b/samples/client/petstore/python-experimental/petstore_api/api_client.py
@@ -522,9 +522,7 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if not auth_setting['value']:
-                    continue
-                elif auth_setting['in'] == 'cookie':
+                if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']

--- a/samples/client/petstore/python-experimental/petstore_api/api_client.py
+++ b/samples/client/petstore/python-experimental/petstore_api/api_client.py
@@ -520,7 +520,10 @@ class ApiClient(object):
         if not auth_settings:
             return
         if self.configuration.security_schemes:
-            auth_settings = [value for value in auth_settings if value in self.configuration.security_schemes]
+            auth_settings = [
+                value for value in auth_settings
+                if value in self.configuration.security_schemes
+            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/samples/client/petstore/python-experimental/petstore_api/api_client.py
+++ b/samples/client/petstore/python-experimental/petstore_api/api_client.py
@@ -519,11 +519,6 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-        if self.configuration.security_schemes:
-            auth_settings = [
-                value for value in auth_settings
-                if value in self.configuration.security_schemes
-            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -32,11 +32,13 @@ class Configuration(object):
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
+    :param access_token: The OAuth2 access token
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
-                 username=None, password=None):
+                 username=None, password=None,
+                 access_token=None):
         """Constructor
         """
         self.host = host
@@ -65,7 +67,7 @@ class Configuration(object):
         self.password = password
         """Password for HTTP basic authentication
         """
-        self.access_token = None
+        self.access_token = access_token
         """access token for OAuth/Bearer
         """
         self.logger = {}
@@ -260,14 +262,14 @@ class Configuration(object):
                 'key': 'api_key_query',
                 'value': self.get_api_key_with_prefix('api_key_query')
             }
-        if self.username and self.password:
+        if self.username is not None and self.password is not None:
             auth['http_basic_test'] = {
                 'type': 'basic',
                 'in': 'header',
                 'key': 'Authorization',
                 'value': self.get_basic_auth_token()
             }
-        if self.access_token:
+        if self.access_token is not None:
             auth['petstore_auth'] = {
                 'type': 'oauth2',
                 'in': 'header',

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -29,7 +29,8 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict key should be the name of the api key, as specified in the
+      OAS specification.
       The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -36,7 +36,7 @@ class Configuration(object):
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
-                 username="", password=""):
+                 username=None, password=None):
         """Constructor
         """
         self.host = host
@@ -65,8 +65,13 @@ class Configuration(object):
         self.password = password
         """Password for HTTP basic authentication
         """
-        self.access_token = ""
+        self.access_token = None
         """access token for OAuth/Bearer
+        """
+        self.security_schemes = None
+        """The security schemes to use when authenticating and authorizing the client.
+        While the OpenAPI specification may support multiple security schemes (e.g. OAuth2, basic),
+        the client may want to explicitly use a specific security scheme.
         """
         self.logger = {}
         """Logging Settings
@@ -245,36 +250,36 @@ class Configuration(object):
 
         :return: The Auth Settings information dict.
         """
-        return {
-            'api_key':
-                {
-                    'type': 'api_key',
-                    'in': 'header',
-                    'key': 'api_key',
-                    'value': self.get_api_key_with_prefix('api_key')
-                },
-            'api_key_query':
-                {
-                    'type': 'api_key',
-                    'in': 'query',
-                    'key': 'api_key_query',
-                    'value': self.get_api_key_with_prefix('api_key_query')
-                },
-            'http_basic_test':
-                {
-                    'type': 'basic',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': self.get_basic_auth_token()
-                },
-            'petstore_auth':
-                {
-                    'type': 'oauth2',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': 'Bearer ' + self.access_token
-                },
-        }
+        auth = {}
+        if self.api_key:
+            auth['api_key'] = {
+                'type': 'api_key',
+                'in': 'header',
+                'key': 'api_key',
+                'value': self.get_api_key_with_prefix('api_key')
+            }
+        if self.api_key:
+            auth['api_key_query'] = {
+                'type': 'api_key',
+                'in': 'query',
+                'key': 'api_key_query',
+                'value': self.get_api_key_with_prefix('api_key_query')
+            }
+        if self.username and self.password:
+            auth['http_basic_test'] = {
+                'type': 'basic',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': self.get_basic_auth_token()
+            }
+        if self.access_token:
+            auth['petstore_auth'] = {
+                'type': 'oauth2',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
+            }
+        return auth
 
     def to_debug_report(self):
         """Gets the essential information for debugging.

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -246,14 +246,14 @@ class Configuration(object):
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if self.api_key:
+        if self.api_key and 'api_key' in self.api_key:
             auth['api_key'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'api_key',
                 'value': self.get_api_key_with_prefix('api_key')
             }
-        if self.api_key:
+        if self.api_key and 'api_key_query' in self.api_key:
             auth['api_key_query'] = {
                 'type': 'api_key',
                 'in': 'query',

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -68,11 +68,6 @@ class Configuration(object):
         self.access_token = None
         """access token for OAuth/Bearer
         """
-        self.security_schemes = None
-        """The security schemes to use when authenticating and authorizing the client.
-        While the OpenAPI specification may support multiple security schemes (e.g. OAuth2, basic),
-        the client may want to explicitly use a specific security scheme.
-        """
         self.logger = {}
         """Logging Settings
         """

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -238,8 +238,14 @@ class Configuration(object):
 
         :return: The token for basic HTTP authentication.
         """
+        username = ""
+        if self.username is not None:
+            username = self.username
+        password = ""
+        if self.password is not None:
+            password = self.password
         return urllib3.util.make_headers(
-            basic_auth=self.username + ':' + self.password
+            basic_auth=username + ':' + password
         ).get('authorization')
 
     def auth_settings(self):

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -28,11 +28,31 @@ class Configuration(object):
     Do not edit the class manually.
 
     :param host: Base url
-    :param api_key: Dict to store API key(s)
+    :param api_key: Dict to store API key(s).
+      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
+
+    :Example:
+
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          cookieAuth:         # name for the security scheme
+            type: apiKey
+            in: cookie
+            name: JSESSIONID  # cookie name
+
+    You can programmatically set the cookie:
+      conf = petstore_api.Configuration(
+        api_key={'JSESSIONID': 'abc123'}
+        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+      )
+    The following cookie will be added to the HTTP request:
+       Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
@@ -229,7 +249,7 @@ class Configuration(object):
         if key:
             prefix = self.api_key_prefix.get(identifier)
             if prefix:
-                return "%s %s" % (prefix, key)
+                return "%s%s" % (prefix, key)
             else:
                 return key
 
@@ -254,14 +274,14 @@ class Configuration(object):
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if self.api_key and 'api_key' in self.api_key:
+        if 'api_key' in self.api_key:
             auth['api_key'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'api_key',
                 'value': self.get_api_key_with_prefix('api_key')
             }
-        if self.api_key and 'api_key_query' in self.api_key:
+        if 'api_key_query' in self.api_key:
             auth['api_key_query'] = {
                 'type': 'api_key',
                 'in': 'query',

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -29,10 +29,12 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the
-      OAS specification.
-      The dict value should be the value of the api key (i.e. the secret).
-    :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
+      Each entry in the dict specifies an API key. The dict key is the name
+      of the api key, as specified in the OAS specification.
+      The dict value is itself a dict that must have a 'value' entry.
+      The 'value' entry is required and specifies the api key secret.
+      The 'prefix' entry is optional and specifies an api key prefix when
+      generating the auth data.
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
@@ -49,15 +51,14 @@ class Configuration(object):
 
     You can programmatically set the cookie:
       conf = petstore_api.Configuration(
-        api_key={'JSESSIONID': 'abc123'}
-        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+        api_key={'JSESSIONID': {prefix='JSESSIONID=', value='abc123'}}
       )
     The following cookie will be added to the HTTP request:
        Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
-                 api_key=None, api_key_prefix=None,
+                 api_key=None,
                  username=None, password=None,
                  access_token=None):
         """Constructor
@@ -73,11 +74,6 @@ class Configuration(object):
         if api_key:
             self.api_key = api_key
         """dict to store API key(s)
-        """
-        self.api_key_prefix = {}
-        if api_key_prefix:
-            self.api_key_prefix = api_key_prefix
-        """dict to store API prefix (e.g. Bearer)
         """
         self.refresh_api_key_hook = None
         """function hook to refresh API key if expired
@@ -246,11 +242,13 @@ class Configuration(object):
         """
         if self.refresh_api_key_hook is not None:
             self.refresh_api_key_hook(self)
-        key = self.api_key.get(identifier)
-        if key:
-            prefix = self.api_key_prefix.get(identifier)
-            if prefix:
-                return "%s%s" % (prefix, key)
+        key_entry = self.api_key.get(identifier)
+        if not isinstance(key_entry, dict):
+            raise Exception("The api_key attribute must be a dictionary")
+        if key_entry:
+            key = key_entry["value"]
+            if "prefix" in key_entry:
+                return "%s%s" % (key_entry["prefix"], key)
             else:
                 return key
 

--- a/samples/client/petstore/python-experimental/tests/test_api_client.py
+++ b/samples/client/petstore/python-experimental/tests/test_api_client.py
@@ -30,7 +30,7 @@ class ApiClientTests(unittest.TestCase):
         config.host = 'http://localhost/'
 
         config.api_key['api_key'] = '123456'
-        config.api_key_prefix['api_key'] = 'PREFIX'
+        config.api_key_prefix['api_key'] = 'PREFIX '
         config.username = 'test_username'
         config.password = 'test_password'
 
@@ -41,7 +41,7 @@ class ApiClientTests(unittest.TestCase):
         client = petstore_api.ApiClient(config)
 
         # test prefix
-        self.assertEqual('PREFIX', client.configuration.api_key_prefix['api_key'])
+        self.assertEqual('PREFIX ', client.configuration.api_key_prefix['api_key'])
 
         # update parameters based on auth setting
         client.update_params_for_auth(header_params, query_params, auth_settings)

--- a/samples/client/petstore/python-experimental/tests/test_api_client.py
+++ b/samples/client/petstore/python-experimental/tests/test_api_client.py
@@ -50,7 +50,7 @@ class ApiClientTests(unittest.TestCase):
 
         # test api key auth
         self.assertEqual(header_params['test1'], 'value1')
-        self.assertEqual(header_params['api_key'], 'PREFIX123456')
+        self.assertEqual(header_params['api_key'], 'PREFIX=123456')
         self.assertEqual(query_params['test2'], 'value2')
 
         # test basic auth

--- a/samples/client/petstore/python-experimental/tests/test_api_client.py
+++ b/samples/client/petstore/python-experimental/tests/test_api_client.py
@@ -29,10 +29,10 @@ class ApiClientTests(unittest.TestCase):
         config = petstore_api.Configuration()
         config.host = 'http://localhost/'
 
-        config.api_key['api_key'] = {'value': '123456', 'prefix': 'PREFIX'}
+        config.api_key['api_key'] = {'value': '123456', 'prefix': 'PREFIX='}
         # api key prefix used to be set with the api_key_prefix attribute.
         # Now the key prefix is set in the 'api_key' dictionary.
-        #config.api_key_prefix['api_key'] = 'PREFIX'
+        #config.api_key_prefix['api_key'] = 'PREFIX='
         config.username = 'test_username'
         config.password = 'test_password'
 
@@ -43,7 +43,7 @@ class ApiClientTests(unittest.TestCase):
         client = petstore_api.ApiClient(config)
 
         # test prefix
-        self.assertEqual('PREFIX', client.configuration.api_key['api_key']['prefix'])
+        self.assertEqual('PREFIX=', client.configuration.api_key['api_key']['prefix'])
 
         # update parameters based on auth setting
         client.update_params_for_auth(header_params, query_params, auth_settings)

--- a/samples/client/petstore/python-experimental/tests/test_pet_api.py
+++ b/samples/client/petstore/python-experimental/tests/test_pet_api.py
@@ -73,6 +73,7 @@ class PetApiTests(unittest.TestCase):
     def setUp(self):
         config = Configuration()
         config.host = HOST
+        config.access_token = 'ACCESS_TOKEN'
         self.api_client = petstore_api.ApiClient(config)
         self.pet_api = petstore_api.PetApi(self.api_client)
         self.setUpModels()
@@ -122,13 +123,13 @@ class PetApiTests(unittest.TestCase):
         mock_pool.expect_request('POST', 'http://localhost/v2/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
-                                          'Authorization': 'Bearer ',
+                                          'Authorization': 'Bearer ACCESS_TOKEN',
                                           'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=TimeoutWithEqual(total=5))
         mock_pool.expect_request('POST', 'http://localhost/v2/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
-                                          'Authorization': 'Bearer ',
+                                          'Authorization': 'Bearer ACCESS_TOKEN',
                                           'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=TimeoutWithEqual(connect=1, read=2))
 
@@ -325,7 +326,7 @@ class PetApiTests(unittest.TestCase):
                         'Accept': 'application/json',
                         'Content-Type': 'multipart/form-data',
                         'User-Agent': 'OpenAPI-Generator/1.0.0/python',
-                        'Authorization': 'Bearer '
+                        'Authorization': 'Bearer ACCESS_TOKEN'
                     },
                     post_params=[
                         ('files', ('1px_pic1.png', b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x00\x00\x00\x00:~\x9bU\x00\x00\x00\nIDATx\x9cc\xfa\x0f\x00\x01\x05\x01\x02\xcf\xa0.\xcd\x00\x00\x00\x00IEND\xaeB`\x82', 'image/png')),

--- a/samples/client/petstore/python-experimental/tests/test_pet_api.py
+++ b/samples/client/petstore/python-experimental/tests/test_pet_api.py
@@ -71,10 +71,10 @@ class MockPoolManager(object):
 class PetApiTests(unittest.TestCase):
 
     def setUp(self):
-        self.config = Configuration()
-        self.config.host = HOST
-        self.config.access_token = 'ACCESS_TOKEN'
-        self.api_client = petstore_api.ApiClient(self.config)
+        config = Configuration()
+        config.host = HOST
+        config.access_token = 'ACCESS_TOKEN'
+        self.api_client = petstore_api.ApiClient(config)
         self.pet_api = petstore_api.PetApi(self.api_client)
         self.setUpModels()
         self.setUpFiles()
@@ -117,23 +117,24 @@ class PetApiTests(unittest.TestCase):
         resp.release_conn()
 
     def test_config(self):
-        self.assertIsNotNone(self.config.get_host_settings())
-        self.assertEquals(self.config.get_basic_auth_token(),
+        config = Configuration(host=HOST, access_token='ACCESS_TOKEN')
+        self.assertIsNotNone(config.get_host_settings())
+        self.assertEquals(config.get_basic_auth_token(),
                           urllib3.util.make_headers(basic_auth=":").get('authorization'))
-        self.assertEquals(len(self.config.auth_settings()), 1)
-        self.assertIn("petstore_auth", self.config.auth_settings().keys())
-        self.config.username = "user"
-        self.config.password = "password"
+        self.assertEquals(len(config.auth_settings()), 1)
+        self.assertIn("petstore_auth", config.auth_settings().keys())
+        config.username = "user"
+        config.password = "password"
         self.assertEquals(
-            self.config.get_basic_auth_token(),
+            config.get_basic_auth_token(),
             urllib3.util.make_headers(basic_auth="user:password").get('authorization'))
-        self.assertEquals(len(self.config.auth_settings()), 2)
-        self.assertIn("petstore_auth", self.config.auth_settings().keys())
-        self.assertIn("http_basic_test", self.config.auth_settings().keys())
-        self.config.username = None
-        self.config.password = None
-        self.assertEquals(len(self.config.auth_settings()), 1)
-        self.assertIn("petstore_auth", self.config.auth_settings().keys())
+        self.assertEquals(len(config.auth_settings()), 2)
+        self.assertIn("petstore_auth", config.auth_settings().keys())
+        self.assertIn("http_basic_test", config.auth_settings().keys())
+        config.username = None
+        config.password = None
+        self.assertEquals(len(config.auth_settings()), 1)
+        self.assertIn("petstore_auth", config.auth_settings().keys())
 
     def test_timeout(self):
         mock_pool = MockPoolManager(self)

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -511,11 +511,6 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-        if self.configuration.security_schemes:
-            auth_settings = [
-                value for value in auth_settings
-                if value in self.configuration.security_schemes
-            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -514,9 +514,7 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if not auth_setting['value']:
-                    continue
-                elif auth_setting['in'] == 'cookie':
+                if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']

--- a/samples/client/petstore/python-tornado/petstore_api/api_client.py
+++ b/samples/client/petstore/python-tornado/petstore_api/api_client.py
@@ -511,7 +511,11 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-
+        if self.configuration.security_schemes:
+            auth_settings = [
+                value for value in auth_settings
+                if value in self.configuration.security_schemes
+            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -32,11 +32,13 @@ class Configuration(object):
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
+    :param access_token: The OAuth2 access token
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
-                 username=None, password=None):
+                 username=None, password=None,
+                 access_token=None):
         """Constructor
         """
         self.host = host
@@ -65,7 +67,7 @@ class Configuration(object):
         self.password = password
         """Password for HTTP basic authentication
         """
-        self.access_token = None
+        self.access_token = access_token
         """access token for OAuth/Bearer
         """
         self.logger = {}
@@ -260,14 +262,14 @@ class Configuration(object):
                 'key': 'api_key_query',
                 'value': self.get_api_key_with_prefix('api_key_query')
             }
-        if self.username and self.password:
+        if self.username is not None and self.password is not None:
             auth['http_basic_test'] = {
                 'type': 'basic',
                 'in': 'header',
                 'key': 'Authorization',
                 'value': self.get_basic_auth_token()
             }
-        if self.access_token:
+        if self.access_token is not None:
             auth['petstore_auth'] = {
                 'type': 'oauth2',
                 'in': 'header',

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -29,7 +29,8 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict key should be the name of the api key, as specified in the
+      OAS specification.
       The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -36,7 +36,7 @@ class Configuration(object):
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
-                 username="", password=""):
+                 username=None, password=None):
         """Constructor
         """
         self.host = host
@@ -65,8 +65,13 @@ class Configuration(object):
         self.password = password
         """Password for HTTP basic authentication
         """
-        self.access_token = ""
+        self.access_token = None
         """access token for OAuth/Bearer
+        """
+        self.security_schemes = None
+        """The security schemes to use when authenticating and authorizing the client.
+        While the OpenAPI specification may support multiple security schemes (e.g. OAuth2, basic),
+        the client may want to explicitly use a specific security scheme.
         """
         self.logger = {}
         """Logging Settings
@@ -245,36 +250,36 @@ class Configuration(object):
 
         :return: The Auth Settings information dict.
         """
-        return {
-            'api_key':
-                {
-                    'type': 'api_key',
-                    'in': 'header',
-                    'key': 'api_key',
-                    'value': self.get_api_key_with_prefix('api_key')
-                },
-            'api_key_query':
-                {
-                    'type': 'api_key',
-                    'in': 'query',
-                    'key': 'api_key_query',
-                    'value': self.get_api_key_with_prefix('api_key_query')
-                },
-            'http_basic_test':
-                {
-                    'type': 'basic',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': self.get_basic_auth_token()
-                },
-            'petstore_auth':
-                {
-                    'type': 'oauth2',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': 'Bearer ' + self.access_token
-                },
-        }
+        auth = {}
+        if self.api_key:
+            auth['api_key'] = {
+                'type': 'api_key',
+                'in': 'header',
+                'key': 'api_key',
+                'value': self.get_api_key_with_prefix('api_key')
+            }
+        if self.api_key:
+            auth['api_key_query'] = {
+                'type': 'api_key',
+                'in': 'query',
+                'key': 'api_key_query',
+                'value': self.get_api_key_with_prefix('api_key_query')
+            }
+        if self.username and self.password:
+            auth['http_basic_test'] = {
+                'type': 'basic',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': self.get_basic_auth_token()
+            }
+        if self.access_token:
+            auth['petstore_auth'] = {
+                'type': 'oauth2',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
+            }
+        return auth
 
     def to_debug_report(self):
         """Gets the essential information for debugging.

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -246,14 +246,14 @@ class Configuration(object):
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if self.api_key:
+        if self.api_key and 'api_key' in self.api_key:
             auth['api_key'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'api_key',
                 'value': self.get_api_key_with_prefix('api_key')
             }
-        if self.api_key:
+        if self.api_key and 'api_key_query' in self.api_key:
             auth['api_key_query'] = {
                 'type': 'api_key',
                 'in': 'query',

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -68,11 +68,6 @@ class Configuration(object):
         self.access_token = None
         """access token for OAuth/Bearer
         """
-        self.security_schemes = None
-        """The security schemes to use when authenticating and authorizing the client.
-        While the OpenAPI specification may support multiple security schemes (e.g. OAuth2, basic),
-        the client may want to explicitly use a specific security scheme.
-        """
         self.logger = {}
         """Logging Settings
         """

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -238,8 +238,14 @@ class Configuration(object):
 
         :return: The token for basic HTTP authentication.
         """
+        username = ""
+        if self.username is not None:
+            username = self.username
+        password = ""
+        if self.password is not None:
+            password = self.password
         return urllib3.util.make_headers(
-            basic_auth=self.username + ':' + self.password
+            basic_auth=username + ':' + password
         ).get('authorization')
 
     def auth_settings(self):

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -28,11 +28,31 @@ class Configuration(object):
     Do not edit the class manually.
 
     :param host: Base url
-    :param api_key: Dict to store API key(s)
+    :param api_key: Dict to store API key(s).
+      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
+
+    :Example:
+
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          cookieAuth:         # name for the security scheme
+            type: apiKey
+            in: cookie
+            name: JSESSIONID  # cookie name
+
+    You can programmatically set the cookie:
+      conf = petstore_api.Configuration(
+        api_key={'JSESSIONID': 'abc123'}
+        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+      )
+    The following cookie will be added to the HTTP request:
+       Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
@@ -229,7 +249,7 @@ class Configuration(object):
         if key:
             prefix = self.api_key_prefix.get(identifier)
             if prefix:
-                return "%s %s" % (prefix, key)
+                return "%s%s" % (prefix, key)
             else:
                 return key
 
@@ -254,14 +274,14 @@ class Configuration(object):
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if self.api_key and 'api_key' in self.api_key:
+        if 'api_key' in self.api_key:
             auth['api_key'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'api_key',
                 'value': self.get_api_key_with_prefix('api_key')
             }
-        if self.api_key and 'api_key_query' in self.api_key:
+        if 'api_key_query' in self.api_key:
             auth['api_key_query'] = {
                 'type': 'api_key',
                 'in': 'query',

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -29,10 +29,12 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the
-      OAS specification.
-      The dict value should be the value of the api key (i.e. the secret).
-    :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
+      Each entry in the dict specifies an API key. The dict key is the name
+      of the api key, as specified in the OAS specification.
+      The dict value is itself a dict that must have a 'value' entry.
+      The 'value' entry is required and specifies the api key secret.
+      The 'prefix' entry is optional and specifies an api key prefix when
+      generating the auth data.
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
@@ -49,15 +51,14 @@ class Configuration(object):
 
     You can programmatically set the cookie:
       conf = petstore_api.Configuration(
-        api_key={'JSESSIONID': 'abc123'}
-        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+        api_key={'JSESSIONID': {prefix='JSESSIONID=', value='abc123'}}
       )
     The following cookie will be added to the HTTP request:
        Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
-                 api_key=None, api_key_prefix=None,
+                 api_key=None,
                  username=None, password=None,
                  access_token=None):
         """Constructor
@@ -73,11 +74,6 @@ class Configuration(object):
         if api_key:
             self.api_key = api_key
         """dict to store API key(s)
-        """
-        self.api_key_prefix = {}
-        if api_key_prefix:
-            self.api_key_prefix = api_key_prefix
-        """dict to store API prefix (e.g. Bearer)
         """
         self.refresh_api_key_hook = None
         """function hook to refresh API key if expired
@@ -246,11 +242,13 @@ class Configuration(object):
         """
         if self.refresh_api_key_hook is not None:
             self.refresh_api_key_hook(self)
-        key = self.api_key.get(identifier)
-        if key:
-            prefix = self.api_key_prefix.get(identifier)
-            if prefix:
-                return "%s%s" % (prefix, key)
+        key_entry = self.api_key.get(identifier)
+        if not isinstance(key_entry, dict):
+            raise Exception("The api_key attribute must be a dictionary")
+        if key_entry:
+            key = key_entry["value"]
+            if "prefix" in key_entry:
+                return "%s%s" % (key_entry["prefix"], key)
             else:
                 return key
 

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -509,7 +509,11 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-
+        if self.configuration.security_schemes:
+            auth_settings = [
+                value for value in auth_settings
+                if value in self.configuration.security_schemes
+            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -512,9 +512,7 @@ class ApiClient(object):
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if not auth_setting['value']:
-                    continue
-                elif auth_setting['in'] == 'cookie':
+                if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']

--- a/samples/client/petstore/python/petstore_api/api_client.py
+++ b/samples/client/petstore/python/petstore_api/api_client.py
@@ -509,11 +509,6 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-        if self.configuration.security_schemes:
-            auth_settings = [
-                value for value in auth_settings
-                if value in self.configuration.security_schemes
-            ]
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -32,11 +32,13 @@ class Configuration(object):
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
+    :param access_token: The OAuth2 access token
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
-                 username=None, password=None):
+                 username=None, password=None,
+                 access_token=None):
         """Constructor
         """
         self.host = host
@@ -65,7 +67,7 @@ class Configuration(object):
         self.password = password
         """Password for HTTP basic authentication
         """
-        self.access_token = None
+        self.access_token = access_token
         """access token for OAuth/Bearer
         """
         self.logger = {}
@@ -260,14 +262,14 @@ class Configuration(object):
                 'key': 'api_key_query',
                 'value': self.get_api_key_with_prefix('api_key_query')
             }
-        if self.username and self.password:
+        if self.username is not None and self.password is not None:
             auth['http_basic_test'] = {
                 'type': 'basic',
                 'in': 'header',
                 'key': 'Authorization',
                 'value': self.get_basic_auth_token()
             }
-        if self.access_token:
+        if self.access_token is not None:
             auth['petstore_auth'] = {
                 'type': 'oauth2',
                 'in': 'header',

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -29,7 +29,8 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict key should be the name of the api key, as specified in the
+      OAS specification.
       The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -36,7 +36,7 @@ class Configuration(object):
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
-                 username="", password=""):
+                 username=None, password=None):
         """Constructor
         """
         self.host = host
@@ -65,8 +65,13 @@ class Configuration(object):
         self.password = password
         """Password for HTTP basic authentication
         """
-        self.access_token = ""
+        self.access_token = None
         """access token for OAuth/Bearer
+        """
+        self.security_schemes = None
+        """The security schemes to use when authenticating and authorizing the client.
+        While the OpenAPI specification may support multiple security schemes (e.g. OAuth2, basic),
+        the client may want to explicitly use a specific security scheme.
         """
         self.logger = {}
         """Logging Settings
@@ -245,36 +250,36 @@ class Configuration(object):
 
         :return: The Auth Settings information dict.
         """
-        return {
-            'api_key':
-                {
-                    'type': 'api_key',
-                    'in': 'header',
-                    'key': 'api_key',
-                    'value': self.get_api_key_with_prefix('api_key')
-                },
-            'api_key_query':
-                {
-                    'type': 'api_key',
-                    'in': 'query',
-                    'key': 'api_key_query',
-                    'value': self.get_api_key_with_prefix('api_key_query')
-                },
-            'http_basic_test':
-                {
-                    'type': 'basic',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': self.get_basic_auth_token()
-                },
-            'petstore_auth':
-                {
-                    'type': 'oauth2',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': 'Bearer ' + self.access_token
-                },
-        }
+        auth = {}
+        if self.api_key:
+            auth['api_key'] = {
+                'type': 'api_key',
+                'in': 'header',
+                'key': 'api_key',
+                'value': self.get_api_key_with_prefix('api_key')
+            }
+        if self.api_key:
+            auth['api_key_query'] = {
+                'type': 'api_key',
+                'in': 'query',
+                'key': 'api_key_query',
+                'value': self.get_api_key_with_prefix('api_key_query')
+            }
+        if self.username and self.password:
+            auth['http_basic_test'] = {
+                'type': 'basic',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': self.get_basic_auth_token()
+            }
+        if self.access_token:
+            auth['petstore_auth'] = {
+                'type': 'oauth2',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
+            }
+        return auth
 
     def to_debug_report(self):
         """Gets the essential information for debugging.

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -246,14 +246,14 @@ class Configuration(object):
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if self.api_key:
+        if self.api_key and 'api_key' in self.api_key:
             auth['api_key'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'api_key',
                 'value': self.get_api_key_with_prefix('api_key')
             }
-        if self.api_key:
+        if self.api_key and 'api_key_query' in self.api_key:
             auth['api_key_query'] = {
                 'type': 'api_key',
                 'in': 'query',

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -68,11 +68,6 @@ class Configuration(object):
         self.access_token = None
         """access token for OAuth/Bearer
         """
-        self.security_schemes = None
-        """The security schemes to use when authenticating and authorizing the client.
-        While the OpenAPI specification may support multiple security schemes (e.g. OAuth2, basic),
-        the client may want to explicitly use a specific security scheme.
-        """
         self.logger = {}
         """Logging Settings
         """

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -238,8 +238,14 @@ class Configuration(object):
 
         :return: The token for basic HTTP authentication.
         """
+        username = ""
+        if self.username is not None:
+            username = self.username
+        password = ""
+        if self.password is not None:
+            password = self.password
         return urllib3.util.make_headers(
-            basic_auth=self.username + ':' + self.password
+            basic_auth=username + ':' + password
         ).get('authorization')
 
     def auth_settings(self):

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -28,11 +28,31 @@ class Configuration(object):
     Do not edit the class manually.
 
     :param host: Base url
-    :param api_key: Dict to store API key(s)
+    :param api_key: Dict to store API key(s).
+      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
+
+    :Example:
+
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          cookieAuth:         # name for the security scheme
+            type: apiKey
+            in: cookie
+            name: JSESSIONID  # cookie name
+
+    You can programmatically set the cookie:
+      conf = petstore_api.Configuration(
+        api_key={'JSESSIONID': 'abc123'}
+        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+      )
+    The following cookie will be added to the HTTP request:
+       Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
@@ -229,7 +249,7 @@ class Configuration(object):
         if key:
             prefix = self.api_key_prefix.get(identifier)
             if prefix:
-                return "%s %s" % (prefix, key)
+                return "%s%s" % (prefix, key)
             else:
                 return key
 
@@ -254,14 +274,14 @@ class Configuration(object):
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if self.api_key and 'api_key' in self.api_key:
+        if 'api_key' in self.api_key:
             auth['api_key'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'api_key',
                 'value': self.get_api_key_with_prefix('api_key')
             }
-        if self.api_key and 'api_key_query' in self.api_key:
+        if 'api_key_query' in self.api_key:
             auth['api_key_query'] = {
                 'type': 'api_key',
                 'in': 'query',

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -29,10 +29,12 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the
-      OAS specification.
-      The dict value should be the value of the api key (i.e. the secret).
-    :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
+      Each entry in the dict specifies an API key. The dict key is the name
+      of the api key, as specified in the OAS specification.
+      The dict value is itself a dict that must have a 'value' entry.
+      The 'value' entry is required and specifies the api key secret.
+      The 'prefix' entry is optional and specifies an api key prefix when
+      generating the auth data.
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
@@ -49,15 +51,14 @@ class Configuration(object):
 
     You can programmatically set the cookie:
       conf = petstore_api.Configuration(
-        api_key={'JSESSIONID': 'abc123'}
-        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+        api_key={'JSESSIONID': {prefix='JSESSIONID=', value='abc123'}}
       )
     The following cookie will be added to the HTTP request:
        Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
-                 api_key=None, api_key_prefix=None,
+                 api_key=None,
                  username=None, password=None,
                  access_token=None):
         """Constructor
@@ -73,11 +74,6 @@ class Configuration(object):
         if api_key:
             self.api_key = api_key
         """dict to store API key(s)
-        """
-        self.api_key_prefix = {}
-        if api_key_prefix:
-            self.api_key_prefix = api_key_prefix
-        """dict to store API prefix (e.g. Bearer)
         """
         self.refresh_api_key_hook = None
         """function hook to refresh API key if expired
@@ -246,11 +242,13 @@ class Configuration(object):
         """
         if self.refresh_api_key_hook is not None:
             self.refresh_api_key_hook(self)
-        key = self.api_key.get(identifier)
-        if key:
-            prefix = self.api_key_prefix.get(identifier)
-            if prefix:
-                return "%s%s" % (prefix, key)
+        key_entry = self.api_key.get(identifier)
+        if not isinstance(key_entry, dict):
+            raise Exception("The api_key attribute must be a dictionary")
+        if key_entry:
+            key = key_entry["value"]
+            if "prefix" in key_entry:
+                return "%s%s" % (key_entry["prefix"], key)
             else:
                 return key
 

--- a/samples/client/petstore/python/tests/test_api_client.py
+++ b/samples/client/petstore/python/tests/test_api_client.py
@@ -29,7 +29,7 @@ class ApiClientTests(unittest.TestCase):
         config = petstore_api.Configuration()
 
         config.api_key['api_key'] = '123456'
-        config.api_key_prefix['api_key'] = 'PREFIX'
+        config.api_key_prefix['api_key'] = 'PREFIX='
         config.username = 'test_username'
         config.password = 'test_password'
 
@@ -40,14 +40,14 @@ class ApiClientTests(unittest.TestCase):
         client = petstore_api.ApiClient(config)
 
         # test prefix
-        self.assertEqual('PREFIX', client.configuration.api_key_prefix['api_key'])
+        self.assertEqual('PREFIX=', client.configuration.api_key_prefix['api_key'])
 
         # update parameters based on auth setting
         client.update_params_for_auth(header_params, query_params, auth_settings)
 
         # test api key auth
         self.assertEqual(header_params['test1'], 'value1')
-        self.assertEqual(header_params['api_key'], 'PREFIX 123456')
+        self.assertEqual(header_params['api_key'], 'PREFIX=123456')
         self.assertEqual(query_params['test2'], 'value2')
 
         # test basic auth

--- a/samples/client/petstore/python/tests/test_api_client.py
+++ b/samples/client/petstore/python/tests/test_api_client.py
@@ -47,7 +47,7 @@ class ApiClientTests(unittest.TestCase):
 
         # test api key auth
         self.assertEqual(header_params['test1'], 'value1')
-        self.assertEqual(header_params['api_key'], 'PREFIX= 123456')
+        self.assertEqual(header_params['api_key'], 'PREFIX=123456')
         self.assertEqual(query_params['test2'], 'value2')
 
         # test basic auth

--- a/samples/client/petstore/python/tests/test_api_client.py
+++ b/samples/client/petstore/python/tests/test_api_client.py
@@ -47,7 +47,7 @@ class ApiClientTests(unittest.TestCase):
 
         # test api key auth
         self.assertEqual(header_params['test1'], 'value1')
-        self.assertEqual(header_params['api_key'], 'PREFIX=123456')
+        self.assertEqual(header_params['api_key'], 'PREFIX= 123456')
         self.assertEqual(query_params['test2'], 'value2')
 
         # test basic auth

--- a/samples/client/petstore/python/tests/test_api_client.py
+++ b/samples/client/petstore/python/tests/test_api_client.py
@@ -28,8 +28,7 @@ class ApiClientTests(unittest.TestCase):
     def test_configuration(self):
         config = petstore_api.Configuration()
 
-        config.api_key['api_key'] = '123456'
-        config.api_key_prefix['api_key'] = 'PREFIX='
+        config.api_key['api_key'] = { 'value': '123456', 'prefix': 'PREFIX' }
         config.username = 'test_username'
         config.password = 'test_password'
 
@@ -39,15 +38,12 @@ class ApiClientTests(unittest.TestCase):
 
         client = petstore_api.ApiClient(config)
 
-        # test prefix
-        self.assertEqual('PREFIX=', client.configuration.api_key_prefix['api_key'])
-
         # update parameters based on auth setting
         client.update_params_for_auth(header_params, query_params, auth_settings)
 
         # test api key auth
         self.assertEqual(header_params['test1'], 'value1')
-        self.assertEqual(header_params['api_key'], 'PREFIX=123456')
+        self.assertEqual(header_params['api_key'], 'PREFIX123456')
         self.assertEqual(query_params['test2'], 'value2')
 
         # test basic auth

--- a/samples/client/petstore/python/tests/test_configuration.py
+++ b/samples/client/petstore/python/tests/test_configuration.py
@@ -29,7 +29,6 @@ class TestConfiguration(unittest.TestCase):
         c1 = petstore_api.Configuration()
         c2 = petstore_api.Configuration()
         assert id(c1.api_key) != id(c2.api_key)
-        assert id(c1.api_key_prefix) != id(c2.api_key_prefix)
 
 
 if __name__ == '__main__':

--- a/samples/client/petstore/python/tests/test_pet_api.py
+++ b/samples/client/petstore/python/tests/test_pet_api.py
@@ -13,6 +13,7 @@ $ nosetests -v
 
 import os
 import unittest
+import pprint
 
 import petstore_api
 from petstore_api import Configuration
@@ -223,7 +224,10 @@ class PetApiTests(unittest.TestCase):
 
     def test_find_pets_by_tags(self):
         self.pet_api.add_pet(self.pet)
-
+        with open("file_out.txt", "w") as fout:
+            pp = pprint.PrettyPrinter(indent=4, stream=fout)
+            pp.pprint(self.pet)
+            pp.pprint(self.pet_api.find_pets_by_tags(tags=[self.tag.name]))
         self.assertIn(
             self.pet.id,
             list(map(lambda x: getattr(x, 'id'), self.pet_api.find_pets_by_tags(tags=[self.tag.name])))

--- a/samples/client/petstore/python/tests/test_pet_api.py
+++ b/samples/client/petstore/python/tests/test_pet_api.py
@@ -57,6 +57,7 @@ class PetApiTests(unittest.TestCase):
     def setUp(self):
         config = Configuration()
         config.host = HOST
+        config.access_token = 'ACCESS_TOKEN'
         self.api_client = petstore_api.ApiClient(config)
         self.pet_api = petstore_api.PetApi(self.api_client)
         self.setUpModels()
@@ -107,13 +108,13 @@ class PetApiTests(unittest.TestCase):
         mock_pool.expect_request('POST', HOST + '/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
-                                          'Authorization': 'Bearer ',
+                                          'Authorization': 'Bearer ACCESS_TOKEN',
                                           'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=TimeoutWithEqual(total=5))
         mock_pool.expect_request('POST', HOST + '/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
-                                          'Authorization': 'Bearer ',
+                                          'Authorization': 'Bearer ACCESS_TOKEN',
                                           'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=TimeoutWithEqual(connect=1, read=2))
 

--- a/samples/client/petstore/python/tests/test_pet_api.py
+++ b/samples/client/petstore/python/tests/test_pet_api.py
@@ -13,7 +13,6 @@ $ nosetests -v
 
 import os
 import unittest
-import pprint
 
 import petstore_api
 from petstore_api import Configuration
@@ -224,10 +223,6 @@ class PetApiTests(unittest.TestCase):
 
     def test_find_pets_by_tags(self):
         self.pet_api.add_pet(self.pet)
-        with open("file_out.txt", "w") as fout:
-            pp = pprint.PrettyPrinter(indent=4, stream=fout)
-            pp.pprint(self.pet)
-            pp.pprint(self.pet_api.find_pets_by_tags(tags=[self.tag.name]))
         self.assertIn(
             self.pet.id,
             list(map(lambda x: getattr(x, 'id'), self.pet_api.find_pets_by_tags(tags=[self.tag.name])))

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -509,13 +509,10 @@ class ApiClient(object):
         """
         if not auth_settings:
             return
-
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)
             if auth_setting:
-                if not auth_setting['value']:
-                    continue
-                elif auth_setting['in'] == 'cookie':
+                if auth_setting['in'] == 'cookie':
                     headers['Cookie'] = auth_setting['value']
                 elif auth_setting['in'] == 'header':
                     headers[auth_setting['key']] = auth_setting['value']

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -29,7 +29,8 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict key should be the name of the api key, as specified in the
+      OAS specification.
       The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -238,8 +238,14 @@ class Configuration(object):
 
         :return: The token for basic HTTP authentication.
         """
+        username = ""
+        if self.username is not None:
+            username = self.username
+        password = ""
+        if self.password is not None:
+            password = self.password
         return urllib3.util.make_headers(
-            basic_auth=self.username + ':' + self.password
+            basic_auth=username + ':' + password
         ).get('authorization')
 
     def auth_settings(self):

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -28,11 +28,31 @@ class Configuration(object):
     Do not edit the class manually.
 
     :param host: Base url
-    :param api_key: Dict to store API key(s)
+    :param api_key: Dict to store API key(s).
+      The dict key should be the name of the api key, as specified in the OAS specification.
+      The dict value should be the value of the api key (i.e. the secret).
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
+
+    :Example:
+
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          cookieAuth:         # name for the security scheme
+            type: apiKey
+            in: cookie
+            name: JSESSIONID  # cookie name
+
+    You can programmatically set the cookie:
+      conf = petstore_api.Configuration(
+        api_key={'JSESSIONID': 'abc123'}
+        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+      )
+    The following cookie will be added to the HTTP request:
+       Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
@@ -229,7 +249,7 @@ class Configuration(object):
         if key:
             prefix = self.api_key_prefix.get(identifier)
             if prefix:
-                return "%s %s" % (prefix, key)
+                return "%s%s" % (prefix, key)
             else:
                 return key
 
@@ -254,14 +274,14 @@ class Configuration(object):
         :return: The Auth Settings information dict.
         """
         auth = {}
-        if self.api_key and 'api_key' in self.api_key:
+        if 'api_key' in self.api_key:
             auth['api_key'] = {
                 'type': 'api_key',
                 'in': 'header',
                 'key': 'api_key',
                 'value': self.get_api_key_with_prefix('api_key')
             }
-        if self.api_key and 'api_key_query' in self.api_key:
+        if 'api_key_query' in self.api_key:
             auth['api_key_query'] = {
                 'type': 'api_key',
                 'in': 'query',

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -32,11 +32,13 @@ class Configuration(object):
     :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
+    :param access_token: The OAuth2 access token
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
                  api_key=None, api_key_prefix=None,
-                 username="", password=""):
+                 username=None, password=None,
+                 access_token=None):
         """Constructor
         """
         self.host = host
@@ -65,7 +67,7 @@ class Configuration(object):
         self.password = password
         """Password for HTTP basic authentication
         """
-        self.access_token = ""
+        self.access_token = access_token
         """access token for OAuth/Bearer
         """
         self.logger = {}
@@ -245,44 +247,44 @@ class Configuration(object):
 
         :return: The Auth Settings information dict.
         """
-        return {
-            'api_key':
-                {
-                    'type': 'api_key',
-                    'in': 'header',
-                    'key': 'api_key',
-                    'value': self.get_api_key_with_prefix('api_key')
-                },
-            'api_key_query':
-                {
-                    'type': 'api_key',
-                    'in': 'query',
-                    'key': 'api_key_query',
-                    'value': self.get_api_key_with_prefix('api_key_query')
-                },
-            'bearer_test':
-                {
-                    'type': 'bearer',
-                    'in': 'header',
-                    'format': 'JWT',
-                    'key': 'Authorization',
-                    'value': 'Bearer ' + self.access_token
-                },
-            'http_basic_test':
-                {
-                    'type': 'basic',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': self.get_basic_auth_token()
-                },
-            'petstore_auth':
-                {
-                    'type': 'oauth2',
-                    'in': 'header',
-                    'key': 'Authorization',
-                    'value': 'Bearer ' + self.access_token
-                },
-        }
+        auth = {}
+        if self.api_key and 'api_key' in self.api_key:
+            auth['api_key'] = {
+                'type': 'api_key',
+                'in': 'header',
+                'key': 'api_key',
+                'value': self.get_api_key_with_prefix('api_key')
+            }
+        if self.api_key and 'api_key_query' in self.api_key:
+            auth['api_key_query'] = {
+                'type': 'api_key',
+                'in': 'query',
+                'key': 'api_key_query',
+                'value': self.get_api_key_with_prefix('api_key_query')
+            }
+        if self.access_token is not None:
+            auth['bearer_test'] = {
+                'type': 'bearer',
+                'in': 'header',
+                'format': 'JWT',
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
+            }
+        if self.username is not None and self.password is not None:
+            auth['http_basic_test'] = {
+                'type': 'basic',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': self.get_basic_auth_token()
+            }
+        if self.access_token is not None:
+            auth['petstore_auth'] = {
+                'type': 'oauth2',
+                'in': 'header',
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
+            }
+        return auth
 
     def to_debug_report(self):
         """Gets the essential information for debugging.

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -29,10 +29,12 @@ class Configuration(object):
 
     :param host: Base url
     :param api_key: Dict to store API key(s).
-      The dict key should be the name of the api key, as specified in the
-      OAS specification.
-      The dict value should be the value of the api key (i.e. the secret).
-    :param api_key_prefix: Dict to store API prefix (e.g. Bearer)
+      Each entry in the dict specifies an API key. The dict key is the name
+      of the api key, as specified in the OAS specification.
+      The dict value is itself a dict that must have a 'value' entry.
+      The 'value' entry is required and specifies the api key secret.
+      The 'prefix' entry is optional and specifies an api key prefix when
+      generating the auth data.
     :param username: Username for HTTP basic authentication
     :param password: Password for HTTP basic authentication
     :param access_token: The OAuth2 access token
@@ -49,15 +51,14 @@ class Configuration(object):
 
     You can programmatically set the cookie:
       conf = petstore_api.Configuration(
-        api_key={'JSESSIONID': 'abc123'}
-        api_key_prefix={'JSESSIONID': 'JSESSIONID='}
+        api_key={'JSESSIONID': {prefix='JSESSIONID=', value='abc123'}}
       )
     The following cookie will be added to the HTTP request:
        Cookie: JSESSIONID=abc123
     """
 
     def __init__(self, host="http://petstore.swagger.io:80/v2",
-                 api_key=None, api_key_prefix=None,
+                 api_key=None,
                  username=None, password=None,
                  access_token=None):
         """Constructor
@@ -73,11 +74,6 @@ class Configuration(object):
         if api_key:
             self.api_key = api_key
         """dict to store API key(s)
-        """
-        self.api_key_prefix = {}
-        if api_key_prefix:
-            self.api_key_prefix = api_key_prefix
-        """dict to store API prefix (e.g. Bearer)
         """
         self.refresh_api_key_hook = None
         """function hook to refresh API key if expired
@@ -246,11 +242,13 @@ class Configuration(object):
         """
         if self.refresh_api_key_hook is not None:
             self.refresh_api_key_hook(self)
-        key = self.api_key.get(identifier)
-        if key:
-            prefix = self.api_key_prefix.get(identifier)
-            if prefix:
-                return "%s%s" % (prefix, key)
+        key_entry = self.api_key.get(identifier)
+        if not isinstance(key_entry, dict):
+            raise Exception("The api_key attribute must be a dictionary")
+        if key_entry:
+            key = key_entry["value"]
+            if "prefix" in key_entry:
+                return "%s%s" % (key_entry["prefix"], key)
             else:
                 return key
 


### PR DESCRIPTION
Fix for #3844:
- Do not add auth parameter in HTTP request if auth parameter is set None
- Add attribute to control which auth schemes can be used.

Currently, the python client obtains the list of security schemes that have been specified in the OAS spec, and automatically adds the authentication attributes in the header, cookie or query. This happens even if the parameters are unset. For example, the "Authorization" header may be set with an empty Bearer token:
```
'Authorization': 'Bearer '
```
With this PR, the bearer access token is no longer set if its value is None. 

Tests performed:
1) Use OAS spec that specifies more than one security scheme for a given operation, e.g. OAuth2 and cookie
2) Generate the Python SDK using the master branch
3) Write a Python client that sets the cookie but not the OAuth2 access token
4) Invoke the client and verifies both auth attributes have been set (causing auth failure)
5) Generate the Python SDK using code from this PR
6) Invoke the client again, verify the auth parameters are set conditionally.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
