### PR TITLE
Simplify body check

### DIFF
--- a/samples/client/petstore/javascript-flowtyped/lib/api.js
+++ b/samples/client/petstore/javascript-flowtyped/lib/api.js
@@ -100,7 +100,7 @@ export var PetApiFetchParamCreator = function PetApiFetchParamCreator(configurat
       delete localVarUrlObj.search;
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
       var needsSerialization = typeof body !== "string" || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body != null ? body : {}) : body || "";
+      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body) : body;
       return {
         url: url.format(localVarUrlObj),
         options: localVarRequestOptions
@@ -289,7 +289,7 @@ export var PetApiFetchParamCreator = function PetApiFetchParamCreator(configurat
       delete localVarUrlObj.search;
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
       var needsSerialization = typeof body !== "string" || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body != null ? body : {}) : body || "";
+      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body) : body;
       return {
         url: url.format(localVarUrlObj),
         options: localVarRequestOptions
@@ -649,7 +649,7 @@ export var StoreApiFetchParamCreator = function StoreApiFetchParamCreator(config
       delete localVarUrlObj.search;
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
       var needsSerialization = typeof body !== "string" || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body != null ? body : {}) : body || "";
+      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body) : body;
       return {
         url: url.format(localVarUrlObj),
         options: localVarRequestOptions
@@ -766,7 +766,7 @@ export var UserApiFetchParamCreator = function UserApiFetchParamCreator(configur
       delete localVarUrlObj.search;
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
       var needsSerialization = typeof body !== "string" || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body != null ? body : {}) : body || "";
+      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body) : body;
       return {
         url: url.format(localVarUrlObj),
         options: localVarRequestOptions
@@ -797,7 +797,7 @@ export var UserApiFetchParamCreator = function UserApiFetchParamCreator(configur
       delete localVarUrlObj.search;
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
       var needsSerialization = typeof body !== "string" || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body != null ? body : {}) : body || "";
+      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body) : body;
       return {
         url: url.format(localVarUrlObj),
         options: localVarRequestOptions
@@ -828,7 +828,7 @@ export var UserApiFetchParamCreator = function UserApiFetchParamCreator(configur
       delete localVarUrlObj.search;
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
       var needsSerialization = typeof body !== "string" || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body != null ? body : {}) : body || "";
+      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body) : body;
       return {
         url: url.format(localVarUrlObj),
         options: localVarRequestOptions
@@ -985,7 +985,7 @@ export var UserApiFetchParamCreator = function UserApiFetchParamCreator(configur
       delete localVarUrlObj.search;
       localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
       var needsSerialization = typeof body !== "string" || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body != null ? body : {}) : body || "";
+      localVarRequestOptions.body = needsSerialization ? JSON.stringify(body) : body;
       return {
         url: url.format(localVarUrlObj),
         options: localVarRequestOptions

--- a/samples/client/petstore/javascript-flowtyped/src/api.js
+++ b/samples/client/petstore/javascript-flowtyped/src/api.js
@@ -323,7 +323,7 @@ export const PetApiFetchParamCreator = function (configuration?: Configuration) 
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body) : body;
 
             return {
                 url: url.format(localVarUrlObj),
@@ -515,7 +515,7 @@ export const PetApiFetchParamCreator = function (configuration?: Configuration) 
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body) : body;
 
             return {
                 url: url.format(localVarUrlObj),
@@ -878,7 +878,7 @@ export const StoreApiFetchParamCreator = function (configuration?: Configuration
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body) : body;
 
             return {
                 url: url.format(localVarUrlObj),
@@ -997,7 +997,7 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body) : body;
 
             return {
                 url: url.format(localVarUrlObj),
@@ -1027,7 +1027,7 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body) : body;
 
             return {
                 url: url.format(localVarUrlObj),
@@ -1057,7 +1057,7 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body) : body;
 
             return {
                 url: url.format(localVarUrlObj),
@@ -1206,7 +1206,7 @@ export const UserApiFetchParamCreator = function (configuration?: Configuration)
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
             const needsSerialization = (typeof body !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body != null ? body : {}) : (((body:any):string) || "");
+            localVarRequestOptions.body =  needsSerialization ? JSON.stringify(body) : body;
 
             return {
                 url: url.format(localVarUrlObj),


### PR DESCRIPTION
This PR simplified the checks for `body`.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
