### PR TITLE
[go-experimental] Fix issue with Nullable marshaling comparing value to empty string no matter the enum type

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/model.mustache
@@ -25,32 +25,6 @@ const (
 	{{/enumVars}}
 	{{/allowableValues}}
 )
-
-type Nullable{{{classname}}} struct {
-	Value {{{classname}}}
-	ExplicitNull bool
-}
-
-func (v Nullable{{{classname}}}) MarshalJSON() ([]byte, error) {
-    switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
-    case v.ExplicitNull:
-        return []byte("null"), nil
-    default:
-		return json.Marshal(v.Value)
-	}	
-}
-
-func (v *Nullable{{{classname}}}) UnmarshalJSON(src []byte) error {
-	if bytes.Equal(src, []byte("null")) {
-		v.ExplicitNull = true
-		return nil
-	}
-
-	return json.Unmarshal(src, &v.Value)
-}
-
 {{/isEnum}}
 {{^isEnum}}
 // {{classname}}{{#description}} {{{description}}}{{/description}}{{^description}} struct for {{{classname}}}{{/description}}
@@ -121,6 +95,7 @@ func (o *{{classname}}) Set{{name}}(v {{dataType}}) {
 
 {{/required}}
 {{/vars}}
+{{/isEnum}}
 type Nullable{{{classname}}} struct {
 	Value {{{classname}}}
 	ExplicitNull bool
@@ -132,7 +107,7 @@ func (v Nullable{{{classname}}}) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *Nullable{{{classname}}}) UnmarshalJSON(src []byte) error {
@@ -143,7 +118,5 @@ func (v *Nullable{{{classname}}}) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-{{/isEnum}}
-
 {{/model}}
 {{/models}}

--- a/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -97,7 +97,7 @@ func (v NullableModel200Response) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableModel200Response) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableModel200Response) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_any_type.go
@@ -63,7 +63,7 @@ func (v NullableAdditionalPropertiesAnyType) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAdditionalPropertiesAnyType) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableAdditionalPropertiesAnyType) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_array.go
@@ -63,7 +63,7 @@ func (v NullableAdditionalPropertiesArray) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAdditionalPropertiesArray) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableAdditionalPropertiesArray) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_boolean.go
@@ -63,7 +63,7 @@ func (v NullableAdditionalPropertiesBoolean) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAdditionalPropertiesBoolean) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableAdditionalPropertiesBoolean) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -403,7 +403,7 @@ func (v NullableAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
@@ -414,4 +414,3 @@ func (v *NullableAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_integer.go
@@ -63,7 +63,7 @@ func (v NullableAdditionalPropertiesInteger) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAdditionalPropertiesInteger) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableAdditionalPropertiesInteger) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_number.go
@@ -63,7 +63,7 @@ func (v NullableAdditionalPropertiesNumber) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAdditionalPropertiesNumber) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableAdditionalPropertiesNumber) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_object.go
@@ -63,7 +63,7 @@ func (v NullableAdditionalPropertiesObject) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAdditionalPropertiesObject) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableAdditionalPropertiesObject) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_additional_properties_string.go
@@ -63,7 +63,7 @@ func (v NullableAdditionalPropertiesString) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAdditionalPropertiesString) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableAdditionalPropertiesString) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -79,7 +79,7 @@ func (v NullableAnimal) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAnimal) UnmarshalJSON(src []byte) error {
@@ -90,4 +90,3 @@ func (v *NullableAnimal) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -131,7 +131,7 @@ func (v NullableApiResponse) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableApiResponse) UnmarshalJSON(src []byte) error {
@@ -142,4 +142,3 @@ func (v *NullableApiResponse) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -63,7 +63,7 @@ func (v NullableArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableArrayOfArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableArrayOfArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -63,7 +63,7 @@ func (v NullableArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -131,7 +131,7 @@ func (v NullableArrayTest) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableArrayTest) UnmarshalJSON(src []byte) error {
@@ -142,4 +142,3 @@ func (v *NullableArrayTest) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -234,7 +234,7 @@ func (v NullableCapitalization) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableCapitalization) UnmarshalJSON(src []byte) error {
@@ -245,4 +245,3 @@ func (v *NullableCapitalization) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -113,7 +113,7 @@ func (v NullableCat) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableCat) UnmarshalJSON(src []byte) error {
@@ -124,4 +124,3 @@ func (v *NullableCat) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -63,7 +63,7 @@ func (v NullableCatAllOf) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableCatAllOf) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableCatAllOf) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_category.go
@@ -79,7 +79,7 @@ func (v NullableCategory) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableCategory) UnmarshalJSON(src []byte) error {
@@ -90,4 +90,3 @@ func (v *NullableCategory) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -63,7 +63,7 @@ func (v NullableClassModel) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableClassModel) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableClassModel) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_client.go
@@ -63,7 +63,7 @@ func (v NullableClient) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableClient) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableClient) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -113,7 +113,7 @@ func (v NullableDog) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableDog) UnmarshalJSON(src []byte) error {
@@ -124,4 +124,3 @@ func (v *NullableDog) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -63,7 +63,7 @@ func (v NullableDogAllOf) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableDogAllOf) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableDogAllOf) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -97,7 +97,7 @@ func (v NullableEnumArrays) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableEnumArrays) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableEnumArrays) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -31,13 +31,11 @@ type NullableEnumClass struct {
 
 func (v NullableEnumClass) MarshalJSON() ([]byte, error) {
     switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
     case v.ExplicitNull:
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableEnumClass) UnmarshalJSON(src []byte) error {
@@ -48,6 +46,3 @@ func (v *NullableEnumClass) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-
-
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -181,7 +181,7 @@ func (v NullableEnumTest) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableEnumTest) UnmarshalJSON(src []byte) error {
@@ -192,4 +192,3 @@ func (v *NullableEnumTest) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file.go
@@ -64,7 +64,7 @@ func (v NullableFile) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableFile) UnmarshalJSON(src []byte) error {
@@ -75,4 +75,3 @@ func (v *NullableFile) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -97,7 +97,7 @@ func (v NullableFileSchemaTestClass) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableFileSchemaTestClass) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableFileSchemaTestClass) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -435,7 +435,7 @@ func (v NullableFormatTest) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableFormatTest) UnmarshalJSON(src []byte) error {
@@ -446,4 +446,3 @@ func (v *NullableFormatTest) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -97,7 +97,7 @@ func (v NullableHasOnlyReadOnly) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableHasOnlyReadOnly) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableHasOnlyReadOnly) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_list.go
@@ -63,7 +63,7 @@ func (v NullableList) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableList) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableList) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -165,7 +165,7 @@ func (v NullableMapTest) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableMapTest) UnmarshalJSON(src []byte) error {
@@ -176,4 +176,3 @@ func (v *NullableMapTest) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -132,7 +132,7 @@ func (v NullableMixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]by
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
@@ -143,4 +143,3 @@ func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(src 
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_name.go
@@ -147,7 +147,7 @@ func (v NullableName) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableName) UnmarshalJSON(src []byte) error {
@@ -158,4 +158,3 @@ func (v *NullableName) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -63,7 +63,7 @@ func (v NullableNumberOnly) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableNumberOnly) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableNumberOnly) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_order.go
@@ -235,7 +235,7 @@ func (v NullableOrder) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableOrder) UnmarshalJSON(src []byte) error {
@@ -246,4 +246,3 @@ func (v *NullableOrder) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -131,7 +131,7 @@ func (v NullableOuterComposite) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableOuterComposite) UnmarshalJSON(src []byte) error {
@@ -142,4 +142,3 @@ func (v *NullableOuterComposite) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -31,13 +31,11 @@ type NullableOuterEnum struct {
 
 func (v NullableOuterEnum) MarshalJSON() ([]byte, error) {
     switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
     case v.ExplicitNull:
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableOuterEnum) UnmarshalJSON(src []byte) error {
@@ -48,6 +46,3 @@ func (v *NullableOuterEnum) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-
-
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -198,7 +198,7 @@ func (v NullablePet) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullablePet) UnmarshalJSON(src []byte) error {
@@ -209,4 +209,3 @@ func (v *NullablePet) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -97,7 +97,7 @@ func (v NullableReadOnlyFirst) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableReadOnlyFirst) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableReadOnlyFirst) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_return.go
@@ -63,7 +63,7 @@ func (v NullableReturn) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableReturn) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableReturn) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_special_model_name.go
@@ -63,7 +63,7 @@ func (v NullableSpecialModelName) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableSpecialModelName) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableSpecialModelName) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -97,7 +97,7 @@ func (v NullableTag) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableTag) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableTag) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_default.go
@@ -109,7 +109,7 @@ func (v NullableTypeHolderDefault) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableTypeHolderDefault) UnmarshalJSON(src []byte) error {
@@ -120,4 +120,3 @@ func (v *NullableTypeHolderDefault) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_type_holder_example.go
@@ -125,7 +125,7 @@ func (v NullableTypeHolderExample) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableTypeHolderExample) UnmarshalJSON(src []byte) error {
@@ -136,4 +136,3 @@ func (v *NullableTypeHolderExample) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_user.go
@@ -302,7 +302,7 @@ func (v NullableUser) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableUser) UnmarshalJSON(src []byte) error {
@@ -313,4 +313,3 @@ func (v *NullableUser) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
+++ b/samples/client/petstore/go-experimental/go-petstore/model_xml_item.go
@@ -1015,7 +1015,7 @@ func (v NullableXmlItem) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableXmlItem) UnmarshalJSON(src []byte) error {
@@ -1026,4 +1026,3 @@ func (v *NullableXmlItem) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_200_response.go
@@ -97,7 +97,7 @@ func (v NullableModel200Response) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableModel200Response) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableModel200Response) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model__special_model_name_.go
@@ -63,7 +63,7 @@ func (v NullableSpecialModelName) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableSpecialModelName) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableSpecialModelName) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_additional_properties_class.go
@@ -97,7 +97,7 @@ func (v NullableAdditionalPropertiesClass) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_animal.go
@@ -79,7 +79,7 @@ func (v NullableAnimal) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableAnimal) UnmarshalJSON(src []byte) error {
@@ -90,4 +90,3 @@ func (v *NullableAnimal) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_api_response.go
@@ -131,7 +131,7 @@ func (v NullableApiResponse) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableApiResponse) UnmarshalJSON(src []byte) error {
@@ -142,4 +142,3 @@ func (v *NullableApiResponse) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_array_of_number_only.go
@@ -63,7 +63,7 @@ func (v NullableArrayOfArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableArrayOfArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableArrayOfArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_of_number_only.go
@@ -63,7 +63,7 @@ func (v NullableArrayOfNumberOnly) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableArrayOfNumberOnly) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_array_test_.go
@@ -131,7 +131,7 @@ func (v NullableArrayTest) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableArrayTest) UnmarshalJSON(src []byte) error {
@@ -142,4 +142,3 @@ func (v *NullableArrayTest) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_capitalization.go
@@ -234,7 +234,7 @@ func (v NullableCapitalization) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableCapitalization) UnmarshalJSON(src []byte) error {
@@ -245,4 +245,3 @@ func (v *NullableCapitalization) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat.go
@@ -113,7 +113,7 @@ func (v NullableCat) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableCat) UnmarshalJSON(src []byte) error {
@@ -124,4 +124,3 @@ func (v *NullableCat) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_cat_all_of.go
@@ -63,7 +63,7 @@ func (v NullableCatAllOf) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableCatAllOf) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableCatAllOf) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_category.go
@@ -79,7 +79,7 @@ func (v NullableCategory) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableCategory) UnmarshalJSON(src []byte) error {
@@ -90,4 +90,3 @@ func (v *NullableCategory) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_class_model.go
@@ -63,7 +63,7 @@ func (v NullableClassModel) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableClassModel) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableClassModel) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_client.go
@@ -63,7 +63,7 @@ func (v NullableClient) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableClient) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableClient) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog.go
@@ -113,7 +113,7 @@ func (v NullableDog) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableDog) UnmarshalJSON(src []byte) error {
@@ -124,4 +124,3 @@ func (v *NullableDog) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_dog_all_of.go
@@ -63,7 +63,7 @@ func (v NullableDogAllOf) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableDogAllOf) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableDogAllOf) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_arrays.go
@@ -97,7 +97,7 @@ func (v NullableEnumArrays) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableEnumArrays) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableEnumArrays) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_class.go
@@ -31,13 +31,11 @@ type NullableEnumClass struct {
 
 func (v NullableEnumClass) MarshalJSON() ([]byte, error) {
     switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
     case v.ExplicitNull:
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableEnumClass) UnmarshalJSON(src []byte) error {
@@ -48,6 +46,3 @@ func (v *NullableEnumClass) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-
-
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_enum_test_.go
@@ -283,7 +283,7 @@ func (v NullableEnumTest) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableEnumTest) UnmarshalJSON(src []byte) error {
@@ -294,4 +294,3 @@ func (v *NullableEnumTest) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file.go
@@ -64,7 +64,7 @@ func (v NullableFile) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableFile) UnmarshalJSON(src []byte) error {
@@ -75,4 +75,3 @@ func (v *NullableFile) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_file_schema_test_class.go
@@ -97,7 +97,7 @@ func (v NullableFileSchemaTestClass) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableFileSchemaTestClass) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableFileSchemaTestClass) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_foo.go
@@ -63,7 +63,7 @@ func (v NullableFoo) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableFoo) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableFoo) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_format_test_.go
@@ -471,7 +471,7 @@ func (v NullableFormatTest) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableFormatTest) UnmarshalJSON(src []byte) error {
@@ -482,4 +482,3 @@ func (v *NullableFormatTest) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_has_only_read_only.go
@@ -97,7 +97,7 @@ func (v NullableHasOnlyReadOnly) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableHasOnlyReadOnly) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableHasOnlyReadOnly) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_health_check_result.go
@@ -63,7 +63,7 @@ func (v NullableHealthCheckResult) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableHealthCheckResult) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableHealthCheckResult) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object.go
@@ -99,7 +99,7 @@ func (v NullableInlineObject) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableInlineObject) UnmarshalJSON(src []byte) error {
@@ -110,4 +110,3 @@ func (v *NullableInlineObject) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_1.go
@@ -100,7 +100,7 @@ func (v NullableInlineObject1) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableInlineObject1) UnmarshalJSON(src []byte) error {
@@ -111,4 +111,3 @@ func (v *NullableInlineObject1) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_2.go
@@ -99,7 +99,7 @@ func (v NullableInlineObject2) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableInlineObject2) UnmarshalJSON(src []byte) error {
@@ -110,4 +110,3 @@ func (v *NullableInlineObject2) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_3.go
@@ -449,7 +449,7 @@ func (v NullableInlineObject3) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableInlineObject3) UnmarshalJSON(src []byte) error {
@@ -460,4 +460,3 @@ func (v *NullableInlineObject3) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_4.go
@@ -63,7 +63,7 @@ func (v NullableInlineObject4) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableInlineObject4) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableInlineObject4) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_object_5.go
@@ -82,7 +82,7 @@ func (v NullableInlineObject5) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableInlineObject5) UnmarshalJSON(src []byte) error {
@@ -93,4 +93,3 @@ func (v *NullableInlineObject5) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_inline_response_default.go
@@ -63,7 +63,7 @@ func (v NullableInlineResponseDefault) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableInlineResponseDefault) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableInlineResponseDefault) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_list.go
@@ -63,7 +63,7 @@ func (v NullableList) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableList) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableList) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_map_test_.go
@@ -165,7 +165,7 @@ func (v NullableMapTest) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableMapTest) UnmarshalJSON(src []byte) error {
@@ -176,4 +176,3 @@ func (v *NullableMapTest) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -132,7 +132,7 @@ func (v NullableMixedPropertiesAndAdditionalPropertiesClass) MarshalJSON() ([]by
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(src []byte) error {
@@ -143,4 +143,3 @@ func (v *NullableMixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(src 
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_name.go
@@ -147,7 +147,7 @@ func (v NullableName) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableName) UnmarshalJSON(src []byte) error {
@@ -158,4 +158,3 @@ func (v *NullableName) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_nullable_class.go
@@ -438,7 +438,7 @@ func (v NullableNullableClass) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableNullableClass) UnmarshalJSON(src []byte) error {
@@ -449,4 +449,3 @@ func (v *NullableNullableClass) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_number_only.go
@@ -63,7 +63,7 @@ func (v NullableNumberOnly) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableNumberOnly) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableNumberOnly) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_order.go
@@ -235,7 +235,7 @@ func (v NullableOrder) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableOrder) UnmarshalJSON(src []byte) error {
@@ -246,4 +246,3 @@ func (v *NullableOrder) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_composite.go
@@ -131,7 +131,7 @@ func (v NullableOuterComposite) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableOuterComposite) UnmarshalJSON(src []byte) error {
@@ -142,4 +142,3 @@ func (v *NullableOuterComposite) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum.go
@@ -31,13 +31,11 @@ type NullableOuterEnum struct {
 
 func (v NullableOuterEnum) MarshalJSON() ([]byte, error) {
     switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
     case v.ExplicitNull:
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableOuterEnum) UnmarshalJSON(src []byte) error {
@@ -48,6 +46,3 @@ func (v *NullableOuterEnum) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-
-
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_default_value.go
@@ -31,13 +31,11 @@ type NullableOuterEnumDefaultValue struct {
 
 func (v NullableOuterEnumDefaultValue) MarshalJSON() ([]byte, error) {
     switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
     case v.ExplicitNull:
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableOuterEnumDefaultValue) UnmarshalJSON(src []byte) error {
@@ -48,6 +46,3 @@ func (v *NullableOuterEnumDefaultValue) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-
-
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer.go
@@ -31,13 +31,11 @@ type NullableOuterEnumInteger struct {
 
 func (v NullableOuterEnumInteger) MarshalJSON() ([]byte, error) {
     switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
     case v.ExplicitNull:
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableOuterEnumInteger) UnmarshalJSON(src []byte) error {
@@ -48,6 +46,3 @@ func (v *NullableOuterEnumInteger) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-
-
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_outer_enum_integer_default_value.go
@@ -31,13 +31,11 @@ type NullableOuterEnumIntegerDefaultValue struct {
 
 func (v NullableOuterEnumIntegerDefaultValue) MarshalJSON() ([]byte, error) {
     switch {
-    case v.ExplicitNull && v.Value != "":
-        return nil, ErrInvalidNullable
     case v.ExplicitNull:
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableOuterEnumIntegerDefaultValue) UnmarshalJSON(src []byte) error {
@@ -48,6 +46,3 @@ func (v *NullableOuterEnumIntegerDefaultValue) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-
-
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_pet.go
@@ -198,7 +198,7 @@ func (v NullablePet) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullablePet) UnmarshalJSON(src []byte) error {
@@ -209,4 +209,3 @@ func (v *NullablePet) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_read_only_first.go
@@ -97,7 +97,7 @@ func (v NullableReadOnlyFirst) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableReadOnlyFirst) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableReadOnlyFirst) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_return.go
@@ -63,7 +63,7 @@ func (v NullableReturn) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableReturn) UnmarshalJSON(src []byte) error {
@@ -74,4 +74,3 @@ func (v *NullableReturn) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_tag.go
@@ -97,7 +97,7 @@ func (v NullableTag) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableTag) UnmarshalJSON(src []byte) error {
@@ -108,4 +108,3 @@ func (v *NullableTag) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/model_user.go
@@ -302,7 +302,7 @@ func (v NullableUser) MarshalJSON() ([]byte, error) {
         return []byte("null"), nil
     default:
 		return json.Marshal(v.Value)
-	}	
+	}
 }
 
 func (v *NullableUser) UnmarshalJSON(src []byte) error {
@@ -313,4 +313,3 @@ func (v *NullableUser) UnmarshalJSON(src []byte) error {
 
 	return json.Unmarshal(src, &v.Value)
 }
-


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

For enum models, there was a hardcoded `v.Value != ""` in the template, where `v.Value` could be any type, so the code wouldn't compile.
This PR removes this to make the marshaling function identical with non-enum types, and removes the duplication.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)
