### PR TITLE
Added support for jsonb in java jaxrs spec.

### DIFF
--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -50,5 +50,7 @@ sidebar_label: jaxrs-cxf-cdi
 |interfaceOnly|Whether to generate only API interface stubs without the server files.| |false|
 |returnResponse|Whether generate API interface should return javax.ws.rs.core.Response instead of a deserialized entity. Only useful if interfaceOnly is true.| |false|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|
+|useJsonbAnnotations|Whether to generate Jsonb annotations.| |false|
+|jackson|Whether to use Jackson.| |true|
 |openApiSpecFileLocation|Location where the file containing the spec will be generated in the output folder. No file generated when set to null or empty string.| |null|
 |useBeanValidation|Use BeanValidation API annotations| |true|

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -50,4 +50,6 @@ sidebar_label: jaxrs-spec
 |interfaceOnly|Whether to generate only API interface stubs without the server files.| |false|
 |returnResponse|Whether generate API interface should return javax.ws.rs.core.Response instead of a deserialized entity. Only useful if interfaceOnly is true.| |false|
 |useSwaggerAnnotations|Whether to generate Swagger annotations.| |true|
+|useJsonbAnnotations|Whether to generate Jsonb annotations.| |false|
+|jackson|Whether to use Jackson.| |true|
 |openApiSpecFileLocation|Location where the file containing the spec will be generated in the output folder. No file generated when set to null or empty string.| |null|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -40,6 +40,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     public static final String RETURN_RESPONSE = "returnResponse";
     public static final String GENERATE_POM = "generatePom";
     public static final String USE_SWAGGER_ANNOTATIONS = "useSwaggerAnnotations";
+    public static final String USE_JSONB_ANNOTATIONS = "useJsonbAnnotations";
     public static final String JACKSON = "jackson";
     public static final String OPEN_API_SPEC_FILE_LOCATION = "openApiSpecFileLocation";
 
@@ -52,7 +53,8 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     private boolean returnResponse = false;
     private boolean generatePom = true;
     private boolean useSwaggerAnnotations = true;
-    private boolean useJackson = false;
+    private boolean useJsonbAnnotations = false;
+    private boolean useJackson = true;
     private String openApiSpecFileLocation = "src/main/openapi/openapi.yaml";
 
     private String primaryResourceName;
@@ -105,6 +107,8 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         cliOptions.add(CliOption.newBoolean(INTERFACE_ONLY, "Whether to generate only API interface stubs without the server files.").defaultValue(String.valueOf(interfaceOnly)));
         cliOptions.add(CliOption.newBoolean(RETURN_RESPONSE, "Whether generate API interface should return javax.ws.rs.core.Response instead of a deserialized entity. Only useful if interfaceOnly is true.").defaultValue(String.valueOf(returnResponse)));
         cliOptions.add(CliOption.newBoolean(USE_SWAGGER_ANNOTATIONS, "Whether to generate Swagger annotations.", useSwaggerAnnotations));
+        cliOptions.add(CliOption.newBoolean(USE_JSONB_ANNOTATIONS, "Whether to generate Jsonb annotations.", useJsonbAnnotations));
+        cliOptions.add(CliOption.newBoolean(JACKSON, "Whether to use Jackson.", useJackson));
         cliOptions.add(CliOption.newString(OPEN_API_SPEC_FILE_LOCATION, "Location where the file containing the spec will be generated in the output folder. No file generated when set to null or empty string."));
     }
 
@@ -112,6 +116,9 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
     public void processOpts() {
         if (additionalProperties.containsKey(GENERATE_POM)) {
             generatePom = Boolean.valueOf(additionalProperties.get(GENERATE_POM).toString());
+        }
+        if (additionalProperties.containsKey(USE_JSONB_ANNOTATIONS)) {
+            useJsonbAnnotations = Boolean.valueOf(additionalProperties.get(USE_JSONB_ANNOTATIONS).toString());
         }
         if (additionalProperties.containsKey(INTERFACE_ONLY)) {
             interfaceOnly = Boolean.valueOf(additionalProperties.get(INTERFACE_ONLY).toString());
@@ -260,6 +267,10 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
             codegenModel.imports.remove("ToStringSerializer");
             codegenModel.imports.remove("JsonValue");
             codegenModel.imports.remove("JsonProperty");
+        }
+        if (!useJsonbAnnotations) {
+            codegenModel.imports.remove("JsonbProperty");
+            codegenModel.imports.remove("JsonbCreator");
         }
         return codegenModel;
     }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumOuterClass.mustache
@@ -2,6 +2,9 @@
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 {{/jackson}}
+{{#useJsonbAnnotations}}
+import javax.json.bind.annotation.JsonbCreator;
+{{/useJsonbAnnotations}}
 
 /**
  * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
@@ -26,12 +29,19 @@ public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum
   }
 
   @Override
+  {{#jackson}}
   @JsonValue
+  {{/jackson}}
   public String toString() {
     return String.valueOf(value);
   }
 
+  {{#jackson}}
   @JsonCreator
+  {{/jackson}}
+  {{#useJsonbAnnotations}}
+  @JsonbCreator
+  {{/useJsonbAnnotations}}
   public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
     for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
       if (b.value.equals(value)) {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/openliberty/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/openliberty/pom.mustache
@@ -33,11 +33,13 @@
 			<artifactId>validation-api</artifactId>
 			<version>2.0.1.Final</version>
 		</dependency>
+        {{#jackson}}
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
 			<version>2.0.1</version>
 		</dependency>
+        {{/jackson}}
 	</dependencies>
 
 	<properties>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/quarkus/pom.mustache
@@ -49,6 +49,12 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
+    {{#useJsonbAnnotations}}
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jsonb</artifactId>
+    </dependency>
+    {{/useJsonbAnnotations}}
   </dependencies>
   <build>
     <plugins>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/thorntail/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/libraries/thorntail/pom.mustache
@@ -35,6 +35,12 @@
       <groupId>io.thorntail</groupId>
       <artifactId>microprofile-openapi</artifactId>
     </dependency>
+    {{#useJsonbAnnotations}}
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>jsonb</artifactId>
+    </dependency>
+    {{/useJsonbAnnotations}}
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -2,9 +2,14 @@
 import io.swagger.annotations.*;
 {{/useSwaggerAnnotations}}
 import java.util.Objects;
+{{#jackson}}
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+{{/jackson}}
+{{#useJsonbAnnotations}}
+import javax.json.bind.annotation.JsonbProperty;
+{{/useJsonbAnnotations}}
 
 {{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{#description}}
 /**
@@ -38,7 +43,12 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
 
   {{#vendorExtensions.extraAnnotation}}{{{vendorExtensions.extraAnnotation}}}{{/vendorExtensions.extraAnnotation}}{{#useSwaggerAnnotations}}
   @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{/useSwaggerAnnotations}}
+  {{#jackson}}
   @JsonProperty("{{baseName}}")
+  {{/jackson}}
+  {{#useJsonbAnnotations}}
+  @JsonbProperty("{{baseName}}")
+  {{/useJsonbAnnotations}}
 {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{{datatypeWithEnum}}} {{getter}}() {
     return {{name}};
   }

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
@@ -62,24 +62,30 @@
       <scope>provided</scope>
     </dependency>
   {{#java8}}
+    {{#jackson}}
     <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${jackson-version}</version>
     </dependency>
+    {{/jackson}}
   {{/java8}}
   {{^java8}}
+    {{#jackson}}
     <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-joda</artifactId>
         <version>${jackson-version}</version>
     </dependency>
+    {{/jackson}}
   {{/java8}}
+    {{#jackson}}
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
       <version>${jackson-version}</version>
     </dependency>
+    {{/jackson}}
     {{#useSwaggerAnnotations}}
     <dependency>
       <groupId>io.swagger</groupId>
@@ -128,7 +134,21 @@
         <version>1.1.0.Final</version>
         <scope>provided</scope>
     </dependency>
-{{/useBeanValidation}}
+    {{/useBeanValidation}}
+    {{#useJsonbAnnotations}}
+    <dependency>
+        <groupId>javax.json.bind</groupId>
+        <artifactId>javax.json.bind-api</artifactId>
+        <version>1.0</version>
+        <scope>provided</scope>
+    </dependency>
+    {{/useJsonbAnnotations}}
+    <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.2</version>
+        <scope>provided</scope>
+    </dependency>
   </dependencies>
   <properties>
     <jackson-version>2.9.9</jackson-version>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -57,6 +57,8 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
         Assert.assertEquals(codegen.additionalProperties().get(JavaJAXRSSpecServerCodegen.SERVER_PORT), "8082");
         Assert.assertEquals(codegen.getOpenApiSpecFileLocation(), "src/main/openapi/openapi.yaml");
         Assert.assertEquals(codegen.additionalProperties().get(JavaJAXRSSpecServerCodegen.OPEN_API_SPEC_FILE_LOCATION), "src/main/openapi/openapi.yaml");
+        Assert.assertEquals(codegen.additionalProperties().get(JavaJAXRSSpecServerCodegen.JACKSON), Boolean.TRUE.toString());
+        Assert.assertNull(codegen.additionalProperties().get(JavaJAXRSSpecServerCodegen.USE_JSONB_ANNOTATIONS));
     }
 
     @Test


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR addresses: #4104
Added support for jsonb in java jaxrs spec. User can now disable Jackson and enable jsonb annotations.

<!-- Please check the completed items below -->
### PR checklist

- [+] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [+] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [+] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [+] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [+] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608