### PR TITLE
[go-experimental] Support selection and formatting of endpoint servers

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-experimental/README.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/README.mustache
@@ -34,6 +34,47 @@ Put the package under your project folder and add the following in import:
 import sw "./{{packageName}}"
 ```
 
+## Configuration of Server URL
+
+Default configuration comes with `Servers` field that contains server objects as defined in the OpenAPI specification.
+
+### Select Server Configuration
+
+For using other server than the one defined on index 0 set context value `sw.ContextServerIndex` of type `int`.
+
+```golang
+ctx := context.WithValue(context.Background(), sw.ContextServerIndex, 1)
+```
+
+### Templated Server URL
+
+Templated server URL is formatted using default variables from configuration or from context value `sw.ContextServerVariables` of type `map[string]string`.
+
+```golang
+ctx := context.WithValue(context.Background(), sw.ContextServerVariables, map[string]string{
+	"basePath": "v2",
+})
+```
+
+Note, enum values are always validated and all unused variables are silently ignored.
+
+### URLs Configuration per Operation
+
+Each operation can use different server URL defined using `OperationServers` map in the `Configuration`.
+An operation is uniquely identifield by `"{classname}Service.{nickname}"` string.
+Similar rules for overriding default operation server index and variables applies by using `sw.ContextOperationServerIndices` and `sw.ContextOperationServerVariables` context maps.
+
+```
+ctx := context.WithValue(context.Background(), sw.ContextOperationServerIndices, map[string]int{
+	"{classname}Service.{nickname}": 2,
+})
+ctx = context.WithValue(context.Background(), sw.ContextOperationServerVariables, map[string]map[string]string{
+	"{classname}Service.{nickname}": {
+		"port": "8443",
+	},
+})
+```
+
 ## Documentation for API Endpoints
 
 All URIs are relative to *{{basePath}}*

--- a/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
@@ -76,10 +76,13 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 		{{/returnType}}
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "{{{path}}}"{{#pathParams}}
-	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.QueryEscape(parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")) , -1)
-	{{/pathParams}}
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "{{{classname}}}Service.{{{nickname}}}")
+	if err != nil {
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "{{{path}}}"{{#pathParams}}
+	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.QueryEscape(parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")) , -1){{/pathParams}}
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
@@ -76,7 +76,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 		{{/returnType}}
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "{{{classname}}}Service.{{{nickname}}}")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "{{{classname}}}Service.{{{nickname}}}")
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/modules/openapi-generator/src/main/resources/go-experimental/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/client.mustache
@@ -186,11 +186,6 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-// ChangeBasePath changes base path to allow switching to mocks
-func (c *APIClient) ChangeBasePath(path string) {
-	c.cfg.BasePath = path
-}
-
 // Allow modification of underlying config for alternate implementations and testing
 // Caution: modifying the configuration while live can cause data races and potentially unwanted behavior
 func (c *APIClient) GetConfig() *Configuration {

--- a/modules/openapi-generator/src/main/resources/go-experimental/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/configuration.mustache
@@ -65,7 +65,7 @@ type ServerVariable struct {
 
 // ServerConfiguration stores the information about a server
 type ServerConfiguration struct {
-	Url string
+	URL string
 	Description string
 	Variables map[string]ServerVariable
 }
@@ -98,7 +98,7 @@ func NewConfiguration() *Configuration {
 		Servers:          ServerConfigurations{
 		{{/-first}}
 		{
-			Url: "{{{url}}}",
+			URL: "{{{url}}}",
 			Description: "{{{description}}}{{^description}}No description provided{{/description}}",
 			{{#variables}}
 			{{#-first}}
@@ -136,7 +136,7 @@ func NewConfiguration() *Configuration {
 			"{{{classname}}}Service.{{{nickname}}}": {
 		{{/-first}}
 				{
-					Url: "{{{url}}}",
+					URL: "{{{url}}}",
 					Description: "{{{description}}}{{^description}}No description provided{{/description}}",
 					{{#variables}}
 					{{#-first}}
@@ -178,13 +178,13 @@ func (c *Configuration) AddDefaultHeader(key string, value string) {
 	c.DefaultHeader[key] = value
 }
 
-// ServerUrl returns URL based on variables
-func (sc ServerConfigurations) Url(index int, variables map[string]string) (string, error) {
+// URL formats template on a index using given variables
+func (sc ServerConfigurations) URL(index int, variables map[string]string) (string, error) {
 	if index < 0 || len(sc) <= index {
 		return "", fmt.Errorf("Index %v out of range %v", index, len(sc)-1)
 	}
 	server := sc[index]
-	url := server.Url
+	url := server.URL
 
 	// go through variables and replace placeholders
 	for name, variable := range server.Variables {
@@ -206,9 +206,9 @@ func (sc ServerConfigurations) Url(index int, variables map[string]string) (stri
 	return url, nil
 }
 
-// ServerUrl returns URL based on server settings
-func (c *Configuration) ServerUrl(index int, variables map[string]string) (string, error) {
-	return c.Servers.Url(index, variables)
+// ServerURL returns URL based on server settings
+func (c *Configuration) ServerURL(index int, variables map[string]string) (string, error) {
+	return c.Servers.URL(index, variables)
 }
 
 func getServerIndex(ctx context.Context) (int, error) {
@@ -263,8 +263,8 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 	return getServerVariables(ctx)
 }
 
-// ServerUrlWithContext returns a new server URL given an endpoint
-func (c *Configuration) ServerUrlWithContext(ctx context.Context, endpoint string) (string, error) {
+// ServerURLWithContext returns a new server URL given an endpoint
+func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint string) (string, error) {
 	if ctx == nil {
 		return c.BasePath, nil
 	}
@@ -284,7 +284,7 @@ func (c *Configuration) ServerUrlWithContext(ctx context.Context, endpoint strin
 		return "", err
 	}
 
-	url, err := sc.Url(index, variables)
+	url, err := sc.URL(index, variables)
 	if err != nil {
 		return "", err
 	}

--- a/modules/openapi-generator/src/main/resources/go-experimental/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/configuration.mustache
@@ -75,7 +75,6 @@ type ServerConfigurations []ServerConfiguration
 
 // Configuration stores the configuration of the API client
 type Configuration struct {
-	BasePath         string            `json:"basePath,omitempty"`
 	Host             string            `json:"host,omitempty"`
 	Scheme           string            `json:"scheme,omitempty"`
 	DefaultHeader    map[string]string `json:"defaultHeader,omitempty"`
@@ -89,7 +88,6 @@ type Configuration struct {
 // NewConfiguration returns a new Configuration object
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:         "{{{basePath}}}",
 		DefaultHeader:    make(map[string]string),
 		UserAgent:        "{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{packageVersion}}}/go{{/httpUserAgent}}",
 		Debug:            false,
@@ -266,7 +264,7 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 // ServerURLWithContext returns a new server URL given an endpoint
 func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint string) (string, error) {
 	if ctx == nil {
-		return c.BasePath, nil
+		return sc.URL(0, nil)
 	}
 
 	sc, ok := c.OperationServers[endpoint]
@@ -284,10 +282,5 @@ func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint strin
 		return "", err
 	}
 
-	url, err := sc.URL(index, variables)
-	if err != nil {
-		return "", err
-	}
-
-	return url, nil
+	return sc.URL(index, variables)
 }

--- a/modules/openapi-generator/src/main/resources/go-experimental/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/configuration.mustache
@@ -241,7 +241,7 @@ func getServerVariables(ctx context.Context) (map[string]string, error) {
 		if variables, ok := sv.(map[string]string); ok {
 			return variables, nil
 		}
-		return nil, reportError("Invalid type %T should be map[string]string", sv)
+		return nil, reportError("ctx value of ContextServerVariables has invalid type %T should be map[string]string", sv)
 	}
 	return nil, nil
 }
@@ -250,7 +250,7 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 	osv := ctx.Value(ContextOperationServerVariables)
 	if osv != nil {
 		if operationVariables, ok := osv.(map[string]map[string]string); !ok {
-			return nil, reportError("Invalid type %T should be map[string]map[string]string", osv)
+			return nil, reportError("ctx value of ContextOperationServerVariables has invalid type %T should be map[string]map[string]string", osv)
 		} else {
 			variables, ok := operationVariables[endpoint]
 			if ok {
@@ -263,13 +263,13 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 
 // ServerURLWithContext returns a new server URL given an endpoint
 func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint string) (string, error) {
-	if ctx == nil {
-		return sc.URL(0, nil)
-	}
-
 	sc, ok := c.OperationServers[endpoint]
 	if !ok {
 		sc = c.Servers
+	}
+
+	if ctx == nil {
+		return sc.URL(0, nil)
 	}
 
 	index, err := getServerOperationIndex(ctx, endpoint)

--- a/modules/openapi-generator/src/main/resources/go-experimental/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/configuration.mustache
@@ -2,6 +2,7 @@
 package {{packageName}}
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -29,6 +30,18 @@ var (
 
 	// ContextAPIKeys takes a string apikey as authentication for the request
 	ContextAPIKeys = contextKey("apiKeys")
+
+	// ContextServerIndex uses a server configuration from the index.
+	ContextServerIndex = contextKey("serverIndex")
+
+	// ContextOperationServerIndices uses a server configuration from the index mapping.
+	ContextOperationServerIndices = contextKey("serverOperationIndices")
+
+	// ContextServerVariables overrides a server configuration variables.
+	ContextServerVariables = contextKey("serverVariables")
+
+	// ContextOperationServerVariables overrides a server configuration variables using operation specific values.
+	ContextOperationServerVariables = contextKey("serverOperationVariables")
 )
 
 // BasicAuth provides basic http authentication to a request passed via context using ContextBasicAuth
@@ -57,29 +70,34 @@ type ServerConfiguration struct {
 	Variables map[string]ServerVariable
 }
 
+// ServerConfigurations stores multiple ServerConfiguration items
+type ServerConfigurations []ServerConfiguration
+
 // Configuration stores the configuration of the API client
 type Configuration struct {
-	BasePath      string            `json:"basePath,omitempty"`
-	Host          string            `json:"host,omitempty"`
-	Scheme        string            `json:"scheme,omitempty"`
-	DefaultHeader map[string]string `json:"defaultHeader,omitempty"`
-	UserAgent     string            `json:"userAgent,omitempty"`
-	Debug         bool              `json:"debug,omitempty"`
-	Servers       []ServerConfiguration
-	HTTPClient    *http.Client
+	BasePath         string            `json:"basePath,omitempty"`
+	Host             string            `json:"host,omitempty"`
+	Scheme           string            `json:"scheme,omitempty"`
+	DefaultHeader    map[string]string `json:"defaultHeader,omitempty"`
+	UserAgent        string            `json:"userAgent,omitempty"`
+	Debug            bool              `json:"debug,omitempty"`
+	Servers          ServerConfigurations
+	OperationServers map[string]ServerConfigurations
+	HTTPClient       *http.Client
 }
 
 // NewConfiguration returns a new Configuration object
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:      "{{{basePath}}}",
-		DefaultHeader: make(map[string]string),
-		UserAgent:     "{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{packageVersion}}}/go{{/httpUserAgent}}",
-		Debug:         false,
+		BasePath:         "{{{basePath}}}",
+		DefaultHeader:    make(map[string]string),
+		UserAgent:        "{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{packageVersion}}}/go{{/httpUserAgent}}",
+		Debug:            false,
 		{{#servers}}
 		{{#-first}}
-		Servers:       []ServerConfiguration{{
+		Servers:          ServerConfigurations{
 		{{/-first}}
+		{
 			Url: "{{{url}}}",
 			Description: "{{{description}}}{{^description}}No description provided{{/description}}",
 			{{#variables}}
@@ -108,6 +126,49 @@ func NewConfiguration() *Configuration {
 		},
 		{{/-last}}
 		{{/servers}}
+		{{#apiInfo}}
+		OperationServers: map[string]ServerConfigurations{
+		{{#apis}}
+		{{#operations}}
+		{{#operation}}
+		{{#servers}}
+		{{#-first}}
+			"{{{classname}}}Service.{{{nickname}}}": {
+		{{/-first}}
+				{
+					Url: "{{{url}}}",
+					Description: "{{{description}}}{{^description}}No description provided{{/description}}",
+					{{#variables}}
+					{{#-first}}
+					Variables: map[string]ServerVariable{
+					{{/-first}}
+						"{{{name}}}": ServerVariable{
+							Description: "{{{description}}}{{^description}}No description provided{{/description}}",
+							DefaultValue: "{{{defaultValue}}}",
+							{{#enumValues}}
+							{{#-first}}
+							EnumValues: []string{
+							{{/-first}}
+								"{{{.}}}",
+							{{#-last}}
+							},
+							{{/-last}}
+							{{/enumValues}}
+						},
+					{{#-last}}
+					},
+					{{/-last}}
+					{{/variables}}
+				},
+		{{#-last}}
+			},
+		{{/-last}}
+		{{/servers}}
+		{{/operation}}
+		{{/operations}}
+		{{/apis}}
+		},
+		{{/apiInfo}}
 	}
 	return cfg
 }
@@ -117,12 +178,12 @@ func (c *Configuration) AddDefaultHeader(key string, value string) {
 	c.DefaultHeader[key] = value
 }
 
-// ServerUrl returns URL based on server settings
-func (c *Configuration) ServerUrl(index int, variables map[string]string) (string, error) {
-	if index < 0 || len(c.Servers) <= index {
-		return "", fmt.Errorf("Index %v out of range %v", index, len(c.Servers) - 1)
+// ServerUrl returns URL based on variables
+func (sc ServerConfigurations) Url(index int, variables map[string]string) (string, error) {
+	if index < 0 || len(sc) <= index {
+		return "", fmt.Errorf("Index %v out of range %v", index, len(sc)-1)
 	}
-	server := c.Servers[index]
+	server := sc[index]
 	url := server.Url
 
 	// go through variables and replace placeholders
@@ -142,5 +203,91 @@ func (c *Configuration) ServerUrl(index int, variables map[string]string) (strin
 			url = strings.Replace(url, "{"+name+"}", variable.DefaultValue, -1)
 		}
 	}
+	return url, nil
+}
+
+// ServerUrl returns URL based on server settings
+func (c *Configuration) ServerUrl(index int, variables map[string]string) (string, error) {
+	return c.Servers.Url(index, variables)
+}
+
+func getServerIndex(ctx context.Context) (int, error) {
+	si := ctx.Value(ContextServerIndex)
+	if si != nil {
+		if index, ok := si.(int); ok {
+			return index, nil
+		}
+		return 0, reportError("Invalid type %T should be int", si)
+	}
+	return 0, nil
+}
+
+func getServerOperationIndex(ctx context.Context, endpoint string) (int, error) {
+	osi := ctx.Value(ContextOperationServerIndices)
+	if osi != nil {
+		if operationIndices, ok := osi.(map[string]int); !ok {
+			return 0, reportError("Invalid type %T should be map[string]int", osi)
+		} else {
+			index, ok := operationIndices[endpoint]
+			if ok {
+				return index, nil
+			}
+		}
+	}
+	return getServerIndex(ctx)
+}
+
+func getServerVariables(ctx context.Context) (map[string]string, error) {
+	sv := ctx.Value(ContextServerVariables)
+	if sv != nil {
+		if variables, ok := sv.(map[string]string); ok {
+			return variables, nil
+		}
+		return nil, reportError("Invalid type %T should be map[string]string", sv)
+	}
+	return nil, nil
+}
+
+func getServerOperationVariables(ctx context.Context, endpoint string) (map[string]string, error) {
+	osv := ctx.Value(ContextOperationServerVariables)
+	if osv != nil {
+		if operationVariables, ok := osv.(map[string]map[string]string); !ok {
+			return nil, reportError("Invalid type %T should be map[string]map[string]string", osv)
+		} else {
+			variables, ok := operationVariables[endpoint]
+			if ok {
+				return variables, nil
+			}
+		}
+	}
+	return getServerVariables(ctx)
+}
+
+// ServerUrlWithContext returns a new server URL given an endpoint
+func (c *Configuration) ServerUrlWithContext(ctx context.Context, endpoint string) (string, error) {
+	if ctx == nil {
+		return c.BasePath, nil
+	}
+
+	sc, ok := c.OperationServers[endpoint]
+	if !ok {
+		sc = c.Servers
+	}
+
+	index, err := getServerOperationIndex(ctx, endpoint)
+	if err != nil {
+		return "", err
+	}
+
+	variables, err := getServerOperationVariables(ctx, endpoint)
+	if err != nil {
+		return "", err
+	}
+
+	url, err := sc.Url(index, variables)
+	if err != nil {
+		return "", err
+	}
+
 	return url, nil
 }

--- a/samples/client/petstore/go-experimental/go-petstore/README.md
+++ b/samples/client/petstore/go-experimental/go-petstore/README.md
@@ -26,6 +26,47 @@ Put the package under your project folder and add the following in import:
 import sw "./petstore"
 ```
 
+## Configuration of Server URL
+
+Default configuration comes with `Servers` field that contains server objects as defined in the OpenAPI specification.
+
+### Select Server Configuration
+
+For using other server than the one defined on index 0 set context value `sw.ContextServerIndex` of type `int`.
+
+```golang
+ctx := context.WithValue(context.Background(), sw.ContextServerIndex, 1)
+```
+
+### Templated Server URL
+
+Templated server URL is formatted using default variables from configuration or from context value `sw.ContextServerVariables` of type `map[string]string`.
+
+```golang
+ctx := context.WithValue(context.Background(), sw.ContextServerVariables, map[string]string{
+	"basePath": "v2",
+})
+```
+
+Note, enum values are always validated and all unused variables are silently ignored.
+
+### URLs Configuration per Operation
+
+Each operation can use different server URL defined using `OperationServers` map in the `Configuration`.
+An operation is uniquely identifield by `"{classname}Service.{nickname}"` string.
+Similar rules for overriding default operation server index and variables applies by using `sw.ContextOperationServerIndices` and `sw.ContextOperationServerVariables` context maps.
+
+```
+ctx := context.WithValue(context.Background(), sw.ContextOperationServerIndices, map[string]int{
+	"{classname}Service.{nickname}": 2,
+})
+ctx = context.WithValue(context.Background(), sw.ContextOperationServerVariables, map[string]map[string]string{
+	"{classname}Service.{nickname}": {
+		"port": "8443",
+	},
+})
+```
+
 ## Documentation for API Endpoints
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*

--- a/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -41,7 +41,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 		localVarReturnValue  Client
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "AnotherFakeApiService.Call123TestSpecialTags")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "AnotherFakeApiService.Call123TestSpecialTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -41,8 +41,13 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 		localVarReturnValue  Client
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/another-fake/dummy"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "AnotherFakeApiService.Call123TestSpecialTags")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/another-fake/dummy"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -42,8 +42,13 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/create_xml_item"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.CreateXmlItem")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/create_xml_item"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -117,8 +122,13 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		localVarReturnValue  bool
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/outer/boolean"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterBooleanSerialize")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/outer/boolean"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -213,8 +223,13 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		localVarReturnValue  OuterComposite
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/outer/composite"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterCompositeSerialize")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/outer/composite"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -313,8 +328,13 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		localVarReturnValue  float32
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/outer/number"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterNumberSerialize")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/outer/number"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -409,8 +429,13 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		localVarReturnValue  string
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/outer/string"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterStringSerialize")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/outer/string"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -497,8 +522,13 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileS
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/body-with-file-schema"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestBodyWithFileSchema")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/body-with-file-schema"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -564,8 +594,13 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/body-with-query-params"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestBodyWithQueryParams")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/body-with-query-params"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -634,8 +669,13 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 		localVarReturnValue  Client
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestClientModel")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -747,8 +787,13 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestEndpointParameters")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -890,8 +935,13 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestEnumParameters")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -992,8 +1042,13 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestGroupParameters")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1068,8 +1123,13 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, pa
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/inline-additionalProperties"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestInlineAdditionalProperties")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/inline-additionalProperties"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1135,8 +1195,13 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/jsonFormData"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestJsonFormData")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/jsonFormData"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1206,8 +1271,13 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/test-query-paramters"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestQueryParameterCollectionFormat")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/test-query-paramters"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -42,7 +42,7 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.CreateXmlItem")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.CreateXmlItem")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -122,7 +122,7 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		localVarReturnValue  bool
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterBooleanSerialize")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterBooleanSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -223,7 +223,7 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		localVarReturnValue  OuterComposite
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterCompositeSerialize")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterCompositeSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -328,7 +328,7 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		localVarReturnValue  float32
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterNumberSerialize")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterNumberSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -429,7 +429,7 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		localVarReturnValue  string
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterStringSerialize")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterStringSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -522,7 +522,7 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileS
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestBodyWithFileSchema")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithFileSchema")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -594,7 +594,7 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestBodyWithQueryParams")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithQueryParams")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -669,7 +669,7 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 		localVarReturnValue  Client
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestClientModel")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestClientModel")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -787,7 +787,7 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestEndpointParameters")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEndpointParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -935,7 +935,7 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestEnumParameters")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEnumParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -1042,7 +1042,7 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestGroupParameters")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestGroupParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -1123,7 +1123,7 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, pa
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestInlineAdditionalProperties")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestInlineAdditionalProperties")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -1195,7 +1195,7 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestJsonFormData")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestJsonFormData")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -1271,7 +1271,7 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestQueryParameterCollectionFormat")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestQueryParameterCollectionFormat")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -41,8 +41,13 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 		localVarReturnValue  Client
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake_classname_test"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeClassnameTags123ApiService.TestClassname")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake_classname_test"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -41,7 +41,7 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 		localVarReturnValue  Client
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeClassnameTags123ApiService.TestClassname")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeClassnameTags123ApiService.TestClassname")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -41,7 +41,7 @@ func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Respon
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.AddPet")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.AddPet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -119,7 +119,7 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.DeletePet")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.DeletePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -195,7 +195,7 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 		localVarReturnValue  []Pet
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.FindPetsByStatus")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByStatus")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -288,7 +288,7 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 		localVarReturnValue  []Pet
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.FindPetsByTags")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -381,7 +381,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 		localVarReturnValue  Pet
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.GetPetById")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.GetPetById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -485,7 +485,7 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Res
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UpdatePet")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -565,7 +565,7 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UpdatePetWithForm")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePetWithForm")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -652,7 +652,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		localVarReturnValue  ApiResponse
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UploadFile")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -768,7 +768,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 		localVarReturnValue  ApiResponse
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UploadFileWithRequiredFile")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFileWithRequiredFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -41,8 +41,13 @@ func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Respon
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.AddPet")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -114,8 +119,12 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.DeletePet")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -186,8 +195,13 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 		localVarReturnValue  []Pet
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/findByStatus"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.FindPetsByStatus")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/findByStatus"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -274,8 +288,13 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 		localVarReturnValue  []Pet
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/findByTags"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.FindPetsByTags")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/findByTags"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -362,8 +381,12 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 		localVarReturnValue  Pet
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.GetPetById")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -462,8 +485,13 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Res
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UpdatePet")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -537,8 +565,12 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UpdatePetWithForm")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -620,8 +652,12 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		localVarReturnValue  ApiResponse
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/{petId}/uploadImage"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UploadFile")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -732,8 +768,12 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 		localVarReturnValue  ApiResponse
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/{petId}/uploadImageWithRequiredFile"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UploadFileWithRequiredFile")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)

--- a/samples/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_store.go
@@ -40,8 +40,12 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.DeleteOrder")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/store/order/{order_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -108,8 +112,13 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 		localVarReturnValue  map[string]int32
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/store/inventory"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.GetInventory")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/store/inventory"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -207,8 +216,12 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 		localVarReturnValue  Order
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.GetOrderById")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/store/order/{order_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -301,8 +314,13 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 		localVarReturnValue  Order
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/store/order"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.PlaceOrder")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/store/order"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_store.go
@@ -40,7 +40,7 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.DeleteOrder")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.DeleteOrder")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -112,7 +112,7 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 		localVarReturnValue  map[string]int32
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.GetInventory")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetInventory")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -216,7 +216,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 		localVarReturnValue  Order
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.GetOrderById")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetOrderById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -314,7 +314,7 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 		localVarReturnValue  Order
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.PlaceOrder")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.PlaceOrder")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_user.go
@@ -40,7 +40,7 @@ func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUser")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -111,7 +111,7 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUsersWithArrayInput")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithArrayInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -182,7 +182,7 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []U
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUsersWithListInput")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithListInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -254,7 +254,7 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.DeleteUser")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.DeleteUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -326,7 +326,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 		localVarReturnValue  User
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.GetUserByName")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.GetUserByName")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -419,7 +419,7 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 		localVarReturnValue  string
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.LoginUser")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LoginUser")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -509,7 +509,7 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.LogoutUser")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LogoutUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -580,7 +580,7 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, body 
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.UpdateUser")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.UpdateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_user.go
@@ -40,8 +40,13 @@ func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUser")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -106,8 +111,13 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/createWithArray"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUsersWithArrayInput")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/createWithArray"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -172,8 +182,13 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []U
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/createWithList"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUsersWithListInput")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/createWithList"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -239,8 +254,12 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/{username}"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.DeleteUser")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -307,8 +326,12 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 		localVarReturnValue  User
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/{username}"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.GetUserByName")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -396,8 +419,13 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 		localVarReturnValue  string
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/login"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.LoginUser")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/login"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -481,8 +509,13 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/logout"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.LogoutUser")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/logout"
+
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -547,8 +580,12 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, body 
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/{username}"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.UpdateUser")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)

--- a/samples/client/petstore/go-experimental/go-petstore/client.go
+++ b/samples/client/petstore/go-experimental/go-petstore/client.go
@@ -197,11 +197,6 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-// ChangeBasePath changes base path to allow switching to mocks
-func (c *APIClient) ChangeBasePath(path string) {
-	c.cfg.BasePath = path
-}
-
 // Allow modification of underlying config for alternate implementations and testing
 // Caution: modifying the configuration while live can cause data races and potentially unwanted behavior
 func (c *APIClient) GetConfig() *Configuration {

--- a/samples/client/petstore/go-experimental/go-petstore/configuration.go
+++ b/samples/client/petstore/go-experimental/go-petstore/configuration.go
@@ -181,7 +181,7 @@ func getServerVariables(ctx context.Context) (map[string]string, error) {
 		if variables, ok := sv.(map[string]string); ok {
 			return variables, nil
 		}
-		return nil, reportError("Invalid type %T should be map[string]string", sv)
+		return nil, reportError("ctx value of ContextServerVariables has invalid type %T should be map[string]string", sv)
 	}
 	return nil, nil
 }
@@ -190,7 +190,7 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 	osv := ctx.Value(ContextOperationServerVariables)
 	if osv != nil {
 		if operationVariables, ok := osv.(map[string]map[string]string); !ok {
-			return nil, reportError("Invalid type %T should be map[string]map[string]string", osv)
+			return nil, reportError("ctx value of ContextOperationServerVariables has invalid type %T should be map[string]map[string]string", osv)
 		} else {
 			variables, ok := operationVariables[endpoint]
 			if ok {
@@ -203,13 +203,13 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 
 // ServerURLWithContext returns a new server URL given an endpoint
 func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint string) (string, error) {
-	if ctx == nil {
-		return sc.URL(0, nil)
-	}
-
 	sc, ok := c.OperationServers[endpoint]
 	if !ok {
 		sc = c.Servers
+	}
+
+	if ctx == nil {
+		return sc.URL(0, nil)
 	}
 
 	index, err := getServerOperationIndex(ctx, endpoint)

--- a/samples/client/petstore/go-experimental/go-petstore/configuration.go
+++ b/samples/client/petstore/go-experimental/go-petstore/configuration.go
@@ -83,7 +83,6 @@ type ServerConfigurations []ServerConfiguration
 
 // Configuration stores the configuration of the API client
 type Configuration struct {
-	BasePath         string            `json:"basePath,omitempty"`
 	Host             string            `json:"host,omitempty"`
 	Scheme           string            `json:"scheme,omitempty"`
 	DefaultHeader    map[string]string `json:"defaultHeader,omitempty"`
@@ -97,7 +96,6 @@ type Configuration struct {
 // NewConfiguration returns a new Configuration object
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:         "http://petstore.swagger.io:80/v2",
 		DefaultHeader:    make(map[string]string),
 		UserAgent:        "OpenAPI-Generator/1.0.0/go",
 		Debug:            false,
@@ -206,7 +204,7 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 // ServerURLWithContext returns a new server URL given an endpoint
 func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint string) (string, error) {
 	if ctx == nil {
-		return c.BasePath, nil
+		return sc.URL(0, nil)
 	}
 
 	sc, ok := c.OperationServers[endpoint]
@@ -224,10 +222,5 @@ func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint strin
 		return "", err
 	}
 
-	url, err := sc.URL(index, variables)
-	if err != nil {
-		return "", err
-	}
-
-	return url, nil
+	return sc.URL(index, variables)
 }

--- a/samples/client/petstore/go-experimental/go-petstore/configuration.go
+++ b/samples/client/petstore/go-experimental/go-petstore/configuration.go
@@ -73,7 +73,7 @@ type ServerVariable struct {
 
 // ServerConfiguration stores the information about a server
 type ServerConfiguration struct {
-	Url string
+	URL string
 	Description string
 	Variables map[string]ServerVariable
 }
@@ -103,7 +103,7 @@ func NewConfiguration() *Configuration {
 		Debug:            false,
 		Servers:          ServerConfigurations{
 		{
-			Url: "http://petstore.swagger.io:80/v2",
+			URL: "http://petstore.swagger.io:80/v2",
 			Description: "No description provided",
 		},
 		},
@@ -118,13 +118,13 @@ func (c *Configuration) AddDefaultHeader(key string, value string) {
 	c.DefaultHeader[key] = value
 }
 
-// ServerUrl returns URL based on variables
-func (sc ServerConfigurations) Url(index int, variables map[string]string) (string, error) {
+// URL formats template on a index using given variables
+func (sc ServerConfigurations) URL(index int, variables map[string]string) (string, error) {
 	if index < 0 || len(sc) <= index {
 		return "", fmt.Errorf("Index %v out of range %v", index, len(sc)-1)
 	}
 	server := sc[index]
-	url := server.Url
+	url := server.URL
 
 	// go through variables and replace placeholders
 	for name, variable := range server.Variables {
@@ -146,9 +146,9 @@ func (sc ServerConfigurations) Url(index int, variables map[string]string) (stri
 	return url, nil
 }
 
-// ServerUrl returns URL based on server settings
-func (c *Configuration) ServerUrl(index int, variables map[string]string) (string, error) {
-	return c.Servers.Url(index, variables)
+// ServerURL returns URL based on server settings
+func (c *Configuration) ServerURL(index int, variables map[string]string) (string, error) {
+	return c.Servers.URL(index, variables)
 }
 
 func getServerIndex(ctx context.Context) (int, error) {
@@ -203,8 +203,8 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 	return getServerVariables(ctx)
 }
 
-// ServerUrlWithContext returns a new server URL given an endpoint
-func (c *Configuration) ServerUrlWithContext(ctx context.Context, endpoint string) (string, error) {
+// ServerURLWithContext returns a new server URL given an endpoint
+func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint string) (string, error) {
 	if ctx == nil {
 		return c.BasePath, nil
 	}
@@ -224,7 +224,7 @@ func (c *Configuration) ServerUrlWithContext(ctx context.Context, endpoint strin
 		return "", err
 	}
 
-	url, err := sc.Url(index, variables)
+	url, err := sc.URL(index, variables)
 	if err != nil {
 		return "", err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/README.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/README.md
@@ -26,6 +26,47 @@ Put the package under your project folder and add the following in import:
 import sw "./openapi"
 ```
 
+## Configuration of Server URL
+
+Default configuration comes with `Servers` field that contains server objects as defined in the OpenAPI specification.
+
+### Select Server Configuration
+
+For using other server than the one defined on index 0 set context value `sw.ContextServerIndex` of type `int`.
+
+```golang
+ctx := context.WithValue(context.Background(), sw.ContextServerIndex, 1)
+```
+
+### Templated Server URL
+
+Templated server URL is formatted using default variables from configuration or from context value `sw.ContextServerVariables` of type `map[string]string`.
+
+```golang
+ctx := context.WithValue(context.Background(), sw.ContextServerVariables, map[string]string{
+	"basePath": "v2",
+})
+```
+
+Note, enum values are always validated and all unused variables are silently ignored.
+
+### URLs Configuration per Operation
+
+Each operation can use different server URL defined using `OperationServers` map in the `Configuration`.
+An operation is uniquely identifield by `"{classname}Service.{nickname}"` string.
+Similar rules for overriding default operation server index and variables applies by using `sw.ContextOperationServerIndices` and `sw.ContextOperationServerVariables` context maps.
+
+```
+ctx := context.WithValue(context.Background(), sw.ContextOperationServerIndices, map[string]int{
+	"{classname}Service.{nickname}": 2,
+})
+ctx = context.WithValue(context.Background(), sw.ContextOperationServerVariables, map[string]map[string]string{
+	"{classname}Service.{nickname}": {
+		"port": "8443",
+	},
+})
+```
+
 ## Documentation for API Endpoints
 
 All URIs are relative to *http://petstore.swagger.io:80/v2*

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -41,8 +41,12 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, cli
 		localVarReturnValue  Client
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/another-fake/dummy"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "AnotherFakeApiService.Call123TestSpecialTags")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/another-fake/dummy"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -41,7 +41,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, cli
 		localVarReturnValue  Client
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "AnotherFakeApiService.Call123TestSpecialTags")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "AnotherFakeApiService.Call123TestSpecialTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
@@ -39,7 +39,7 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) (InlineResponseDefault,
 		localVarReturnValue  InlineResponseDefault
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "DefaultApiService.FooGet")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "DefaultApiService.FooGet")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
@@ -39,8 +39,12 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) (InlineResponseDefault,
 		localVarReturnValue  InlineResponseDefault
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/foo"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "DefaultApiService.FooGet")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/foo"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -42,7 +42,7 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 		localVarReturnValue  HealthCheckResult
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeHealthGet")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeHealthGet")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -138,7 +138,7 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		localVarReturnValue  bool
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterBooleanSerialize")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterBooleanSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -239,7 +239,7 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		localVarReturnValue  OuterComposite
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterCompositeSerialize")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterCompositeSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -344,7 +344,7 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		localVarReturnValue  float32
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterNumberSerialize")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterNumberSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -445,7 +445,7 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		localVarReturnValue  string
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterStringSerialize")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterStringSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -538,7 +538,7 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, fileSchema
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestBodyWithFileSchema")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithFileSchema")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -610,7 +610,7 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestBodyWithQueryParams")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithQueryParams")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -685,7 +685,7 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (C
 		localVarReturnValue  Client
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestClientModel")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestClientModel")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -803,7 +803,7 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestEndpointParameters")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEndpointParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -951,7 +951,7 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestEnumParameters")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEnumParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -1066,7 +1066,7 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestGroupParameters")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestGroupParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -1147,7 +1147,7 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, re
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestInlineAdditionalProperties")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestInlineAdditionalProperties")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -1219,7 +1219,7 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestJsonFormData")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestJsonFormData")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -1295,7 +1295,7 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestQueryParameterCollectionFormat")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestQueryParameterCollectionFormat")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -42,8 +42,12 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 		localVarReturnValue  HealthCheckResult
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/health"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeHealthGet")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/health"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -134,8 +138,12 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		localVarReturnValue  bool
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/outer/boolean"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterBooleanSerialize")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/outer/boolean"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -231,8 +239,12 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		localVarReturnValue  OuterComposite
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/outer/composite"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterCompositeSerialize")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/outer/composite"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -332,8 +344,12 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		localVarReturnValue  float32
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/outer/number"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterNumberSerialize")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/outer/number"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -429,8 +445,12 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		localVarReturnValue  string
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/outer/string"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.FakeOuterStringSerialize")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/outer/string"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -518,8 +538,12 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, fileSchema
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/body-with-file-schema"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestBodyWithFileSchema")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/body-with-file-schema"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -586,8 +610,12 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/body-with-query-params"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestBodyWithQueryParams")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/body-with-query-params"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -657,8 +685,12 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (C
 		localVarReturnValue  Client
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestClientModel")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -771,8 +803,12 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestEndpointParameters")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -915,8 +951,12 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestEnumParameters")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -1026,8 +1066,12 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestGroupParameters")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -1103,8 +1147,12 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, re
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/inline-additionalProperties"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestInlineAdditionalProperties")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/inline-additionalProperties"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -1171,8 +1219,12 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/jsonFormData"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestJsonFormData")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/jsonFormData"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -1243,8 +1295,12 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/test-query-paramters"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeApiService.TestQueryParameterCollectionFormat")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/test-query-paramters"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -41,7 +41,7 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, cli
 		localVarReturnValue  Client
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeClassnameTags123ApiService.TestClassname")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeClassnameTags123ApiService.TestClassname")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -41,8 +41,12 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, cli
 		localVarReturnValue  Client
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake_classname_test"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "FakeClassnameTags123ApiService.TestClassname")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake_classname_test"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -41,7 +41,7 @@ func (a *PetApiService) AddPet(ctx _context.Context, pet Pet) (*_nethttp.Respons
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.AddPet")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.AddPet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -119,7 +119,7 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.DeletePet")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.DeletePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -195,7 +195,7 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 		localVarReturnValue  []Pet
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.FindPetsByStatus")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByStatus")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -288,7 +288,7 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 		localVarReturnValue  []Pet
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.FindPetsByTags")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -381,7 +381,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 		localVarReturnValue  Pet
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.GetPetById")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.GetPetById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -485,7 +485,7 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, pet Pet) (*_nethttp.Resp
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UpdatePet")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -565,7 +565,7 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UpdatePetWithForm")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePetWithForm")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -652,7 +652,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		localVarReturnValue  ApiResponse
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UploadFile")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -768,7 +768,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 		localVarReturnValue  ApiResponse
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UploadFileWithRequiredFile")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFileWithRequiredFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 	"github.com/antihax/optional"
 	"os"
@@ -42,8 +41,12 @@ func (a *PetApiService) AddPet(ctx _context.Context, pet Pet) (*_nethttp.Respons
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.AddPet")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -116,9 +119,13 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.DeletePet")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/{petId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -188,8 +195,12 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 		localVarReturnValue  []Pet
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/findByStatus"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.FindPetsByStatus")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/findByStatus"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -277,8 +288,12 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 		localVarReturnValue  []Pet
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/findByTags"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.FindPetsByTags")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/findByTags"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -366,9 +381,13 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 		localVarReturnValue  Pet
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.GetPetById")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/{petId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -466,8 +485,12 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, pet Pet) (*_nethttp.Resp
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UpdatePet")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -542,9 +565,13 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UpdatePetWithForm")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/{petId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -625,9 +652,13 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		localVarReturnValue  ApiResponse
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/pet/{petId}/uploadImage"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UploadFile")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -737,9 +768,13 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 		localVarReturnValue  ApiResponse
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/fake/{petId}/uploadImageWithRequiredFile"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", petId)), -1)
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "PetApiService.UploadFileWithRequiredFile")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
@@ -40,7 +40,7 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.DeleteOrder")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.DeleteOrder")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -112,7 +112,7 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 		localVarReturnValue  map[string]int32
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.GetInventory")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetInventory")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -216,7 +216,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 		localVarReturnValue  Order
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.GetOrderById")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetOrderById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -314,7 +314,7 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, order Order) (Order, 
 		localVarReturnValue  Order
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.PlaceOrder")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.PlaceOrder")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 )
 
@@ -41,9 +40,13 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", orderId)), -1)
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.DeleteOrder")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/store/order/{order_id}"
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -109,8 +112,12 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 		localVarReturnValue  map[string]int32
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/store/inventory"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.GetInventory")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/store/inventory"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -209,9 +216,13 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 		localVarReturnValue  Order
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", orderId)), -1)
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.GetOrderById")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/store/order/{order_id}"
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -303,8 +314,12 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, order Order) (Order, 
 		localVarReturnValue  Order
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/store/order"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "StoreApiService.PlaceOrder")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/store/order"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
@@ -14,7 +14,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"fmt"
 	"strings"
 )
 
@@ -41,8 +40,12 @@ func (a *UserApiService) CreateUser(ctx _context.Context, user User) (*_nethttp.
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUser")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -108,8 +111,12 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, user []
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/createWithArray"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUsersWithArrayInput")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/createWithArray"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -175,8 +182,12 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, user []U
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/createWithList"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUsersWithListInput")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/createWithList"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -243,9 +254,13 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.DeleteUser")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/{username}"
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -311,9 +326,13 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 		localVarReturnValue  User
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.GetUserByName")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/{username}"
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -400,8 +419,12 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 		localVarReturnValue  string
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/login"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.LoginUser")
+	if err != nil {
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/login"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -486,8 +509,12 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/logout"
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.LogoutUser")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/logout"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -553,9 +580,13 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, user 
 		localVarFileBytes    []byte
 	)
 
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(fmt.Sprintf("%v", username)), -1)
+	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.UpdateUser")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/user/{username}"
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
@@ -40,7 +40,7 @@ func (a *UserApiService) CreateUser(ctx _context.Context, user User) (*_nethttp.
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUser")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -111,7 +111,7 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, user []
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUsersWithArrayInput")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithArrayInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -182,7 +182,7 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, user []U
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.CreateUsersWithListInput")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithListInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -254,7 +254,7 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.DeleteUser")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.DeleteUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -326,7 +326,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 		localVarReturnValue  User
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.GetUserByName")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.GetUserByName")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -419,7 +419,7 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 		localVarReturnValue  string
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.LoginUser")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LoginUser")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -509,7 +509,7 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.LogoutUser")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LogoutUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
@@ -580,7 +580,7 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, user 
 		localVarFileBytes    []byte
 	)
 
-	localBasePath, err := a.client.cfg.ServerUrlWithContext(ctx, "UserApiService.UpdateUser")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.UpdateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/client.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/client.go
@@ -200,11 +200,6 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-// ChangeBasePath changes base path to allow switching to mocks
-func (c *APIClient) ChangeBasePath(path string) {
-	c.cfg.BasePath = path
-}
-
 // Allow modification of underlying config for alternate implementations and testing
 // Caution: modifying the configuration while live can cause data races and potentially unwanted behavior
 func (c *APIClient) GetConfig() *Configuration {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/configuration.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/configuration.go
@@ -73,7 +73,7 @@ type ServerVariable struct {
 
 // ServerConfiguration stores the information about a server
 type ServerConfiguration struct {
-	Url string
+	URL string
 	Description string
 	Variables map[string]ServerVariable
 }
@@ -103,7 +103,7 @@ func NewConfiguration() *Configuration {
 		Debug:            false,
 		Servers:          ServerConfigurations{
 		{
-			Url: "http://{server}.swagger.io:{port}/v2",
+			URL: "http://{server}.swagger.io:{port}/v2",
 			Description: "petstore server",
 			Variables: map[string]ServerVariable{
 				"server": ServerVariable{
@@ -126,7 +126,7 @@ func NewConfiguration() *Configuration {
 			},
 		},
 		{
-			Url: "https://localhost:8080/{version}",
+			URL: "https://localhost:8080/{version}",
 			Description: "The local server",
 			Variables: map[string]ServerVariable{
 				"version": ServerVariable{
@@ -143,21 +143,21 @@ func NewConfiguration() *Configuration {
 		OperationServers: map[string]ServerConfigurations{
 			"PetApiService.AddPet": {
 				{
-					Url: "http://petstore.swagger.io/v2",
+					URL: "http://petstore.swagger.io/v2",
 					Description: "No description provided",
 				},
 				{
-					Url: "http://path-server-test.petstore.local/v2",
+					URL: "http://path-server-test.petstore.local/v2",
 					Description: "No description provided",
 				},
 			},
 			"PetApiService.UpdatePet": {
 				{
-					Url: "http://petstore.swagger.io/v2",
+					URL: "http://petstore.swagger.io/v2",
 					Description: "No description provided",
 				},
 				{
-					Url: "http://path-server-test.petstore.local/v2",
+					URL: "http://path-server-test.petstore.local/v2",
 					Description: "No description provided",
 				},
 			},
@@ -171,13 +171,13 @@ func (c *Configuration) AddDefaultHeader(key string, value string) {
 	c.DefaultHeader[key] = value
 }
 
-// ServerUrl returns URL based on variables
-func (sc ServerConfigurations) Url(index int, variables map[string]string) (string, error) {
+// URL formats template on a index using given variables
+func (sc ServerConfigurations) URL(index int, variables map[string]string) (string, error) {
 	if index < 0 || len(sc) <= index {
 		return "", fmt.Errorf("Index %v out of range %v", index, len(sc)-1)
 	}
 	server := sc[index]
-	url := server.Url
+	url := server.URL
 
 	// go through variables and replace placeholders
 	for name, variable := range server.Variables {
@@ -199,9 +199,9 @@ func (sc ServerConfigurations) Url(index int, variables map[string]string) (stri
 	return url, nil
 }
 
-// ServerUrl returns URL based on server settings
-func (c *Configuration) ServerUrl(index int, variables map[string]string) (string, error) {
-	return c.Servers.Url(index, variables)
+// ServerURL returns URL based on server settings
+func (c *Configuration) ServerURL(index int, variables map[string]string) (string, error) {
+	return c.Servers.URL(index, variables)
 }
 
 func getServerIndex(ctx context.Context) (int, error) {
@@ -256,8 +256,8 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 	return getServerVariables(ctx)
 }
 
-// ServerUrlWithContext returns a new server URL given an endpoint
-func (c *Configuration) ServerUrlWithContext(ctx context.Context, endpoint string) (string, error) {
+// ServerURLWithContext returns a new server URL given an endpoint
+func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint string) (string, error) {
 	if ctx == nil {
 		return c.BasePath, nil
 	}
@@ -277,7 +277,7 @@ func (c *Configuration) ServerUrlWithContext(ctx context.Context, endpoint strin
 		return "", err
 	}
 
-	url, err := sc.Url(index, variables)
+	url, err := sc.URL(index, variables)
 	if err != nil {
 		return "", err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/configuration.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/configuration.go
@@ -10,6 +10,7 @@
 package openapi
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -37,6 +38,18 @@ var (
 
 	// ContextAPIKeys takes a string apikey as authentication for the request
 	ContextAPIKeys = contextKey("apiKeys")
+
+	// ContextServerIndex uses a server configuration from the index.
+	ContextServerIndex = contextKey("serverIndex")
+
+	// ContextOperationServerIndices uses a server configuration from the index mapping.
+	ContextOperationServerIndices = contextKey("serverOperationIndices")
+
+	// ContextServerVariables overrides a server configuration variables.
+	ContextServerVariables = contextKey("serverVariables")
+
+	// ContextOperationServerVariables overrides a server configuration variables using operation specific values.
+	ContextOperationServerVariables = contextKey("serverOperationVariables")
 )
 
 // BasicAuth provides basic http authentication to a request passed via context using ContextBasicAuth
@@ -65,26 +78,31 @@ type ServerConfiguration struct {
 	Variables map[string]ServerVariable
 }
 
+// ServerConfigurations stores multiple ServerConfiguration items
+type ServerConfigurations []ServerConfiguration
+
 // Configuration stores the configuration of the API client
 type Configuration struct {
-	BasePath      string            `json:"basePath,omitempty"`
-	Host          string            `json:"host,omitempty"`
-	Scheme        string            `json:"scheme,omitempty"`
-	DefaultHeader map[string]string `json:"defaultHeader,omitempty"`
-	UserAgent     string            `json:"userAgent,omitempty"`
-	Debug         bool              `json:"debug,omitempty"`
-	Servers       []ServerConfiguration
-	HTTPClient    *http.Client
+	BasePath         string            `json:"basePath,omitempty"`
+	Host             string            `json:"host,omitempty"`
+	Scheme           string            `json:"scheme,omitempty"`
+	DefaultHeader    map[string]string `json:"defaultHeader,omitempty"`
+	UserAgent        string            `json:"userAgent,omitempty"`
+	Debug            bool              `json:"debug,omitempty"`
+	Servers          ServerConfigurations
+	OperationServers map[string]ServerConfigurations
+	HTTPClient       *http.Client
 }
 
 // NewConfiguration returns a new Configuration object
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:      "http://petstore.swagger.io:80/v2",
-		DefaultHeader: make(map[string]string),
-		UserAgent:     "OpenAPI-Generator/1.0.0/go",
-		Debug:         false,
-		Servers:       []ServerConfiguration{{
+		BasePath:         "http://petstore.swagger.io:80/v2",
+		DefaultHeader:    make(map[string]string),
+		UserAgent:        "OpenAPI-Generator/1.0.0/go",
+		Debug:            false,
+		Servers:          ServerConfigurations{
+		{
 			Url: "http://{server}.swagger.io:{port}/v2",
 			Description: "petstore server",
 			Variables: map[string]ServerVariable{
@@ -107,6 +125,7 @@ func NewConfiguration() *Configuration {
 				},
 			},
 		},
+		{
 			Url: "https://localhost:8080/{version}",
 			Description: "The local server",
 			Variables: map[string]ServerVariable{
@@ -121,6 +140,28 @@ func NewConfiguration() *Configuration {
 			},
 		},
 		},
+		OperationServers: map[string]ServerConfigurations{
+			"PetApiService.AddPet": {
+				{
+					Url: "http://petstore.swagger.io/v2",
+					Description: "No description provided",
+				},
+				{
+					Url: "http://path-server-test.petstore.local/v2",
+					Description: "No description provided",
+				},
+			},
+			"PetApiService.UpdatePet": {
+				{
+					Url: "http://petstore.swagger.io/v2",
+					Description: "No description provided",
+				},
+				{
+					Url: "http://path-server-test.petstore.local/v2",
+					Description: "No description provided",
+				},
+			},
+		},
 	}
 	return cfg
 }
@@ -130,12 +171,12 @@ func (c *Configuration) AddDefaultHeader(key string, value string) {
 	c.DefaultHeader[key] = value
 }
 
-// ServerUrl returns URL based on server settings
-func (c *Configuration) ServerUrl(index int, variables map[string]string) (string, error) {
-	if index < 0 || len(c.Servers) <= index {
-		return "", fmt.Errorf("Index %v out of range %v", index, len(c.Servers) - 1)
+// ServerUrl returns URL based on variables
+func (sc ServerConfigurations) Url(index int, variables map[string]string) (string, error) {
+	if index < 0 || len(sc) <= index {
+		return "", fmt.Errorf("Index %v out of range %v", index, len(sc)-1)
 	}
-	server := c.Servers[index]
+	server := sc[index]
 	url := server.Url
 
 	// go through variables and replace placeholders
@@ -155,5 +196,91 @@ func (c *Configuration) ServerUrl(index int, variables map[string]string) (strin
 			url = strings.Replace(url, "{"+name+"}", variable.DefaultValue, -1)
 		}
 	}
+	return url, nil
+}
+
+// ServerUrl returns URL based on server settings
+func (c *Configuration) ServerUrl(index int, variables map[string]string) (string, error) {
+	return c.Servers.Url(index, variables)
+}
+
+func getServerIndex(ctx context.Context) (int, error) {
+	si := ctx.Value(ContextServerIndex)
+	if si != nil {
+		if index, ok := si.(int); ok {
+			return index, nil
+		}
+		return 0, reportError("Invalid type %T should be int", si)
+	}
+	return 0, nil
+}
+
+func getServerOperationIndex(ctx context.Context, endpoint string) (int, error) {
+	osi := ctx.Value(ContextOperationServerIndices)
+	if osi != nil {
+		if operationIndices, ok := osi.(map[string]int); !ok {
+			return 0, reportError("Invalid type %T should be map[string]int", osi)
+		} else {
+			index, ok := operationIndices[endpoint]
+			if ok {
+				return index, nil
+			}
+		}
+	}
+	return getServerIndex(ctx)
+}
+
+func getServerVariables(ctx context.Context) (map[string]string, error) {
+	sv := ctx.Value(ContextServerVariables)
+	if sv != nil {
+		if variables, ok := sv.(map[string]string); ok {
+			return variables, nil
+		}
+		return nil, reportError("Invalid type %T should be map[string]string", sv)
+	}
+	return nil, nil
+}
+
+func getServerOperationVariables(ctx context.Context, endpoint string) (map[string]string, error) {
+	osv := ctx.Value(ContextOperationServerVariables)
+	if osv != nil {
+		if operationVariables, ok := osv.(map[string]map[string]string); !ok {
+			return nil, reportError("Invalid type %T should be map[string]map[string]string", osv)
+		} else {
+			variables, ok := operationVariables[endpoint]
+			if ok {
+				return variables, nil
+			}
+		}
+	}
+	return getServerVariables(ctx)
+}
+
+// ServerUrlWithContext returns a new server URL given an endpoint
+func (c *Configuration) ServerUrlWithContext(ctx context.Context, endpoint string) (string, error) {
+	if ctx == nil {
+		return c.BasePath, nil
+	}
+
+	sc, ok := c.OperationServers[endpoint]
+	if !ok {
+		sc = c.Servers
+	}
+
+	index, err := getServerOperationIndex(ctx, endpoint)
+	if err != nil {
+		return "", err
+	}
+
+	variables, err := getServerOperationVariables(ctx, endpoint)
+	if err != nil {
+		return "", err
+	}
+
+	url, err := sc.Url(index, variables)
+	if err != nil {
+		return "", err
+	}
+
 	return url, nil
 }

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/configuration.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/configuration.go
@@ -234,7 +234,7 @@ func getServerVariables(ctx context.Context) (map[string]string, error) {
 		if variables, ok := sv.(map[string]string); ok {
 			return variables, nil
 		}
-		return nil, reportError("Invalid type %T should be map[string]string", sv)
+		return nil, reportError("ctx value of ContextServerVariables has invalid type %T should be map[string]string", sv)
 	}
 	return nil, nil
 }
@@ -243,7 +243,7 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 	osv := ctx.Value(ContextOperationServerVariables)
 	if osv != nil {
 		if operationVariables, ok := osv.(map[string]map[string]string); !ok {
-			return nil, reportError("Invalid type %T should be map[string]map[string]string", osv)
+			return nil, reportError("ctx value of ContextOperationServerVariables has invalid type %T should be map[string]map[string]string", osv)
 		} else {
 			variables, ok := operationVariables[endpoint]
 			if ok {
@@ -256,13 +256,13 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 
 // ServerURLWithContext returns a new server URL given an endpoint
 func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint string) (string, error) {
-	if ctx == nil {
-		return sc.URL(0, nil)
-	}
-
 	sc, ok := c.OperationServers[endpoint]
 	if !ok {
 		sc = c.Servers
+	}
+
+	if ctx == nil {
+		return sc.URL(0, nil)
 	}
 
 	index, err := getServerOperationIndex(ctx, endpoint)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/configuration.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/configuration.go
@@ -83,7 +83,6 @@ type ServerConfigurations []ServerConfiguration
 
 // Configuration stores the configuration of the API client
 type Configuration struct {
-	BasePath         string            `json:"basePath,omitempty"`
 	Host             string            `json:"host,omitempty"`
 	Scheme           string            `json:"scheme,omitempty"`
 	DefaultHeader    map[string]string `json:"defaultHeader,omitempty"`
@@ -97,7 +96,6 @@ type Configuration struct {
 // NewConfiguration returns a new Configuration object
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
-		BasePath:         "http://petstore.swagger.io:80/v2",
 		DefaultHeader:    make(map[string]string),
 		UserAgent:        "OpenAPI-Generator/1.0.0/go",
 		Debug:            false,
@@ -259,7 +257,7 @@ func getServerOperationVariables(ctx context.Context, endpoint string) (map[stri
 // ServerURLWithContext returns a new server URL given an endpoint
 func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint string) (string, error) {
 	if ctx == nil {
-		return c.BasePath, nil
+		return sc.URL(0, nil)
 	}
 
 	sc, ok := c.OperationServers[endpoint]
@@ -277,10 +275,5 @@ func (c *Configuration) ServerURLWithContext(ctx context.Context, endpoint strin
 		return "", err
 	}
 
-	url, err := sc.URL(index, variables)
-	if err != nil {
-		return "", err
-	}
-
-	return url, nil
+	return sc.URL(index, variables)
 }


### PR DESCRIPTION
Support selection and formatting of endpoint servers using context.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

---
cc @antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)