### PR TITLE
Update PHP coding style link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Code change should conform to the programming style guide of the respective lang
 - Go: https://github.com/golang/go/wiki/CodeReviewComments
 - ObjC: https://github.com/NYTimes/objective-c-style-guide
 - Perl: http://perldoc.perl.org/perlstyle.html
-- PHP: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+- PHP: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md
 - PowerShell: https://msdn.microsoft.com/en-us/library/dd878270(v=vs.85).aspx
 - Python: https://www.python.org/dev/peps/pep-0008/
 - R: https://google.github.io/styleguide/Rguide.xml

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -65,7 +65,7 @@ Code change should conform to the programming style guide of the respective lang
 - Go: https://github.com/golang/go/wiki/CodeReviewComments
 - ObjC: https://github.com/NYTimes/objective-c-style-guide
 - Perl: http://perldoc.perl.org/perlstyle.html
-- PHP: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+- PHP: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md
 - PowerShell: https://msdn.microsoft.com/en-us/library/dd878270(v=vs.85).aspx
 - Python: https://www.python.org/dev/peps/pep-0008/
 - R: https://google.github.io/styleguide/Rguide.xml


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

From [PSR-2 Coding Style Guide](https://www.php-fig.org/psr/psr-2/):
> **Deprecated** - As of 2019-08-10 PSR-2 has been marked as deprecated. [PSR-12](http://www.php-fig.org/psr/psr-12/) is now recommended as an alternative.

Related to #4726

@OpenAPITools/generator-core-team 