### PR TITLE
Fix validate allof inline

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -944,7 +944,7 @@ public class ModelUtils {
             return refedParentNames.get(0);
         }
 
-        return null;
+        return "";
     }
 
     public static List<String> getAllParentsName(ComposedSchema composedSchema, Map<String, Schema> allSchemas) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/ModelUtilsTest.java
@@ -235,4 +235,13 @@ public class ModelUtilsTest {
         // Test a null schema
         Assert.assertFalse(ModelUtils.isFreeFormObject(null));
     }
+
+    @Test
+    public void canHandleAllOfWithInlineSchema() {
+        final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/allOf-inline.yaml");
+        List<String> allUsedSchemas = ModelUtils.getAllUsedSchemas(openAPI);
+
+        Assert.assertEquals(allUsedSchemas.size(), 1);
+        Assert.assertTrue(allUsedSchemas.contains("allOfInline"), "contains 'allOfInline'");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/allOf-inline.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allOf-inline.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+paths:
+  /person:
+    get:
+      operationId: list
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/allOfInline"
+components:
+  schemas:
+    allOfInline:
+      allOf:
+        - type: object
+          properties:
+            name:
+              type: string


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fix for #4681

This is the minimal fix I could think of, that does not break anything else.

Perhaps @jmini has an opinion about what exactly getChildrenMap() should return in this case?

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- N/A If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- N/A Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- N/A Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
