### PR TITLE
[Python] Do not use mutable default argument

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -143,14 +143,7 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file.
-
-        If the logger_file is None, then add stream handler and remove file
-        handler. Otherwise, add file handler and remove stream handler.
-
-        :param value: The logger_file path.
-        :type: str
-        """
+        """The logger file."""
         return self.__logger_file
 
     @logger_file.setter
@@ -174,16 +167,12 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Debug status
-
-        :param value: The debug status, True or False.
-        :type: bool
-        """
+        """Return debug status."""
         return self.__debug
 
     @debug.setter
     def debug(self, value):
-        """Debug status
+        """Set debug status.
 
         :param value: The debug status, True or False.
         :type: bool
@@ -205,18 +194,12 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """The logger format.
-
-        The logger_formatter will be updated when sets logger_format.
-
-        :param value: The format string.
-        :type: str
-        """
+        """Return the logger format."""
         return self.__logger_format
 
     @logger_format.setter
     def logger_format(self, value):
-        """The logger format.
+        """Set the logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
@@ -227,7 +210,7 @@ class Configuration(object):
         self.logger_formatter = logging.Formatter(self.__logger_format)
 
     def get_api_key_with_prefix(self, identifier):
-        """Gets API key (with prefix if set).
+        """Get API key (with prefix if set).
 
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
@@ -243,7 +226,7 @@ class Configuration(object):
                 return key
 
     def get_basic_auth_token(self):
-        """Gets HTTP basic authentication header (string).
+        """Get HTTP basic authentication header (string).
 
         :return: The token for basic HTTP authentication.
         """
@@ -252,7 +235,7 @@ class Configuration(object):
         ).get('authorization')
 
     def auth_settings(self):
-        """Gets Auth Settings dict for api client.
+        """Get Auth Settings dict for api client.
 
         :return: The Auth Settings information dict.
         """
@@ -303,7 +286,7 @@ class Configuration(object):
         }
 
     def to_debug_report(self):
-        """Gets the essential information for debugging.
+        """Get the essential information for debugging.
 
         :return: The report for debugging.
         """
@@ -315,7 +298,7 @@ class Configuration(object):
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):
-        """Gets an array of host settings
+        """Get an array of host settings
 
         :return: An array of host settings
         """
@@ -349,10 +332,10 @@ class Configuration(object):
             {{/servers}}
         ]
 
-    def get_host_from_settings(self, index, variables=None):
+    def get_host_from_settings(self, index=0, variables=None):
         """Get host URL based on the index and variables.
 
-        :param index: array index of the host settings
+        :param index: array index of the host settings (default: 0)
         :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
@@ -363,23 +346,23 @@ class Configuration(object):
             server = servers[index]
         except IndexError:
             raise ValueError(
-                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
-                .format(index, len(servers)))
+                "Invalid index {0} when selecting the host settings. "
+                "Must be less than {1}".format(index, len(servers)))
 
         url = server['url']
 
-        # go through variable and assign a value
-        for variable_name in server['variables']:
-            server_variable = server['variables'][variable_name]
-            value = variables.get(variable_name, server_variable['default_value'])
+        # go through variables and replace placeholders
+        for variable_name, variable in server['variables'].items():
+            used_value = variables.get(variable_name, variable['default_value'])
 
-            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+            if 'enum_values' in variable \
+                    and used_value not in variable['enum_values']:
                 raise ValueError(
-                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
-                    .format(
+                    "The variable `{0}` in the host URL has invalid value "
+                    "{1}. Must be {2}.".format(
                         variable_name, variables[variable_name],
-                        server['variables'][variable_name]['enum_values']))
+                        variable['enum_values']))
 
-            url = url.replace("{" + variable_name + "}", value)
+            url = url.replace("{" + variable_name + "}", used_value)
 
         return url

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -349,41 +349,37 @@ class Configuration(object):
             {{/servers}}
         ]
 
-    def get_host_from_settings(self, index, variables={}):
-        """Gets host URL based on the index and variables
+    def get_host_from_settings(self, index, variables=None):
+        """Get host URL based on the index and variables.
+
         :param index: array index of the host settings
-        :param variables: hash of variable and the corresponding value
+        :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
-
+        variables = {} if variables is None else variables
         servers = self.get_host_settings()
 
-        # check array index out of bound
-        if index < 0 or index >= len(servers):
+        try:
+            server = servers[index]
+        except IndexError:
             raise ValueError(
-                "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
+                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
                 .format(index, len(servers)))
 
-        server = servers[index]
         url = server['url']
 
         # go through variable and assign a value
         for variable_name in server['variables']:
-            if variable_name in variables:
-                if variables[variable_name] in server['variables'][
-                        variable_name]['enum_values']:
-                    url = url.replace("{" + variable_name + "}",
-                                      variables[variable_name])
-                else:
-                    raise ValueError(
-                        "The variable `{}` in the host URL has invalid value {}. Must be {}."  # noqa: E501
-                        .format(
-                            variable_name, variables[variable_name],
-                            server['variables'][variable_name]['enum_values']))
-            else:
-                # use default value
-                url = url.replace(
-                    "{" + variable_name + "}",
-                    server['variables'][variable_name]['default_value'])
+            server_variable = server['variables'][variable_name]
+            value = variables.get(variable_name, server_variable['default_value'])
+
+            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+                raise ValueError(
+                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
+                    .format(
+                        variable_name, variables[variable_name],
+                        server['variables'][variable_name]['enum_values']))
+
+            url = url.replace("{" + variable_name + "}", value)
 
         return url

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -350,7 +350,8 @@ class Configuration(object):
 
         # go through variables and replace placeholders
         for variable_name, variable in server['variables'].items():
-            used_value = variables.get(variable_name, variable['default_value'])
+            used_value = variables.get(
+                variable_name, variable['default_value'])
 
             if 'enum_values' in variable \
                     and used_value not in variable['enum_values']:

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -332,10 +332,10 @@ class Configuration(object):
             {{/servers}}
         ]
 
-    def get_host_from_settings(self, index=0, variables=None):
+    def get_host_from_settings(self, index, variables=None):
         """Get host URL based on the index and variables.
 
-        :param index: array index of the host settings (default: 0)
+        :param index: array index of the host settings
         :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -143,11 +143,6 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file."""
-        return self.__logger_file
-
-    @logger_file.setter
-    def logger_file(self, value):
         """The logger file.
 
         If the logger_file is None, then add stream handler and remove file
@@ -156,6 +151,10 @@ class Configuration(object):
         :param value: The logger_file path.
         :type: str
         """
+        return self.__logger_file
+
+    @logger_file.setter
+    def logger_file(self, value):
         self.__logger_file = value
         if self.__logger_file:
             # If set logging file,
@@ -167,16 +166,15 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Return debug status."""
-        return self.__debug
-
-    @debug.setter
-    def debug(self, value):
-        """Set debug status.
+        """The debug status.
 
         :param value: The debug status, True or False.
         :type: bool
         """
+        return self.__debug
+
+    @debug.setter
+    def debug(self, value):
         self.__debug = value
         if self.__debug:
             # if debug status is True, turn on debug logging
@@ -194,18 +192,17 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """Return the logger format."""
-        return self.__logger_format
-
-    @logger_format.setter
-    def logger_format(self, value):
-        """Set the logger format.
+        """The logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
         :param value: The format string.
         :type: str
         """
+        return self.__logger_format
+
+    @logger_format.setter
+    def logger_format(self, value):
         self.__logger_format = value
         self.logger_formatter = logging.Formatter(self.__logger_format)
 

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -128,11 +128,6 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file."""
-        return self.__logger_file
-
-    @logger_file.setter
-    def logger_file(self, value):
         """The logger file.
 
         If the logger_file is None, then add stream handler and remove file
@@ -141,6 +136,10 @@ class Configuration(object):
         :param value: The logger_file path.
         :type: str
         """
+        return self.__logger_file
+
+    @logger_file.setter
+    def logger_file(self, value):
         self.__logger_file = value
         if self.__logger_file:
             # If set logging file,
@@ -152,16 +151,15 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Return debug status."""
-        return self.__debug
-
-    @debug.setter
-    def debug(self, value):
-        """Set debug status.
+        """The debug status.
 
         :param value: The debug status, True or False.
         :type: bool
         """
+        return self.__debug
+
+    @debug.setter
+    def debug(self, value):
         self.__debug = value
         if self.__debug:
             # if debug status is True, turn on debug logging
@@ -179,18 +177,17 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """Return the logger format."""
-        return self.__logger_format
-
-    @logger_format.setter
-    def logger_format(self, value):
-        """Set the logger format.
+        """The logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
         :param value: The format string.
         :type: str
         """
+        return self.__logger_format
+
+    @logger_format.setter
+    def logger_format(self, value):
         self.__logger_format = value
         self.logger_formatter = logging.Formatter(self.__logger_format)
 

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -128,14 +128,7 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file.
-
-        If the logger_file is None, then add stream handler and remove file
-        handler. Otherwise, add file handler and remove stream handler.
-
-        :param value: The logger_file path.
-        :type: str
-        """
+        """The logger file."""
         return self.__logger_file
 
     @logger_file.setter
@@ -159,16 +152,12 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Debug status
-
-        :param value: The debug status, True or False.
-        :type: bool
-        """
+        """Return debug status."""
         return self.__debug
 
     @debug.setter
     def debug(self, value):
-        """Debug status
+        """Set debug status.
 
         :param value: The debug status, True or False.
         :type: bool
@@ -190,18 +179,12 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """The logger format.
-
-        The logger_formatter will be updated when sets logger_format.
-
-        :param value: The format string.
-        :type: str
-        """
+        """Return the logger format."""
         return self.__logger_format
 
     @logger_format.setter
     def logger_format(self, value):
-        """The logger format.
+        """Set the logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
@@ -212,7 +195,7 @@ class Configuration(object):
         self.logger_formatter = logging.Formatter(self.__logger_format)
 
     def get_api_key_with_prefix(self, identifier):
-        """Gets API key (with prefix if set).
+        """Get API key (with prefix if set).
 
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
@@ -228,7 +211,7 @@ class Configuration(object):
                 return key
 
     def get_basic_auth_token(self):
-        """Gets HTTP basic authentication header (string).
+        """Get HTTP basic authentication header (string).
 
         :return: The token for basic HTTP authentication.
         """
@@ -237,7 +220,7 @@ class Configuration(object):
         ).get('authorization')
 
     def auth_settings(self):
-        """Gets Auth Settings dict for api client.
+        """Get Auth Settings dict for api client.
 
         :return: The Auth Settings information dict.
         """
@@ -273,7 +256,7 @@ class Configuration(object):
         }
 
     def to_debug_report(self):
-        """Gets the essential information for debugging.
+        """Get the essential information for debugging.
 
         :return: The report for debugging.
         """
@@ -285,7 +268,7 @@ class Configuration(object):
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):
-        """Gets an array of host settings
+        """Get an array of host settings
 
         :return: An array of host settings
         """
@@ -296,10 +279,10 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index, variables=None):
+    def get_host_from_settings(self, index=0, variables=None):
         """Get host URL based on the index and variables.
 
-        :param index: array index of the host settings
+        :param index: array index of the host settings (default: 0)
         :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
@@ -310,23 +293,23 @@ class Configuration(object):
             server = servers[index]
         except IndexError:
             raise ValueError(
-                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
-                .format(index, len(servers)))
+                "Invalid index {0} when selecting the host settings. "
+                "Must be less than {1}".format(index, len(servers)))
 
         url = server['url']
 
-        # go through variable and assign a value
-        for variable_name in server['variables']:
-            server_variable = server['variables'][variable_name]
-            value = variables.get(variable_name, server_variable['default_value'])
+        # go through variables and replace placeholders
+        for variable_name, variable in server['variables'].items():
+            used_value = variables.get(variable_name, variable['default_value'])
 
-            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+            if 'enum_values' in variable \
+                    and used_value not in variable['enum_values']:
                 raise ValueError(
-                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
-                    .format(
+                    "The variable `{0}` in the host URL has invalid value "
+                    "{1}. Must be {2}.".format(
                         variable_name, variables[variable_name],
-                        server['variables'][variable_name]['enum_values']))
+                        variable['enum_values']))
 
-            url = url.replace("{" + variable_name + "}", value)
+            url = url.replace("{" + variable_name + "}", used_value)
 
         return url

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -296,41 +296,37 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index, variables={}):
-        """Gets host URL based on the index and variables
+    def get_host_from_settings(self, index, variables=None):
+        """Get host URL based on the index and variables.
+
         :param index: array index of the host settings
-        :param variables: hash of variable and the corresponding value
+        :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
-
+        variables = {} if variables is None else variables
         servers = self.get_host_settings()
 
-        # check array index out of bound
-        if index < 0 or index >= len(servers):
+        try:
+            server = servers[index]
+        except IndexError:
             raise ValueError(
-                "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
+                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
                 .format(index, len(servers)))
 
-        server = servers[index]
         url = server['url']
 
         # go through variable and assign a value
         for variable_name in server['variables']:
-            if variable_name in variables:
-                if variables[variable_name] in server['variables'][
-                        variable_name]['enum_values']:
-                    url = url.replace("{" + variable_name + "}",
-                                      variables[variable_name])
-                else:
-                    raise ValueError(
-                        "The variable `{}` in the host URL has invalid value {}. Must be {}."  # noqa: E501
-                        .format(
-                            variable_name, variables[variable_name],
-                            server['variables'][variable_name]['enum_values']))
-            else:
-                # use default value
-                url = url.replace(
-                    "{" + variable_name + "}",
-                    server['variables'][variable_name]['default_value'])
+            server_variable = server['variables'][variable_name]
+            value = variables.get(variable_name, server_variable['default_value'])
+
+            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+                raise ValueError(
+                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
+                    .format(
+                        variable_name, variables[variable_name],
+                        server['variables'][variable_name]['enum_values']))
+
+            url = url.replace("{" + variable_name + "}", value)
 
         return url

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -297,7 +297,8 @@ class Configuration(object):
 
         # go through variables and replace placeholders
         for variable_name, variable in server['variables'].items():
-            used_value = variables.get(variable_name, variable['default_value'])
+            used_value = variables.get(
+                variable_name, variable['default_value'])
 
             if 'enum_values' in variable \
                     and used_value not in variable['enum_values']:

--- a/samples/client/petstore/python-asyncio/petstore_api/configuration.py
+++ b/samples/client/petstore/python-asyncio/petstore_api/configuration.py
@@ -279,10 +279,10 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index=0, variables=None):
+    def get_host_from_settings(self, index, variables=None):
         """Get host URL based on the index and variables.
 
-        :param index: array index of the host settings (default: 0)
+        :param index: array index of the host settings
         :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -132,11 +132,6 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file."""
-        return self.__logger_file
-
-    @logger_file.setter
-    def logger_file(self, value):
         """The logger file.
 
         If the logger_file is None, then add stream handler and remove file
@@ -145,6 +140,10 @@ class Configuration(object):
         :param value: The logger_file path.
         :type: str
         """
+        return self.__logger_file
+
+    @logger_file.setter
+    def logger_file(self, value):
         self.__logger_file = value
         if self.__logger_file:
             # If set logging file,
@@ -156,16 +155,15 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Return debug status."""
-        return self.__debug
-
-    @debug.setter
-    def debug(self, value):
-        """Set debug status.
+        """The debug status.
 
         :param value: The debug status, True or False.
         :type: bool
         """
+        return self.__debug
+
+    @debug.setter
+    def debug(self, value):
         self.__debug = value
         if self.__debug:
             # if debug status is True, turn on debug logging
@@ -183,18 +181,17 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """Return the logger format."""
-        return self.__logger_format
-
-    @logger_format.setter
-    def logger_format(self, value):
-        """Set the logger format.
+        """The logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
         :param value: The format string.
         :type: str
         """
+        return self.__logger_format
+
+    @logger_format.setter
+    def logger_format(self, value):
         self.__logger_format = value
         self.logger_formatter = logging.Formatter(self.__logger_format)
 

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -132,14 +132,7 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file.
-
-        If the logger_file is None, then add stream handler and remove file
-        handler. Otherwise, add file handler and remove stream handler.
-
-        :param value: The logger_file path.
-        :type: str
-        """
+        """The logger file."""
         return self.__logger_file
 
     @logger_file.setter
@@ -163,16 +156,12 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Debug status
-
-        :param value: The debug status, True or False.
-        :type: bool
-        """
+        """Return debug status."""
         return self.__debug
 
     @debug.setter
     def debug(self, value):
-        """Debug status
+        """Set debug status.
 
         :param value: The debug status, True or False.
         :type: bool
@@ -194,18 +183,12 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """The logger format.
-
-        The logger_formatter will be updated when sets logger_format.
-
-        :param value: The format string.
-        :type: str
-        """
+        """Return the logger format."""
         return self.__logger_format
 
     @logger_format.setter
     def logger_format(self, value):
-        """The logger format.
+        """Set the logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
@@ -216,7 +199,7 @@ class Configuration(object):
         self.logger_formatter = logging.Formatter(self.__logger_format)
 
     def get_api_key_with_prefix(self, identifier):
-        """Gets API key (with prefix if set).
+        """Get API key (with prefix if set).
 
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
@@ -232,7 +215,7 @@ class Configuration(object):
                 return key
 
     def get_basic_auth_token(self):
-        """Gets HTTP basic authentication header (string).
+        """Get HTTP basic authentication header (string).
 
         :return: The token for basic HTTP authentication.
         """
@@ -241,7 +224,7 @@ class Configuration(object):
         ).get('authorization')
 
     def auth_settings(self):
-        """Gets Auth Settings dict for api client.
+        """Get Auth Settings dict for api client.
 
         :return: The Auth Settings information dict.
         """
@@ -277,7 +260,7 @@ class Configuration(object):
         }
 
     def to_debug_report(self):
-        """Gets the essential information for debugging.
+        """Get the essential information for debugging.
 
         :return: The report for debugging.
         """
@@ -289,7 +272,7 @@ class Configuration(object):
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):
-        """Gets an array of host settings
+        """Get an array of host settings
 
         :return: An array of host settings
         """
@@ -300,10 +283,10 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index, variables=None):
+    def get_host_from_settings(self, index=0, variables=None):
         """Get host URL based on the index and variables.
 
-        :param index: array index of the host settings
+        :param index: array index of the host settings (default: 0)
         :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
@@ -314,23 +297,23 @@ class Configuration(object):
             server = servers[index]
         except IndexError:
             raise ValueError(
-                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
-                .format(index, len(servers)))
+                "Invalid index {0} when selecting the host settings. "
+                "Must be less than {1}".format(index, len(servers)))
 
         url = server['url']
 
-        # go through variable and assign a value
-        for variable_name in server['variables']:
-            server_variable = server['variables'][variable_name]
-            value = variables.get(variable_name, server_variable['default_value'])
+        # go through variables and replace placeholders
+        for variable_name, variable in server['variables'].items():
+            used_value = variables.get(variable_name, variable['default_value'])
 
-            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+            if 'enum_values' in variable \
+                    and used_value not in variable['enum_values']:
                 raise ValueError(
-                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
-                    .format(
+                    "The variable `{0}` in the host URL has invalid value "
+                    "{1}. Must be {2}.".format(
                         variable_name, variables[variable_name],
-                        server['variables'][variable_name]['enum_values']))
+                        variable['enum_values']))
 
-            url = url.replace("{" + variable_name + "}", value)
+            url = url.replace("{" + variable_name + "}", used_value)
 
         return url

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -300,41 +300,37 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index, variables={}):
-        """Gets host URL based on the index and variables
+    def get_host_from_settings(self, index, variables=None):
+        """Get host URL based on the index and variables.
+
         :param index: array index of the host settings
-        :param variables: hash of variable and the corresponding value
+        :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
-
+        variables = {} if variables is None else variables
         servers = self.get_host_settings()
 
-        # check array index out of bound
-        if index < 0 or index >= len(servers):
+        try:
+            server = servers[index]
+        except IndexError:
             raise ValueError(
-                "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
+                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
                 .format(index, len(servers)))
 
-        server = servers[index]
         url = server['url']
 
         # go through variable and assign a value
         for variable_name in server['variables']:
-            if variable_name in variables:
-                if variables[variable_name] in server['variables'][
-                        variable_name]['enum_values']:
-                    url = url.replace("{" + variable_name + "}",
-                                      variables[variable_name])
-                else:
-                    raise ValueError(
-                        "The variable `{}` in the host URL has invalid value {}. Must be {}."  # noqa: E501
-                        .format(
-                            variable_name, variables[variable_name],
-                            server['variables'][variable_name]['enum_values']))
-            else:
-                # use default value
-                url = url.replace(
-                    "{" + variable_name + "}",
-                    server['variables'][variable_name]['default_value'])
+            server_variable = server['variables'][variable_name]
+            value = variables.get(variable_name, server_variable['default_value'])
+
+            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+                raise ValueError(
+                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
+                    .format(
+                        variable_name, variables[variable_name],
+                        server['variables'][variable_name]['enum_values']))
+
+            url = url.replace("{" + variable_name + "}", value)
 
         return url

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -301,7 +301,8 @@ class Configuration(object):
 
         # go through variables and replace placeholders
         for variable_name, variable in server['variables'].items():
-            used_value = variables.get(variable_name, variable['default_value'])
+            used_value = variables.get(
+                variable_name, variable['default_value'])
 
             if 'enum_values' in variable \
                     and used_value not in variable['enum_values']:

--- a/samples/client/petstore/python-experimental/petstore_api/configuration.py
+++ b/samples/client/petstore/python-experimental/petstore_api/configuration.py
@@ -283,10 +283,10 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index=0, variables=None):
+    def get_host_from_settings(self, index, variables=None):
         """Get host URL based on the index and variables.
 
-        :param index: array index of the host settings (default: 0)
+        :param index: array index of the host settings
         :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -132,11 +132,6 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file."""
-        return self.__logger_file
-
-    @logger_file.setter
-    def logger_file(self, value):
         """The logger file.
 
         If the logger_file is None, then add stream handler and remove file
@@ -145,6 +140,10 @@ class Configuration(object):
         :param value: The logger_file path.
         :type: str
         """
+        return self.__logger_file
+
+    @logger_file.setter
+    def logger_file(self, value):
         self.__logger_file = value
         if self.__logger_file:
             # If set logging file,
@@ -156,16 +155,15 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Return debug status."""
-        return self.__debug
-
-    @debug.setter
-    def debug(self, value):
-        """Set debug status.
+        """The debug status.
 
         :param value: The debug status, True or False.
         :type: bool
         """
+        return self.__debug
+
+    @debug.setter
+    def debug(self, value):
         self.__debug = value
         if self.__debug:
             # if debug status is True, turn on debug logging
@@ -183,18 +181,17 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """Return the logger format."""
-        return self.__logger_format
-
-    @logger_format.setter
-    def logger_format(self, value):
-        """Set the logger format.
+        """The logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
         :param value: The format string.
         :type: str
         """
+        return self.__logger_format
+
+    @logger_format.setter
+    def logger_format(self, value):
         self.__logger_format = value
         self.logger_formatter = logging.Formatter(self.__logger_format)
 

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -132,14 +132,7 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file.
-
-        If the logger_file is None, then add stream handler and remove file
-        handler. Otherwise, add file handler and remove stream handler.
-
-        :param value: The logger_file path.
-        :type: str
-        """
+        """The logger file."""
         return self.__logger_file
 
     @logger_file.setter
@@ -163,16 +156,12 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Debug status
-
-        :param value: The debug status, True or False.
-        :type: bool
-        """
+        """Return debug status."""
         return self.__debug
 
     @debug.setter
     def debug(self, value):
-        """Debug status
+        """Set debug status.
 
         :param value: The debug status, True or False.
         :type: bool
@@ -194,18 +183,12 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """The logger format.
-
-        The logger_formatter will be updated when sets logger_format.
-
-        :param value: The format string.
-        :type: str
-        """
+        """Return the logger format."""
         return self.__logger_format
 
     @logger_format.setter
     def logger_format(self, value):
-        """The logger format.
+        """Set the logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
@@ -216,7 +199,7 @@ class Configuration(object):
         self.logger_formatter = logging.Formatter(self.__logger_format)
 
     def get_api_key_with_prefix(self, identifier):
-        """Gets API key (with prefix if set).
+        """Get API key (with prefix if set).
 
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
@@ -232,7 +215,7 @@ class Configuration(object):
                 return key
 
     def get_basic_auth_token(self):
-        """Gets HTTP basic authentication header (string).
+        """Get HTTP basic authentication header (string).
 
         :return: The token for basic HTTP authentication.
         """
@@ -241,7 +224,7 @@ class Configuration(object):
         ).get('authorization')
 
     def auth_settings(self):
-        """Gets Auth Settings dict for api client.
+        """Get Auth Settings dict for api client.
 
         :return: The Auth Settings information dict.
         """
@@ -277,7 +260,7 @@ class Configuration(object):
         }
 
     def to_debug_report(self):
-        """Gets the essential information for debugging.
+        """Get the essential information for debugging.
 
         :return: The report for debugging.
         """
@@ -289,7 +272,7 @@ class Configuration(object):
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):
-        """Gets an array of host settings
+        """Get an array of host settings
 
         :return: An array of host settings
         """
@@ -300,10 +283,10 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index, variables=None):
+    def get_host_from_settings(self, index=0, variables=None):
         """Get host URL based on the index and variables.
 
-        :param index: array index of the host settings
+        :param index: array index of the host settings (default: 0)
         :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
@@ -314,23 +297,23 @@ class Configuration(object):
             server = servers[index]
         except IndexError:
             raise ValueError(
-                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
-                .format(index, len(servers)))
+                "Invalid index {0} when selecting the host settings. "
+                "Must be less than {1}".format(index, len(servers)))
 
         url = server['url']
 
-        # go through variable and assign a value
-        for variable_name in server['variables']:
-            server_variable = server['variables'][variable_name]
-            value = variables.get(variable_name, server_variable['default_value'])
+        # go through variables and replace placeholders
+        for variable_name, variable in server['variables'].items():
+            used_value = variables.get(variable_name, variable['default_value'])
 
-            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+            if 'enum_values' in variable \
+                    and used_value not in variable['enum_values']:
                 raise ValueError(
-                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
-                    .format(
+                    "The variable `{0}` in the host URL has invalid value "
+                    "{1}. Must be {2}.".format(
                         variable_name, variables[variable_name],
-                        server['variables'][variable_name]['enum_values']))
+                        variable['enum_values']))
 
-            url = url.replace("{" + variable_name + "}", value)
+            url = url.replace("{" + variable_name + "}", used_value)
 
         return url

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -300,41 +300,37 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index, variables={}):
-        """Gets host URL based on the index and variables
+    def get_host_from_settings(self, index, variables=None):
+        """Get host URL based on the index and variables.
+
         :param index: array index of the host settings
-        :param variables: hash of variable and the corresponding value
+        :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
-
+        variables = {} if variables is None else variables
         servers = self.get_host_settings()
 
-        # check array index out of bound
-        if index < 0 or index >= len(servers):
+        try:
+            server = servers[index]
+        except IndexError:
             raise ValueError(
-                "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
+                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
                 .format(index, len(servers)))
 
-        server = servers[index]
         url = server['url']
 
         # go through variable and assign a value
         for variable_name in server['variables']:
-            if variable_name in variables:
-                if variables[variable_name] in server['variables'][
-                        variable_name]['enum_values']:
-                    url = url.replace("{" + variable_name + "}",
-                                      variables[variable_name])
-                else:
-                    raise ValueError(
-                        "The variable `{}` in the host URL has invalid value {}. Must be {}."  # noqa: E501
-                        .format(
-                            variable_name, variables[variable_name],
-                            server['variables'][variable_name]['enum_values']))
-            else:
-                # use default value
-                url = url.replace(
-                    "{" + variable_name + "}",
-                    server['variables'][variable_name]['default_value'])
+            server_variable = server['variables'][variable_name]
+            value = variables.get(variable_name, server_variable['default_value'])
+
+            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+                raise ValueError(
+                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
+                    .format(
+                        variable_name, variables[variable_name],
+                        server['variables'][variable_name]['enum_values']))
+
+            url = url.replace("{" + variable_name + "}", value)
 
         return url

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -301,7 +301,8 @@ class Configuration(object):
 
         # go through variables and replace placeholders
         for variable_name, variable in server['variables'].items():
-            used_value = variables.get(variable_name, variable['default_value'])
+            used_value = variables.get(
+                variable_name, variable['default_value'])
 
             if 'enum_values' in variable \
                     and used_value not in variable['enum_values']:

--- a/samples/client/petstore/python-tornado/petstore_api/configuration.py
+++ b/samples/client/petstore/python-tornado/petstore_api/configuration.py
@@ -283,10 +283,10 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index=0, variables=None):
+    def get_host_from_settings(self, index, variables=None):
         """Get host URL based on the index and variables.
 
-        :param index: array index of the host settings (default: 0)
+        :param index: array index of the host settings
         :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -132,11 +132,6 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file."""
-        return self.__logger_file
-
-    @logger_file.setter
-    def logger_file(self, value):
         """The logger file.
 
         If the logger_file is None, then add stream handler and remove file
@@ -145,6 +140,10 @@ class Configuration(object):
         :param value: The logger_file path.
         :type: str
         """
+        return self.__logger_file
+
+    @logger_file.setter
+    def logger_file(self, value):
         self.__logger_file = value
         if self.__logger_file:
             # If set logging file,
@@ -156,16 +155,15 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Return debug status."""
-        return self.__debug
-
-    @debug.setter
-    def debug(self, value):
-        """Set debug status.
+        """The debug status.
 
         :param value: The debug status, True or False.
         :type: bool
         """
+        return self.__debug
+
+    @debug.setter
+    def debug(self, value):
         self.__debug = value
         if self.__debug:
             # if debug status is True, turn on debug logging
@@ -183,18 +181,17 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """Return the logger format."""
-        return self.__logger_format
-
-    @logger_format.setter
-    def logger_format(self, value):
-        """Set the logger format.
+        """The logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
         :param value: The format string.
         :type: str
         """
+        return self.__logger_format
+
+    @logger_format.setter
+    def logger_format(self, value):
         self.__logger_format = value
         self.logger_formatter = logging.Formatter(self.__logger_format)
 

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -132,14 +132,7 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file.
-
-        If the logger_file is None, then add stream handler and remove file
-        handler. Otherwise, add file handler and remove stream handler.
-
-        :param value: The logger_file path.
-        :type: str
-        """
+        """The logger file."""
         return self.__logger_file
 
     @logger_file.setter
@@ -163,16 +156,12 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Debug status
-
-        :param value: The debug status, True or False.
-        :type: bool
-        """
+        """Return debug status."""
         return self.__debug
 
     @debug.setter
     def debug(self, value):
-        """Debug status
+        """Set debug status.
 
         :param value: The debug status, True or False.
         :type: bool
@@ -194,18 +183,12 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """The logger format.
-
-        The logger_formatter will be updated when sets logger_format.
-
-        :param value: The format string.
-        :type: str
-        """
+        """Return the logger format."""
         return self.__logger_format
 
     @logger_format.setter
     def logger_format(self, value):
-        """The logger format.
+        """Set the logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
@@ -216,7 +199,7 @@ class Configuration(object):
         self.logger_formatter = logging.Formatter(self.__logger_format)
 
     def get_api_key_with_prefix(self, identifier):
-        """Gets API key (with prefix if set).
+        """Get API key (with prefix if set).
 
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
@@ -232,7 +215,7 @@ class Configuration(object):
                 return key
 
     def get_basic_auth_token(self):
-        """Gets HTTP basic authentication header (string).
+        """Get HTTP basic authentication header (string).
 
         :return: The token for basic HTTP authentication.
         """
@@ -241,7 +224,7 @@ class Configuration(object):
         ).get('authorization')
 
     def auth_settings(self):
-        """Gets Auth Settings dict for api client.
+        """Get Auth Settings dict for api client.
 
         :return: The Auth Settings information dict.
         """
@@ -277,7 +260,7 @@ class Configuration(object):
         }
 
     def to_debug_report(self):
-        """Gets the essential information for debugging.
+        """Get the essential information for debugging.
 
         :return: The report for debugging.
         """
@@ -289,7 +272,7 @@ class Configuration(object):
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):
-        """Gets an array of host settings
+        """Get an array of host settings
 
         :return: An array of host settings
         """
@@ -300,10 +283,10 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index, variables=None):
+    def get_host_from_settings(self, index=0, variables=None):
         """Get host URL based on the index and variables.
 
-        :param index: array index of the host settings
+        :param index: array index of the host settings (default: 0)
         :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
@@ -314,23 +297,23 @@ class Configuration(object):
             server = servers[index]
         except IndexError:
             raise ValueError(
-                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
-                .format(index, len(servers)))
+                "Invalid index {0} when selecting the host settings. "
+                "Must be less than {1}".format(index, len(servers)))
 
         url = server['url']
 
-        # go through variable and assign a value
-        for variable_name in server['variables']:
-            server_variable = server['variables'][variable_name]
-            value = variables.get(variable_name, server_variable['default_value'])
+        # go through variables and replace placeholders
+        for variable_name, variable in server['variables'].items():
+            used_value = variables.get(variable_name, variable['default_value'])
 
-            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+            if 'enum_values' in variable \
+                    and used_value not in variable['enum_values']:
                 raise ValueError(
-                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
-                    .format(
+                    "The variable `{0}` in the host URL has invalid value "
+                    "{1}. Must be {2}.".format(
                         variable_name, variables[variable_name],
-                        server['variables'][variable_name]['enum_values']))
+                        variable['enum_values']))
 
-            url = url.replace("{" + variable_name + "}", value)
+            url = url.replace("{" + variable_name + "}", used_value)
 
         return url

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -300,41 +300,37 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index, variables={}):
-        """Gets host URL based on the index and variables
+    def get_host_from_settings(self, index, variables=None):
+        """Get host URL based on the index and variables.
+
         :param index: array index of the host settings
-        :param variables: hash of variable and the corresponding value
+        :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
-
+        variables = {} if variables is None else variables
         servers = self.get_host_settings()
 
-        # check array index out of bound
-        if index < 0 or index >= len(servers):
+        try:
+            server = servers[index]
+        except IndexError:
             raise ValueError(
-                "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
+                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
                 .format(index, len(servers)))
 
-        server = servers[index]
         url = server['url']
 
         # go through variable and assign a value
         for variable_name in server['variables']:
-            if variable_name in variables:
-                if variables[variable_name] in server['variables'][
-                        variable_name]['enum_values']:
-                    url = url.replace("{" + variable_name + "}",
-                                      variables[variable_name])
-                else:
-                    raise ValueError(
-                        "The variable `{}` in the host URL has invalid value {}. Must be {}."  # noqa: E501
-                        .format(
-                            variable_name, variables[variable_name],
-                            server['variables'][variable_name]['enum_values']))
-            else:
-                # use default value
-                url = url.replace(
-                    "{" + variable_name + "}",
-                    server['variables'][variable_name]['default_value'])
+            server_variable = server['variables'][variable_name]
+            value = variables.get(variable_name, server_variable['default_value'])
+
+            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+                raise ValueError(
+                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
+                    .format(
+                        variable_name, variables[variable_name],
+                        server['variables'][variable_name]['enum_values']))
+
+            url = url.replace("{" + variable_name + "}", value)
 
         return url

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -301,7 +301,8 @@ class Configuration(object):
 
         # go through variables and replace placeholders
         for variable_name, variable in server['variables'].items():
-            used_value = variables.get(variable_name, variable['default_value'])
+            used_value = variables.get(
+                variable_name, variable['default_value'])
 
             if 'enum_values' in variable \
                     and used_value not in variable['enum_values']:

--- a/samples/client/petstore/python/petstore_api/configuration.py
+++ b/samples/client/petstore/python/petstore_api/configuration.py
@@ -283,10 +283,10 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index=0, variables=None):
+    def get_host_from_settings(self, index, variables=None):
         """Get host URL based on the index and variables.
 
-        :param index: array index of the host settings (default: 0)
+        :param index: array index of the host settings
         :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -132,11 +132,6 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file."""
-        return self.__logger_file
-
-    @logger_file.setter
-    def logger_file(self, value):
         """The logger file.
 
         If the logger_file is None, then add stream handler and remove file
@@ -145,6 +140,10 @@ class Configuration(object):
         :param value: The logger_file path.
         :type: str
         """
+        return self.__logger_file
+
+    @logger_file.setter
+    def logger_file(self, value):
         self.__logger_file = value
         if self.__logger_file:
             # If set logging file,
@@ -156,16 +155,15 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Return debug status."""
-        return self.__debug
-
-    @debug.setter
-    def debug(self, value):
-        """Set debug status.
+        """The debug status.
 
         :param value: The debug status, True or False.
         :type: bool
         """
+        return self.__debug
+
+    @debug.setter
+    def debug(self, value):
         self.__debug = value
         if self.__debug:
             # if debug status is True, turn on debug logging
@@ -183,18 +181,17 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """Return the logger format."""
-        return self.__logger_format
-
-    @logger_format.setter
-    def logger_format(self, value):
-        """Set the logger format.
+        """The logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
         :param value: The format string.
         :type: str
         """
+        return self.__logger_format
+
+    @logger_format.setter
+    def logger_format(self, value):
         self.__logger_format = value
         self.logger_formatter = logging.Formatter(self.__logger_format)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -132,14 +132,7 @@ class Configuration(object):
 
     @property
     def logger_file(self):
-        """The logger file.
-
-        If the logger_file is None, then add stream handler and remove file
-        handler. Otherwise, add file handler and remove stream handler.
-
-        :param value: The logger_file path.
-        :type: str
-        """
+        """The logger file."""
         return self.__logger_file
 
     @logger_file.setter
@@ -163,16 +156,12 @@ class Configuration(object):
 
     @property
     def debug(self):
-        """Debug status
-
-        :param value: The debug status, True or False.
-        :type: bool
-        """
+        """Return debug status."""
         return self.__debug
 
     @debug.setter
     def debug(self, value):
-        """Debug status
+        """Set debug status.
 
         :param value: The debug status, True or False.
         :type: bool
@@ -194,18 +183,12 @@ class Configuration(object):
 
     @property
     def logger_format(self):
-        """The logger format.
-
-        The logger_formatter will be updated when sets logger_format.
-
-        :param value: The format string.
-        :type: str
-        """
+        """Return the logger format."""
         return self.__logger_format
 
     @logger_format.setter
     def logger_format(self, value):
-        """The logger format.
+        """Set the logger format.
 
         The logger_formatter will be updated when sets logger_format.
 
@@ -216,7 +199,7 @@ class Configuration(object):
         self.logger_formatter = logging.Formatter(self.__logger_format)
 
     def get_api_key_with_prefix(self, identifier):
-        """Gets API key (with prefix if set).
+        """Get API key (with prefix if set).
 
         :param identifier: The identifier of apiKey.
         :return: The token for api key authentication.
@@ -232,7 +215,7 @@ class Configuration(object):
                 return key
 
     def get_basic_auth_token(self):
-        """Gets HTTP basic authentication header (string).
+        """Get HTTP basic authentication header (string).
 
         :return: The token for basic HTTP authentication.
         """
@@ -241,7 +224,7 @@ class Configuration(object):
         ).get('authorization')
 
     def auth_settings(self):
-        """Gets Auth Settings dict for api client.
+        """Get Auth Settings dict for api client.
 
         :return: The Auth Settings information dict.
         """
@@ -285,7 +268,7 @@ class Configuration(object):
         }
 
     def to_debug_report(self):
-        """Gets the essential information for debugging.
+        """Get the essential information for debugging.
 
         :return: The report for debugging.
         """
@@ -297,7 +280,7 @@ class Configuration(object):
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self):
-        """Gets an array of host settings
+        """Get an array of host settings
 
         :return: An array of host settings
         """
@@ -355,23 +338,23 @@ class Configuration(object):
             server = servers[index]
         except IndexError:
             raise ValueError(
-                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
-                .format(index, len(servers)))
+                "Invalid index {0} when selecting the host settings. "
+                "Must be less than {1}".format(index, len(servers)))
 
         url = server['url']
 
-        # go through variable and assign a value
-        for variable_name in server['variables']:
-            server_variable = server['variables'][variable_name]
-            value = variables.get(variable_name, server_variable['default_value'])
+        # go through variables and replace placeholders
+        for variable_name, variable in server['variables'].items():
+            used_value = variables.get(variable_name, variable['default_value'])
 
-            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+            if 'enum_values' in variable \
+                    and used_value not in variable['enum_values']:
                 raise ValueError(
-                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
-                    .format(
+                    "The variable `{0}` in the host URL has invalid value "
+                    "{1}. Must be {2}.".format(
                         variable_name, variables[variable_name],
-                        server['variables'][variable_name]['enum_values']))
+                        variable['enum_values']))
 
-            url = url.replace("{" + variable_name + "}", value)
+            url = url.replace("{" + variable_name + "}", used_value)
 
         return url

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -341,41 +341,37 @@ class Configuration(object):
             }
         ]
 
-    def get_host_from_settings(self, index, variables={}):
-        """Gets host URL based on the index and variables
+    def get_host_from_settings(self, index, variables=None):
+        """Get host URL based on the index and variables.
+
         :param index: array index of the host settings
-        :param variables: hash of variable and the corresponding value
+        :param variables: mapping of variable and the corresponding value
         :return: URL based on host settings
         """
-
+        variables = {} if variables is None else variables
         servers = self.get_host_settings()
 
-        # check array index out of bound
-        if index < 0 or index >= len(servers):
+        try:
+            server = servers[index]
+        except IndexError:
             raise ValueError(
-                "Invalid index {} when selecting the host settings. Must be less than {}"  # noqa: E501
+                "Invalid index {0} when selecting the host settings. Must be less than {1}"  # noqa: E501
                 .format(index, len(servers)))
 
-        server = servers[index]
         url = server['url']
 
         # go through variable and assign a value
         for variable_name in server['variables']:
-            if variable_name in variables:
-                if variables[variable_name] in server['variables'][
-                        variable_name]['enum_values']:
-                    url = url.replace("{" + variable_name + "}",
-                                      variables[variable_name])
-                else:
-                    raise ValueError(
-                        "The variable `{}` in the host URL has invalid value {}. Must be {}."  # noqa: E501
-                        .format(
-                            variable_name, variables[variable_name],
-                            server['variables'][variable_name]['enum_values']))
-            else:
-                # use default value
-                url = url.replace(
-                    "{" + variable_name + "}",
-                    server['variables'][variable_name]['default_value'])
+            server_variable = server['variables'][variable_name]
+            value = variables.get(variable_name, server_variable['default_value'])
+
+            if 'enum_values' in server_variable and value not in server_variable['enum_values']:
+                raise ValueError(
+                    "The variable `{0}` in the host URL has invalid value {1}. Must be {2}."  # noqa: E501
+                    .format(
+                        variable_name, variables[variable_name],
+                        server['variables'][variable_name]['enum_values']))
+
+            url = url.replace("{" + variable_name + "}", value)
 
         return url

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -342,7 +342,8 @@ class Configuration(object):
 
         # go through variables and replace placeholders
         for variable_name, variable in server['variables'].items():
-            used_value = variables.get(variable_name, variable['default_value'])
+            used_value = variables.get(
+                variable_name, variable['default_value'])
 
             if 'enum_values' in variable \
                     and used_value not in variable['enum_values']:


### PR DESCRIPTION
Avoid using mutable default arguments in Python.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


--
cc @taxpon (2017/07) @frol (2017/07) @mbohlool (2017/07) @cbornet (2017/09) @kenjones-cisco (2017/11) @tomplus (2018/10) @Jyhess (2019/01) @slash-arun (2019/11) @spacether (2019/11)