### PR TITLE
[go] Fix multi-value path params in go

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -376,7 +376,6 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         // this will only import "fmt" and "strings" if there are items in pathParams
         for (CodegenOperation operation : operations) {
             if (operation.pathParams != null && operation.pathParams.size() > 0) {
-                imports.add(createMapping("import", "fmt"));
                 imports.add(createMapping("import", "strings"));
                 break; //just need to import once
             }

--- a/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
@@ -78,7 +78,8 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "{{{path}}}"{{#pathParams}}
-	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", {{paramName}})), -1){{/pathParams}}
+	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.QueryEscape(parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")) , -1)
+	{{/pathParams}}
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -78,7 +78,8 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "{{{path}}}"{{#pathParams}}
-	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", {{paramName}})), -1){{/pathParams}}
+	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.QueryEscape(parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")) , -1)
+	{{/pathParams}}
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -43,7 +43,6 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/another-fake/dummy"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -44,7 +44,6 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/create_xml_item"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -120,7 +119,6 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/boolean"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -217,7 +215,6 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/composite"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -318,7 +315,6 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/number"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -415,7 +411,6 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/string"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -504,7 +499,6 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileS
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/body-with-file-schema"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -572,7 +566,6 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/body-with-query-params"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -643,7 +636,6 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -757,7 +749,6 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -901,7 +892,6 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1004,7 +994,6 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1081,7 +1070,6 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, pa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/inline-additionalProperties"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1149,7 +1137,6 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/jsonFormData"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1221,7 +1208,6 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/test-query-paramters"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -43,7 +43,6 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake_classname_test"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 	"github.com/antihax/optional"
 	"os"
@@ -44,7 +43,6 @@ func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Respon
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -118,7 +116,7 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -190,7 +188,6 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/findByStatus"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -279,7 +276,6 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/findByTags"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -368,7 +364,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -468,7 +464,6 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Res
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -544,7 +539,7 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -627,7 +622,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}/uploadImage"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -739,7 +734,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/{petId}/uploadImageWithRequiredFile"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_store.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 )
 
@@ -43,7 +42,7 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", orderId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -111,7 +110,6 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/inventory"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -211,7 +209,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", orderId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -305,7 +303,6 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_user.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 )
 
@@ -43,7 +42,6 @@ func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -110,7 +108,6 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/createWithArray"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -177,7 +174,6 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []U
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/createWithList"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -245,7 +241,7 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -313,7 +309,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -402,7 +398,6 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/login"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -488,7 +483,6 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/logout"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -555,7 +549,7 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, body 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore-withXml/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_another_fake.go
@@ -44,7 +44,6 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/another-fake/dummy"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore-withXml/api_fake.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_fake.go
@@ -45,7 +45,6 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/create_xml_item"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -121,7 +120,6 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/boolean"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -218,7 +216,6 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/composite"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -319,7 +316,6 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/number"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -416,7 +412,6 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/string"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -505,7 +500,6 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileS
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/body-with-file-schema"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -573,7 +567,6 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/body-with-query-params"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -644,7 +637,6 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -758,7 +750,6 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -902,7 +893,6 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1005,7 +995,6 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1082,7 +1071,6 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, pa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/inline-additionalProperties"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1150,7 +1138,6 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/jsonFormData"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1222,7 +1209,6 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/test-query-paramters"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore-withXml/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_fake_classname_tags123.go
@@ -44,7 +44,6 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake_classname_test"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore-withXml/api_pet.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_pet.go
@@ -15,7 +15,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 	"github.com/antihax/optional"
 	"os"
@@ -45,7 +44,6 @@ func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Respon
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -119,7 +117,7 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -191,7 +189,6 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/findByStatus"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -279,7 +276,6 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/findByTags"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -367,7 +363,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -464,7 +460,6 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Res
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -540,7 +535,7 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -623,7 +618,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}/uploadImage"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -735,7 +730,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/{petId}/uploadImageWithRequiredFile"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore-withXml/api_store.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_store.go
@@ -15,7 +15,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 )
 
@@ -44,7 +43,7 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", orderId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -112,7 +111,6 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/inventory"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -210,7 +208,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", orderId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -303,7 +301,6 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore-withXml/api_user.go
+++ b/samples/client/petstore/go/go-petstore-withXml/api_user.go
@@ -15,7 +15,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 )
 
@@ -44,7 +43,6 @@ func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -111,7 +109,6 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/createWithArray"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -178,7 +175,6 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []U
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/createWithList"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -246,7 +242,7 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -314,7 +310,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -402,7 +398,6 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/login"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -487,7 +482,6 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/logout"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -554,7 +548,7 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, body 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_another_fake.go
@@ -43,7 +43,6 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/another-fake/dummy"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -44,7 +44,6 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/create_xml_item"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -120,7 +119,6 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/boolean"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -217,7 +215,6 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/composite"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -318,7 +315,6 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/number"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -415,7 +411,6 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/string"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -504,7 +499,6 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileS
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/body-with-file-schema"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -572,7 +566,6 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/body-with-query-params"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -643,7 +636,6 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -757,7 +749,6 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -901,7 +892,6 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1004,7 +994,6 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1081,7 +1070,6 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, pa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/inline-additionalProperties"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1149,7 +1137,6 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/jsonFormData"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1221,7 +1208,6 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/test-query-paramters"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -43,7 +43,6 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake_classname_test"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/client/petstore/go/go-petstore/api_pet.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 	"github.com/antihax/optional"
 	"os"
@@ -44,7 +43,6 @@ func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Respon
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -118,7 +116,7 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -190,7 +188,6 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/findByStatus"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -278,7 +275,6 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/findByTags"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -366,7 +362,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -463,7 +459,6 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Res
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -539,7 +534,7 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -622,7 +617,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}/uploadImage"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -734,7 +729,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/{petId}/uploadImageWithRequiredFile"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore/api_store.go
+++ b/samples/client/petstore/go/go-petstore/api_store.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 )
 
@@ -43,7 +42,7 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", orderId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -111,7 +110,6 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/inventory"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -209,7 +207,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", orderId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -302,7 +300,6 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go/go-petstore/api_user.go
+++ b/samples/client/petstore/go/go-petstore/api_user.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 )
 
@@ -43,7 +42,6 @@ func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -110,7 +108,6 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/createWithArray"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -177,7 +174,6 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []U
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/createWithList"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -245,7 +241,7 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -313,7 +309,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -401,7 +397,6 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/login"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -486,7 +481,6 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/logout"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -553,7 +547,7 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, body 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_another_fake.go
@@ -43,7 +43,6 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, cli
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/another-fake/dummy"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_default.go
@@ -41,7 +41,6 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) (InlineResponseDefault,
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/foo"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -44,7 +44,6 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/health"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -136,7 +135,6 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/boolean"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -233,7 +231,6 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/composite"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -334,7 +331,6 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/number"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -431,7 +427,6 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/outer/string"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -520,7 +515,6 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, fileSchema
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/body-with-file-schema"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -588,7 +582,6 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/body-with-query-params"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -659,7 +652,6 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (C
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -773,7 +765,6 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -917,7 +908,6 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1028,7 +1018,6 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1105,7 +1094,6 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, re
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/inline-additionalProperties"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1173,7 +1161,6 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/jsonFormData"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1245,7 +1232,6 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/test-query-paramters"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake_classname_tags123.go
@@ -43,7 +43,6 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, cli
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake_classname_test"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_pet.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 	"github.com/antihax/optional"
 	"os"
@@ -44,7 +43,6 @@ func (a *PetApiService) AddPet(ctx _context.Context, pet Pet) (*_nethttp.Respons
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -118,7 +116,7 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -190,7 +188,6 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/findByStatus"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -278,7 +275,6 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/findByTags"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -366,7 +362,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -463,7 +459,6 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, pet Pet) (*_nethttp.Resp
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -539,7 +534,7 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -622,7 +617,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/pet/{petId}/uploadImage"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -734,7 +729,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/fake/{petId}/uploadImageWithRequiredFile"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_store.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 )
 
@@ -43,7 +42,7 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", orderId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -111,7 +110,6 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/inventory"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -209,7 +207,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", orderId)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -302,7 +300,6 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, order Order) (Order, 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/store/order"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_user.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 )
 
@@ -43,7 +42,6 @@ func (a *UserApiService) CreateUser(ctx _context.Context, user User) (*_nethttp.
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -110,7 +108,6 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, user []
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/createWithArray"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -177,7 +174,6 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, user []U
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/createWithList"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -245,7 +241,7 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -313,7 +309,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -401,7 +397,6 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/login"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -486,7 +481,6 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/logout"
-
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -553,7 +547,7 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, user 
 
 	// create path and map variables
 	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Path parameters in go did not propery serialize multiple comma-separated values ( Values were serialised as a an array ). This change reuses the code from query param serialization for path parameters.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.


@antihax @bvwells @grokify