### PR TITLE
[BUG][PHP] Parameter property style not fully implemented (related to…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -174,6 +174,7 @@ public class CodegenParameter {
         output.isListContainer = this.isListContainer;
         output.isMapContainer = this.isMapContainer;
         output.isExplode = this.isExplode;
+        output.style = this.style;
 
         return output;
     }
@@ -249,7 +250,8 @@ public class CodegenParameter {
             Objects.equals(minItems, that.minItems) &&
             Objects.equals(uniqueItems, that.uniqueItems) &&
             Objects.equals(multipleOf, that.multipleOf) &&
-            Objects.equals(isExplode, that.isExplode);
+            Objects.equals(isExplode, that.isExplode) &&
+            Objects.equals(style, that.style);
     }
 
     @Override
@@ -319,7 +321,8 @@ public class CodegenParameter {
             minItems,
             uniqueItems,
             multipleOf,
-            isExplode);
+            isExplode,
+            style);
     }
 
     @java.lang.Override
@@ -390,6 +393,7 @@ public class CodegenParameter {
                 ", uniqueItems=" + uniqueItems +
                 ", multipleOf=" + multipleOf +
                 ", isExplode=" + isExplode +
+                ", style='" + style + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
… PR4042)

(Fixes issue #4641)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@jebentier @dkarlovi @mandrean @jfastnacht  @ackintosh @ybelenko @renepardon 

PR #4042 aims to expose style and explode parameter properties to mustache templates. However, this only fully works inside allParams loops - queryParams only receive the explode property, while style remains empty.

The reason for this is because CodegenParameter.java has not fully implemented the style property: it contains only its declaration as a property, but it doesn't deal with it inside its methods - explode, however, is fully implemented there.

I got into this because I'm dealing with PR #3984, which I need to generate a library. Unfortunately, that code is broken due to always getting an empty style, since it loops queryParams. This last one receives copies of allParams parameters, and since the style property is not being copied, it remains empty.