### PR TITLE
[BUG][R] use loadNamespace instead of package:pkgName string

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -276,7 +276,7 @@
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "{{returnType}}", "package:{{packageName}}"),
+          self$apiClient$deserialize(resp, "{{returnType}}", loadNamespace("{{packageName}}")),
           error = function(e){
            {{#useDefaultExceptionHandling}}
              stop("Failed to deserialize response")

--- a/modules/openapi-generator/src/main/resources/r/model.mustache
+++ b/modules/openapi-generator/src/main/resources/r/model.mustache
@@ -145,7 +145,7 @@
       {{#vars}}
       if (!is.null({{classname}}Object$`{{baseName}}`)) {
         {{#isContainer}}
-        self$`{{baseName}}` <- ApiClient$new()$deserializeObj({{classname}}Object$`{{baseName}}`, "{{dataType}}", "package:{{packageName}}")
+        self$`{{baseName}}` <- ApiClient$new()$deserializeObj({{classname}}Object$`{{baseName}}`, "{{dataType}}", loadNamespace("{{packageName}}"))
         {{/isContainer}}
         {{^isContainer}}
         {{#isPrimitiveType}}
@@ -226,7 +226,7 @@
       {{#vars}}
       {{! AAPI - added condition for handling container type of parameters, map and array}}
       {{#isContainer}}
-      self$`{{baseName}}` <- ApiClient$new()$deserializeObj({{classname}}Object$`{{baseName}}`, "{{dataType}}","package:{{packageName}}")
+      self$`{{baseName}}` <- ApiClient$new()$deserializeObj({{classname}}Object$`{{baseName}}`, "{{dataType}}", loadNamespace("{{packageName}}"))
       {{/isContainer}}
       {{^isContainer}}
       {{#isPrimitiveType}}

--- a/samples/client/petstore/R/R/pet.R
+++ b/samples/client/petstore/R/R/pet.R
@@ -107,10 +107,10 @@ Pet <- R6::R6Class(
         self$`name` <- PetObject$`name`
       }
       if (!is.null(PetObject$`photoUrls`)) {
-        self$`photoUrls` <- ApiClient$new()$deserializeObj(PetObject$`photoUrls`, "array[character]", "package:petstore")
+        self$`photoUrls` <- ApiClient$new()$deserializeObj(PetObject$`photoUrls`, "array[character]", loadNamespace("petstore"))
       }
       if (!is.null(PetObject$`tags`)) {
-        self$`tags` <- ApiClient$new()$deserializeObj(PetObject$`tags`, "array[Tag]", "package:petstore")
+        self$`tags` <- ApiClient$new()$deserializeObj(PetObject$`tags`, "array[Tag]", loadNamespace("petstore"))
       }
       if (!is.null(PetObject$`status`)) {
         self$`status` <- PetObject$`status`
@@ -169,8 +169,8 @@ Pet <- R6::R6Class(
       self$`id` <- PetObject$`id`
       self$`category` <- Category$new()$fromJSON(jsonlite::toJSON(PetObject$category, auto_unbox = TRUE, digits = NA))
       self$`name` <- PetObject$`name`
-      self$`photoUrls` <- ApiClient$new()$deserializeObj(PetObject$`photoUrls`, "array[character]","package:petstore")
-      self$`tags` <- ApiClient$new()$deserializeObj(PetObject$`tags`, "array[Tag]","package:petstore")
+      self$`photoUrls` <- ApiClient$new()$deserializeObj(PetObject$`photoUrls`, "array[character]", loadNamespace("petstore"))
+      self$`tags` <- ApiClient$new()$deserializeObj(PetObject$`tags`, "array[Tag]", loadNamespace("petstore"))
       self$`status` <- PetObject$`status`
       self
     }

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -469,7 +469,7 @@ PetApi <- R6::R6Class(
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "array[Pet]", "package:petstore"),
+          self$apiClient$deserialize(resp, "array[Pet]", loadNamespace("petstore")),
           error = function(e){
              stop("Failed to deserialize response")
           }
@@ -521,7 +521,7 @@ PetApi <- R6::R6Class(
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "array[Pet]", "package:petstore"),
+          self$apiClient$deserialize(resp, "array[Pet]", loadNamespace("petstore")),
           error = function(e){
              stop("Failed to deserialize response")
           }
@@ -577,7 +577,7 @@ PetApi <- R6::R6Class(
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "Pet", "package:petstore"),
+          self$apiClient$deserialize(resp, "Pet", loadNamespace("petstore")),
           error = function(e){
              stop("Failed to deserialize response")
           }
@@ -739,7 +739,7 @@ PetApi <- R6::R6Class(
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "ModelApiResponse", "package:petstore"),
+          self$apiClient$deserialize(resp, "ModelApiResponse", loadNamespace("petstore")),
           error = function(e){
              stop("Failed to deserialize response")
           }

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -254,7 +254,7 @@ StoreApi <- R6::R6Class(
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "map(integer)", "package:petstore"),
+          self$apiClient$deserialize(resp, "map(integer)", loadNamespace("petstore")),
           error = function(e){
              stop("Failed to deserialize response")
           }
@@ -306,7 +306,7 @@ StoreApi <- R6::R6Class(
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "Order", "package:petstore"),
+          self$apiClient$deserialize(resp, "Order", loadNamespace("petstore")),
           error = function(e){
              stop("Failed to deserialize response")
           }
@@ -360,7 +360,7 @@ StoreApi <- R6::R6Class(
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "Order", "package:petstore"),
+          self$apiClient$deserialize(resp, "Order", loadNamespace("petstore")),
           error = function(e){
              stop("Failed to deserialize response")
           }

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -521,7 +521,7 @@ UserApi <- R6::R6Class(
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "User", "package:petstore"),
+          self$apiClient$deserialize(resp, "User", loadNamespace("petstore")),
           error = function(e){
              stop("Failed to deserialize response")
           }
@@ -577,7 +577,7 @@ UserApi <- R6::R6Class(
 
       if (httr::status_code(resp) >= 200 && httr::status_code(resp) <= 299) {
         deserializedRespObj <- tryCatch(
-          self$apiClient$deserialize(resp, "character", "package:petstore"),
+          self$apiClient$deserialize(resp, "character", loadNamespace("petstore")),
           error = function(e){
              stop("Failed to deserialize response")
           }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Hi William,  @wing328 

This change makes use of `loadNamespace` instead of `package:{{packageName}}`.
The latter requires that the package be attached to the search path when using
`as.environment` (this can cause issues when it is not). The current change loads
the namespace before its use. 
<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc: @Ramanth @saigiridhar21 