### PR TITLE
[dart-dio] Fixes issue where only some instances of List or Map were replaced wi…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -285,37 +285,26 @@ public class DartDioClientCodegen extends DartClientCodegen {
             property.isNullable = true;
         }
 
-        if (property.isListContainer) {
-            //Updates any List properties on a model to a BuiltList. This happens in post processing rather
-            //than type mapping as we only want this to apply to models, not every other class.
-            if ("List".equals(property.baseType)) {
-                property.setDatatype(
-                    property.dataType.replaceAll(property.baseType, "BuiltList"));
-                property.setBaseType("BuiltList");
-                model.imports.add("BuiltList");
-                if ("Object".equals(property.items.baseType)) {
-                    property.setDatatype(
-                        property.dataType.replaceAll("Object", "JsonObject"));
-                    property.items.setDatatype("JsonObject");
-                    model.imports.add("JsonObject");
-                }
-            }
-        }
-        if (property.isMapContainer) {
-            //Updates any List properties on a model to a BuiltList. This happens in post processing rather
-            //than type mapping as we only want this to apply to models, not every other class.
-            if ("Map".equals(property.baseType)) {
-                property.setDatatype(property.dataType.replaceAll(property.baseType, "BuiltMap"));
-                property.setBaseType("BuiltMap");
-                model.imports.add("BuiltMap");
-                if ("Object".equals(property.items.baseType)) {
-                    property.setDatatype(property.dataType.replaceAll("Object", "JsonObject"));
-                    property.items.setDatatype("JsonObject");
-                    model.imports.add("JsonObject");
-                }
-            }
-        }
+        property.setDatatype(property.getDataType()
+                .replaceAll("\\bList\\b", "BuiltList")
+                .replaceAll("\\bMap\\b", "BuiltMap")
+                .replaceAll("\\bObject\\b", "JsonObject")
+        );
+        property.setBaseType(property.getBaseType()
+                .replaceAll("\\bList\\b", "BuiltList")
+                .replaceAll("\\bMap\\b", "BuiltMap")
+                .replaceAll("\\bObject\\b", "JsonObject")
+        );
 
+        if (property.dataType.contains("BuiltList")) {
+            model.imports.add("BuiltList");
+        }
+        if (property.dataType.contains("BuiltMap")) {
+            model.imports.add("BuiltMap");
+        }
+        if (property.dataType.contains("JsonObject")) {
+            model.imports.add("JsonObject");
+        }
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart-dio/class.mustache
@@ -10,8 +10,6 @@ abstract class {{classname}} implements Built<{{classname}}, {{classname}}Builde
     {{#isNullable}}
         @nullable
     {{/isNullable}}
-
-    {{#description}}/* {{{description}}} */{{/description}}
     @BuiltValueField(wireName: '{{baseName}}')
     {{{dataType}}} get {{name}};
     {{#allowableValues}}


### PR DESCRIPTION
Fixes issue where only some instances of List or Map were replaced with Built equivalents

If there was a type that had a nested type of List or Map, e.g. `Map<String, List<String>>` only the outer types would be replaced with the Built variants, causing issues when running the builder.
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

CC @ircecho @swipesight @jaumard @nickmeinhold