### PR TITLE
Error in the reactive client when the path variables are a list (#4687)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -497,7 +497,7 @@ public class ApiClient {
             formParams
                     .toSingleValueMap()
                     .entrySet()
-                    .forEach(es -> map.add(es.getKey(), (String) es.getValue()));
+                    .forEach(es -> map.add(es.getKey(), String.valueOf(es.getValue())));
 
             return BodyInserters.fromFormData(map);
         } else if(MediaType.MULTIPART_FORM_DATA.equals(contentType)) {
@@ -636,6 +636,28 @@ public class ApiClient {
             }
             auth.applyToParams(queryParams, headerParams, cookieParams);
         }
+    }
+
+    /**
+    * Formats the specified collection path parameter to a string value.
+    *
+    * @param collectionFormat The collection format of the parameter.
+    * @param values The values of the parameter.
+    * @return String representation of the parameter
+    */
+    public String collectionPathParameterToString(CollectionFormat collectionFormat, Collection<?> values) {
+        // create the value based on the collection format
+        if (CollectionFormat.MULTI.equals(collectionFormat)) {
+            // not valid for path params
+            return parameterToString(values);
+        }
+
+         // collectionFormat is assumed to be "csv" by default
+         if(collectionFormat == null) {
+             collectionFormat = CollectionFormat.CSV;
+         }
+
+         return collectionFormat.collectionToString(values);
     }
 
     private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api.mustache
@@ -70,7 +70,8 @@ public class {{classname}} {
         {{/required}}{{/allParams}}
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();{{#hasPathParams}}{{#pathParams}}
-        pathParams.put("{{baseName}}", {{{paramName}}});{{/pathParams}}{{/hasPathParams}}
+        pathParams.put("{{baseName}}", {{#collectionFormat}}apiClient.collectionPathParameterToString(ApiClient.CollectionFormat.valueOf("csv".toUpperCase()), {{/collectionFormat}}{{{paramName}}}{{#collectionFormat}}){{/collectionFormat}});{{/pathParams}}{{/hasPathParams}}
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -493,7 +493,7 @@ public class ApiClient {
             formParams
                     .toSingleValueMap()
                     .entrySet()
-                    .forEach(es -> map.add(es.getKey(), (String) es.getValue()));
+                    .forEach(es -> map.add(es.getKey(), String.valueOf(es.getValue())));
 
             return BodyInserters.fromFormData(map);
         } else if(MediaType.MULTIPART_FORM_DATA.equals(contentType)) {
@@ -632,6 +632,28 @@ public class ApiClient {
             }
             auth.applyToParams(queryParams, headerParams, cookieParams);
         }
+    }
+
+    /**
+    * Formats the specified collection path parameter to a string value.
+    *
+    * @param collectionFormat The collection format of the parameter.
+    * @param values The values of the parameter.
+    * @return String representation of the parameter
+    */
+    public String collectionPathParameterToString(CollectionFormat collectionFormat, Collection<?> values) {
+        // create the value based on the collection format
+        if (CollectionFormat.MULTI.equals(collectionFormat)) {
+            // not valid for path params
+            return parameterToString(values);
+        }
+
+         // collectionFormat is assumed to be "csv" by default
+         if(collectionFormat == null) {
+             collectionFormat = CollectionFormat.CSV;
+         }
+
+         return collectionFormat.collectionToString(values);
     }
 
     private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -64,6 +64,7 @@ public class AnotherFakeApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -71,6 +71,7 @@ public class FakeApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -101,6 +102,7 @@ public class FakeApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -133,6 +135,7 @@ public class FakeApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -164,6 +167,7 @@ public class FakeApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -194,6 +198,7 @@ public class FakeApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -229,6 +234,7 @@ public class FakeApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -271,6 +277,7 @@ public class FakeApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -308,6 +315,7 @@ public class FakeApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -374,6 +382,7 @@ public class FakeApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -442,6 +451,7 @@ public class FakeApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -507,6 +517,7 @@ public class FakeApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -550,6 +561,7 @@ public class FakeApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -590,6 +602,7 @@ public class FakeApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -654,6 +667,7 @@ public class FakeApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -64,6 +64,7 @@ public class FakeClassnameTags123Api {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/PetApi.java
@@ -66,6 +66,7 @@ public class PetApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -103,6 +104,7 @@ public class PetApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
         pathParams.put("petId", petId);
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -142,6 +144,7 @@ public class PetApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -180,6 +183,7 @@ public class PetApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -222,6 +226,7 @@ public class PetApi {
         final Map<String, Object> pathParams = new HashMap<String, Object>();
         pathParams.put("petId", petId);
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -260,6 +265,7 @@ public class PetApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -297,6 +303,7 @@ public class PetApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
         pathParams.put("petId", petId);
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -341,6 +348,7 @@ public class PetApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
         pathParams.put("petId", petId);
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -392,6 +400,7 @@ public class PetApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
         pathParams.put("petId", petId);
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -65,6 +65,7 @@ public class StoreApi {
         final Map<String, Object> pathParams = new HashMap<String, Object>();
         pathParams.put("order_id", orderId);
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -92,6 +93,7 @@ public class StoreApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -132,6 +134,7 @@ public class StoreApi {
         final Map<String, Object> pathParams = new HashMap<String, Object>();
         pathParams.put("order_id", orderId);
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -168,6 +171,7 @@ public class StoreApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/UserApi.java
@@ -63,6 +63,7 @@ public class UserApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -96,6 +97,7 @@ public class UserApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -128,6 +130,7 @@ public class UserApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -163,6 +166,7 @@ public class UserApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
         pathParams.put("username", username);
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -200,6 +204,7 @@ public class UserApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
         pathParams.put("username", username);
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -244,6 +249,7 @@ public class UserApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
 
+
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
@@ -275,6 +281,7 @@ public class UserApi {
         
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();
@@ -316,6 +323,7 @@ public class UserApi {
         // create path and map variables
         final Map<String, Object> pathParams = new HashMap<String, Object>();
         pathParams.put("username", username);
+
 
         final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<String, String>();
         final HttpHeaders headerParams = new HttpHeaders();


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, ~~`4.3.x`~~, ~~`5.0.x`~~. Default: `master`.
- [x] Copy the [technical committee] @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)

### Description of the PR
Addresses issue #4687 for  java webclient