### PR TITLE
fix(r): fixing serializatin bug in empty json array

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_client.mustache
@@ -151,10 +151,12 @@ ApiClient  <- R6::R6Class(
             }
           }
         } else {
-          returnObj <- vector("list", length = nrow(obj))
-          if (nrow(obj) > 0) {
-            for (row in 1:nrow(obj)) {
-              returnObj[[row]] <- self$deserializeObj(obj[row, , drop = FALSE], innerReturnType, pkgEnv)
+          if(!is.null(nrow(obj))){
+            returnObj <- vector("list", length = nrow(obj))
+            if (nrow(obj) > 0) {
+              for (row in 1:nrow(obj)) {
+                returnObj[[row]] <- self$deserializeObj(obj[row, , drop = FALSE], innerReturnType, pkgEnv)
+              }
             }
           }
         }

--- a/samples/client/petstore/R/R/api_client.R
+++ b/samples/client/petstore/R/R/api_client.R
@@ -149,10 +149,12 @@ ApiClient  <- R6::R6Class(
             }
           }
         } else {
-          returnObj <- vector("list", length = nrow(obj))
-          if (nrow(obj) > 0) {
-            for (row in 1:nrow(obj)) {
-              returnObj[[row]] <- self$deserializeObj(obj[row, , drop = FALSE], innerReturnType, pkgEnv)
+          if(!is.null(nrow(obj))){
+            returnObj <- vector("list", length = nrow(obj))
+            if (nrow(obj) > 0) {
+              for (row in 1:nrow(obj)) {
+                returnObj[[row]] <- self$deserializeObj(obj[row, , drop = FALSE], innerReturnType, pkgEnv)
+              }
             }
           }
         }


### PR DESCRIPTION
This PR handles a missing case when deserializing empty json arrays of non-primitive types scenario.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @saigiridhar21
@wing328, please take a look at this and please run the required tests on other R clients (Namsor R SDK) as required.