### PR TITLE
[Python] Add 'supportLargeModel' tag to handle unusually large OAS data type

### DIFF
--- a/docs/generators/python-experimental.md
+++ b/docs/generators/python-experimental.md
@@ -12,4 +12,5 @@ sidebar_label: python-experimental
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |generateSourceCodeOnly|Specifies that only a library source code is to be generated.| |false|
+|supportLargeModel|Generate files that can support unusually large data types, such as data types with more than 255 properties.| |false|
 |library|library template (sub-template) to use: asyncio, tornado, urllib3| |urllib3|

--- a/docs/generators/python.md
+++ b/docs/generators/python.md
@@ -12,4 +12,5 @@ sidebar_label: python
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |generateSourceCodeOnly|Specifies that only a library source code is to be generated.| |false|
+|supportLargeModel|Generate files that can support unusually large data types, such as data types with more than 255 properties.| |false|
 |library|library template (sub-template) to use: asyncio, tornado, urllib3| |urllib3|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -245,6 +245,12 @@ public class CodegenConstants {
     public static final String SOURCECODEONLY_GENERATION = "generateSourceCodeOnly";
     public static final String SOURCECODEONLY_GENERATION_DESC = "Specifies that only a library source code is to be generated.";
 
+    // Some languages may have limitations such as max 255 arguments per function (e.g. Java, Python < 3.7).
+    // This may cause problems during compilation if the generated code exceeds language-specific limits, which could
+    // happen when at least one OpenAPI data type is unusually large.
+    public static final String SUPPORT_LARGE_MODEL = "supportLargeModel";
+    public static final String SUPPORT_LARGE_MODEL_DESC = "Generate files that can support unusually large data types, such as data types with more than 255 properties.";
+
     public static final String PARCELIZE_MODELS = "parcelizeModels";
     public static final String PARCELIZE_MODELS_DESC = "toggle \"@Parcelize\" for generated models";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -151,6 +151,8 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
                 .defaultValue(Boolean.TRUE.toString()));
         cliOptions.add(new CliOption(CodegenConstants.SOURCECODEONLY_GENERATION, CodegenConstants.SOURCECODEONLY_GENERATION_DESC)
                 .defaultValue(Boolean.FALSE.toString()));
+        cliOptions.add(new CliOption(CodegenConstants.SUPPORT_LARGE_MODEL, CodegenConstants.SUPPORT_LARGE_MODEL_DESC)
+                .defaultValue(Boolean.FALSE.toString()));
 
         supportedLibraries.put("urllib3", "urllib3-based client");
         supportedLibraries.put("asyncio", "Asyncio-based client (python 3.5+)");
@@ -195,6 +197,10 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         Boolean generateSourceCodeOnly = false;
         if (additionalProperties.containsKey(CodegenConstants.SOURCECODEONLY_GENERATION)) {
             generateSourceCodeOnly = Boolean.valueOf(additionalProperties.get(CodegenConstants.SOURCECODEONLY_GENERATION).toString());
+        }
+        Boolean supportLargeModel = false;
+        if (additionalProperties.containsKey(CodegenConstants.SUPPORT_LARGE_MODEL)) {
+            supportLargeModel = Boolean.valueOf(additionalProperties.get(CodegenConstants.SUPPORT_LARGE_MODEL).toString());
         }
 
         additionalProperties.put(CodegenConstants.PROJECT_NAME, projectName);

--- a/modules/openapi-generator/src/main/resources/python/model.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model.mustache
@@ -57,7 +57,12 @@ class {{classname}}(object):
     }
 {{/discriminator}}
 
+{{^supportLargeModel}}
     def __init__(self{{#vars}}, {{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}{{/vars}}, local_vars_configuration=None):  # noqa: E501
+{{/supportLargeModel}}
+{{#supportLargeModel}}
+    def __init__(self{{#vars}}{{#required}}, {{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}{{/required}}{{/vars}}, local_vars_configuration=None):  # noqa: E501
+{{/supportLargeModel}}
         """{{classname}} - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -74,11 +79,21 @@ class {{classname}}(object):
 {{/required}}
 {{^required}}
 {{#isNullable}}
+{{^supportLargeModel}}
         self.{{name}} = {{name}}
+{{/supportLargeModel}}
+{{#supportLargeModel}}
+        self.{{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}
+{{/supportLargeModel}}
 {{/isNullable}}
 {{^isNullable}}
+{{^supportLargeModel}}
         if {{name}} is not None:
             self.{{name}} = {{name}}
+{{/supportLargeModel}}
+{{#supportLargeModel}}
+        self.{{name}}={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}
+{{/supportLargeModel}}
 {{/isNullable}}
 {{/required}}
 {{/vars}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PythonClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/PythonClientOptionsProvider.java
@@ -44,6 +44,7 @@ public class PythonClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, "true")
                 .put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true")
                 .put(CodegenConstants.SOURCECODEONLY_GENERATION, "false")
+                .put(CodegenConstants.SUPPORT_LARGE_MODEL, "false")
                 .put(CodegenConstants.LIBRARY, "urllib3")
                 .build();
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR fixes #4600 by introducing a new **supportLargeModel** tag. Some languages have limitations such as max 255 arguments per function (Java, Python < 3.7) or 256 arguments (Eiffel).

This can be a problem for some of the generated code when the OAS data types are unusually large. For example, the Python model.mustache template generates a __init__ function. The function arguments are the properties defined in the data type. However, because the OpenAPI spec does not set a max limit for the number of properties in a data type, this means a data type could have a list of 300 properties. But until version 3.7, python functions cannot have more than 255 arguments.

This PR includes modifications for Python, and potentially in the future it could be done for other languages. This is because every language has its own set of limits.
If the code generator is invoked without the supportLargeModel tag, the generator is exactly the same as before. This ensures this does not break any backward compatibility.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
