### PR TITLE
[Ruby] Fix typo in description

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/configuration.mustache
@@ -217,13 +217,13 @@ module {{moduleName}}
       {{#servers}}
         {
           url: "{{{url}}}",
-          description: "{{{description}}}{{^description}}No descriptoin provided{{/description}}",
+          description: "{{{description}}}{{^description}}No description provided{{/description}}",
           {{#variables}}
           {{#-first}}
           variables: {
           {{/-first}}
             {{{name}}}: {
-                description: "{{{description}}}{{^description}}No descriptoin provided{{/description}}",
+                description: "{{{description}}}{{^description}}No description provided{{/description}}",
                 default_value: "{{{defaultValue}}}",
                 {{#enumValues}}
                 {{#-first}}


### PR DESCRIPTION
Simple typo in Ruby client.

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

--
cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)