### PR TITLE
[Java] Fix serialized name of discriminator in JSON.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/JSON.mustache
@@ -75,7 +75,7 @@ public class JSON {
                         {{/mappedModels}}
                         classByDiscriminatorValue.put("{{classname}}".toUpperCase(Locale.ROOT), {{classname}}.class);
                         return getClassByDiscriminator(classByDiscriminatorValue,
-                                getDiscriminatorValue(readElement, "{{{propertyBaseName}}}"));
+                                getDiscriminatorValue(readElement, "{{{propertyName}}}"));
                     }
           })
         {{/discriminator}}

--- a/modules/openapi-generator/src/main/resources/Java/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/JSON.mustache
@@ -75,7 +75,7 @@ public class JSON {
                         {{/mappedModels}}
                         classByDiscriminatorValue.put("{{classname}}".toUpperCase(Locale.ROOT), {{classname}}.class);
                         return getClassByDiscriminator(classByDiscriminatorValue,
-                                getDiscriminatorValue(readElement, "{{{propertyName}}}"));
+                                getDiscriminatorValue(readElement, "{{{propertyBaseName}}}"));
                     }
           })
         {{/discriminator}}

--- a/samples/client/petstore/python-experimental/tests/test_pet_api.py
+++ b/samples/client/petstore/python-experimental/tests/test_pet_api.py
@@ -71,8 +71,7 @@ class MockPoolManager(object):
 class PetApiTests(unittest.TestCase):
 
     def setUp(self):
-        config = Configuration()
-        config.host = HOST
+        config = Configuration(host=HOST, access_token='ACCESS_TOKEN')
         self.api_client = petstore_api.ApiClient(config)
         self.pet_api = petstore_api.PetApi(self.api_client)
         self.setUpModels()
@@ -115,6 +114,26 @@ class PetApiTests(unittest.TestCase):
         resp.close()
         resp.release_conn()
 
+    def test_config(self):
+        config = Configuration(host=HOST, access_token='ACCESS_TOKEN')
+        self.assertIsNotNone(config.get_host_settings())
+        self.assertEquals(config.get_basic_auth_token(),
+                          urllib3.util.make_headers(basic_auth=":").get('authorization'))
+        self.assertEquals(len(config.auth_settings()), 1)
+        self.assertIn("petstore_auth", config.auth_settings().keys())
+        config.username = "user"
+        config.password = "password"
+        self.assertEquals(
+            config.get_basic_auth_token(),
+            urllib3.util.make_headers(basic_auth="user:password").get('authorization'))
+        self.assertEquals(len(config.auth_settings()), 2)
+        self.assertIn("petstore_auth", config.auth_settings().keys())
+        self.assertIn("http_basic_test", config.auth_settings().keys())
+        config.username = None
+        config.password = None
+        self.assertEquals(len(config.auth_settings()), 1)
+        self.assertIn("petstore_auth", config.auth_settings().keys())
+
     def test_timeout(self):
         mock_pool = MockPoolManager(self)
         self.api_client.rest_client.pool_manager = mock_pool
@@ -122,13 +141,13 @@ class PetApiTests(unittest.TestCase):
         mock_pool.expect_request('POST', 'http://localhost/v2/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
-                                          'Authorization': 'Bearer ',
+                                          'Authorization': 'Bearer ACCESS_TOKEN',
                                           'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=TimeoutWithEqual(total=5))
         mock_pool.expect_request('POST', 'http://localhost/v2/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
-                                          'Authorization': 'Bearer ',
+                                          'Authorization': 'Bearer ACCESS_TOKEN',
                                           'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=TimeoutWithEqual(connect=1, read=2))
 
@@ -325,7 +344,7 @@ class PetApiTests(unittest.TestCase):
                         'Accept': 'application/json',
                         'Content-Type': 'multipart/form-data',
                         'User-Agent': 'OpenAPI-Generator/1.0.0/python',
-                        'Authorization': 'Bearer '
+                        'Authorization': 'Bearer ACCESS_TOKEN'
                     },
                     post_params=[
                         ('files', ('1px_pic1.png', b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x00\x00\x00\x00:~\x9bU\x00\x00\x00\nIDATx\x9cc\xfa\x0f\x00\x01\x05\x01\x02\xcf\xa0.\xcd\x00\x00\x00\x00IEND\xaeB`\x82', 'image/png')),

--- a/samples/client/petstore/python-experimental/tests/test_pet_api.py
+++ b/samples/client/petstore/python-experimental/tests/test_pet_api.py
@@ -71,7 +71,8 @@ class MockPoolManager(object):
 class PetApiTests(unittest.TestCase):
 
     def setUp(self):
-        config = Configuration(host=HOST, access_token='ACCESS_TOKEN')
+        config = Configuration()
+        config.host = HOST
         self.api_client = petstore_api.ApiClient(config)
         self.pet_api = petstore_api.PetApi(self.api_client)
         self.setUpModels()
@@ -114,26 +115,6 @@ class PetApiTests(unittest.TestCase):
         resp.close()
         resp.release_conn()
 
-    def test_config(self):
-        config = Configuration(host=HOST, access_token='ACCESS_TOKEN')
-        self.assertIsNotNone(config.get_host_settings())
-        self.assertEquals(config.get_basic_auth_token(),
-                          urllib3.util.make_headers(basic_auth=":").get('authorization'))
-        self.assertEquals(len(config.auth_settings()), 1)
-        self.assertIn("petstore_auth", config.auth_settings().keys())
-        config.username = "user"
-        config.password = "password"
-        self.assertEquals(
-            config.get_basic_auth_token(),
-            urllib3.util.make_headers(basic_auth="user:password").get('authorization'))
-        self.assertEquals(len(config.auth_settings()), 2)
-        self.assertIn("petstore_auth", config.auth_settings().keys())
-        self.assertIn("http_basic_test", config.auth_settings().keys())
-        config.username = None
-        config.password = None
-        self.assertEquals(len(config.auth_settings()), 1)
-        self.assertIn("petstore_auth", config.auth_settings().keys())
-
     def test_timeout(self):
         mock_pool = MockPoolManager(self)
         self.api_client.rest_client.pool_manager = mock_pool
@@ -141,13 +122,13 @@ class PetApiTests(unittest.TestCase):
         mock_pool.expect_request('POST', 'http://localhost/v2/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
-                                          'Authorization': 'Bearer ACCESS_TOKEN',
+                                          'Authorization': 'Bearer ',
                                           'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=TimeoutWithEqual(total=5))
         mock_pool.expect_request('POST', 'http://localhost/v2/pet',
                                  body=json.dumps(self.api_client.sanitize_for_serialization(self.pet)),
                                  headers={'Content-Type': 'application/json',
-                                          'Authorization': 'Bearer ACCESS_TOKEN',
+                                          'Authorization': 'Bearer ',
                                           'User-Agent': 'OpenAPI-Generator/1.0.0/python'},
                                  preload_content=True, timeout=TimeoutWithEqual(connect=1, read=2))
 
@@ -344,7 +325,7 @@ class PetApiTests(unittest.TestCase):
                         'Accept': 'application/json',
                         'Content-Type': 'multipart/form-data',
                         'User-Agent': 'OpenAPI-Generator/1.0.0/python',
-                        'Authorization': 'Bearer ACCESS_TOKEN'
+                        'Authorization': 'Bearer '
                     },
                     post_params=[
                         ('files', ('1px_pic1.png', b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x00\x00\x00\x00:~\x9bU\x00\x00\x00\nIDATx\x9cc\xfa\x0f\x00\x01\x05\x01\x02\xcf\xa0.\xcd\x00\x00\x00\x00IEND\xaeB`\x82', 'image/png')),


### PR DESCRIPTION
This PR has a fix for #4671. The JSON.mustache template should use "propertyBaseName" tag instead of "propertyName". The "propertyBaseName" tag is the name of the serialized property, whereas "propertyName" is the Java variable name.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
