### PR TITLE
[asciidoctor] javadoc: add missing tag for declared exception

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocSampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/asciidoc/AsciidocSampleGeneratorTest.java
@@ -64,6 +64,7 @@ public class AsciidocSampleGeneratorTest {
 
     /**
      * ensure api-docs.json includes sample and spec files directory as attributes.
+     * @throws Exception exception
      */
     @Test
     public void testSampleAsciidocMarkupGenerationFromJsonWithAttributes() throws Exception {
@@ -75,6 +76,7 @@ public class AsciidocSampleGeneratorTest {
 
     /**
      * ensure api-docs.json includes sample and spec files into markup.
+     * @throws Exception exception
      */
     @Test
     public void testSampleAsciidocMarkupGenerationFromJsonWithIncludes() throws Exception {
@@ -98,6 +100,7 @@ public class AsciidocSampleGeneratorTest {
 
     /**
      * markup doc header content.
+     * @throws Exception exception
      */
     @Test
     public void testSampleAsciidocMarkupGenerationFromJsonWithContent() throws Exception {
@@ -108,6 +111,7 @@ public class AsciidocSampleGeneratorTest {
 
     /**
      * fix: parameter name unchanged.
+     * @throws Exception exception
      */
     @Test
     public void testSampleAsciidocMarkupGenerationParameterNameUnchanged() throws Exception {
@@ -117,6 +121,7 @@ public class AsciidocSampleGeneratorTest {
 
     /**
      * added apikey info in access section.
+     * @throws Exception exception
      */
     @Test
     public void testSampleAsciidocMarkupGenerationAccessApiKey() throws Exception {
@@ -130,6 +135,7 @@ public class AsciidocSampleGeneratorTest {
 
     /**
      * no form params in this sample spec.
+     * @throws Exception exception
      */
     @Test
     public void testSampleAsciidocMarkupGenerationWithoutFormParameter() throws Exception {


### PR DESCRIPTION
Fix Javadoc warnings

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
