### PR TITLE
[typescript-rxjs][client] Unnecessary imports occurs when using allOf

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/modelAllOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/modelAllOf.mustache
@@ -1,0 +1,14 @@
+{{#hasImports}}
+import {
+    {{#imports}}
+    {{{.}}},
+    {{/imports}}
+} from './';
+
+{{/hasImports}}
+/**
+ * @type {{classname}}{{#description}}
+ * {{{description}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#allOf}}{{{.}}}{{^-last}} & {{/-last}}{{/allOf}};

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/models.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/models.mustache
@@ -2,6 +2,6 @@
 {{>licenseInfo}}
 {{#models}}
 {{#model}}
-{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{#allOf}}{{#-first}}{{>modelAllOf}}{{/-first}}{{/allOf}}{{^isEnum}}{{^oneOf}}{{^allOf}}{{>modelGeneric}}{{/allOf}}{{/oneOf}}{{/isEnum}}
 {{/model}}
 {{/models}}


### PR DESCRIPTION
fixes #4629

Hello.
When using rxjs, a warning occurred in unused import.
I tried to fix it, so please take a look if you like.

Before
```js
// tslint:disable
/**
 * My application
 * My application
 *
 * The version of the OpenAPI document: 1.0.0
 * 
 *
 * NOTE: This class is auto generated by OpenAPI Generator (https://openapi-generator.tech).
 * https://openapi-generator.tech
 * Do not edit the class manually.
 */

 import {
     Box,
     Response,
 } from './';

 /**
  * @export
  * @interface BoxResponse
  */
 export interface BoxResponse extends Box, Response{
     /**
      * @type {string}
      * @memberof BoxResponse
      */
     status?: BoxResponseStatusEnum;
     /**
      * @type {number}
      * @memberof BoxResponse
      */
     id?: number;
     /**
      * @type {string}
      * @memberof BoxResponse
      */
     name?: string;
 }

 /**
  * @export
  * @enum {string}
  */
 export enum BoxResponseStatusEnum {
     Success = 'success',
     Error = 'error'
 }
```

After
```js
// tslint:disable
/**
 * Myroad api
 * Myroad user api document
 *
 * The version of the OpenAPI document: 1.0.0
 * 
 *
 * NOTE: This class is auto generated by OpenAPI Generator (https://openapi-generator.tech).
 * https://openapi-generator.tech
 * Do not edit the class manually.
 */

import {
    Box,
    Response,
} from './';

/**
 * @type BoxesResponse
 * @export
 */
export type BoxesResponse = Box & Response;
```

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.



@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11)