### PR TITLE
Added members for circular refs and container of models

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -45,6 +45,7 @@ public class CodegenModel {
     public CodegenDiscriminator discriminator;
     public String defaultValue;
     public String arrayModelType;
+    public Set<String> circularReferences = new TreeSet<String>(); // store all classes cross referencing this
     public boolean isAlias; // Is this effectively an alias of another simple type
     public boolean isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble;
     public List<CodegenProperty> vars = new ArrayList<CodegenProperty>(); // all properties (without parent's properties)
@@ -248,6 +249,14 @@ public class CodegenModel {
 
     public void setArrayModelType(String arrayModelType) {
         this.arrayModelType = arrayModelType;
+    }
+
+    public Set<String> getCircularReferencess() {
+        return circularReferences;
+    }
+
+    public void setCircularReferences(Set<String> circularReferences) {
+        this.circularReferences = circularReferences;
     }
 
     public List<CodegenProperty> getVars() {
@@ -501,6 +510,7 @@ public class CodegenModel {
                 Objects.equals(discriminator, that.discriminator) &&
                 Objects.equals(defaultValue, that.defaultValue) &&
                 Objects.equals(arrayModelType, that.arrayModelType) &&
+                Objects.equals(circularReferences, that.circularReferences) &&
                 Objects.equals(vars, that.vars) &&
                 Objects.equals(allVars, that.allVars) &&
                 Objects.equals(requiredVars, that.requiredVars) &&
@@ -523,7 +533,7 @@ public class CodegenModel {
         return Objects.hash(parent, parentSchema, interfaces, allParents, parentModel, interfaceModels, children,
                 anyOf, oneOf, allOf, name, classname, title, description, classVarName, modelJson, dataType,
                 xmlPrefix, xmlNamespace, xmlName, classFilename, unescapedDescription, discriminator, defaultValue,
-                arrayModelType, isAlias, isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble,
+                arrayModelType, circularReferences, isAlias, isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble,
                 vars, allVars, requiredVars, optionalVars, readOnlyVars, readWriteVars, parentVars, allowableValues,
                 mandatory, allMandatory, imports, hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, isNullable,
                 hasRequired, hasOptional, isArrayModel, hasChildren, isMapModel, hasOnlyReadOnly,
@@ -558,6 +568,7 @@ public class CodegenModel {
         sb.append(", discriminator=").append(discriminator);
         sb.append(", defaultValue='").append(defaultValue).append('\'');
         sb.append(", arrayModelType='").append(arrayModelType).append('\'');
+        sb.append(", circularReferences='").append(circularReferences).append('\'');
         sb.append(", isAlias=").append(isAlias);
         sb.append(", isString=").append(isString);
         sb.append(", isInteger=").append(isInteger);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -56,7 +56,7 @@ public class CodegenProperty implements Cloneable {
     public boolean isPrimitiveType, isModel, isContainer;
     public boolean isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBinary, isFile,
             isBoolean, isDate, isDateTime, isUuid, isUri, isEmail, isFreeFormObject;
-    public boolean isListContainer, isMapContainer;
+    public boolean isListContainer, isMapContainer, isModelContainer;
     public boolean isEnum;
     public boolean isReadOnly;
     public boolean isWriteOnly;
@@ -493,6 +493,7 @@ public class CodegenProperty implements Cloneable {
         sb.append(", isFreeFormObject=").append(isFreeFormObject);
         sb.append(", isListContainer=").append(isListContainer);
         sb.append(", isMapContainer=").append(isMapContainer);
+        sb.append(", isModelContainer=").append(isModelContainer);
         sb.append(", isEnum=").append(isEnum);
         sb.append(", isReadOnly=").append(isReadOnly);
         sb.append(", isWriteOnly=").append(isWriteOnly);
@@ -553,6 +554,7 @@ public class CodegenProperty implements Cloneable {
                 isFreeFormObject == that.isFreeFormObject &&
                 isListContainer == that.isListContainer &&
                 isMapContainer == that.isMapContainer &&
+                isModelContainer == that.isModelContainer &&
                 isEnum == that.isEnum &&
                 isReadOnly == that.isReadOnly &&
                 isWriteOnly == that.isWriteOnly &&
@@ -612,8 +614,8 @@ public class CodegenProperty implements Cloneable {
                 minimum, maximum, exclusiveMinimum, exclusiveMaximum, hasMore, required, secondaryParam,
                 hasMoreNonReadOnly, isPrimitiveType, isModel, isContainer, isString, isNumeric, isInteger,
                 isLong, isNumber, isFloat, isDouble, isByteArray, isBinary, isFile, isBoolean, isDate, isDateTime,
-                isUuid, isUri, isEmail, isFreeFormObject, isListContainer, isMapContainer, isEnum, isReadOnly,
-                isWriteOnly, isNullable, isSelfReference, _enum, allowableValues, items, mostInnerItems,
+                isUuid, isUri, isEmail, isFreeFormObject, isListContainer, isMapContainer, isModelContainer, isEnum,
+                isReadOnly, isWriteOnly, isNullable, isSelfReference, _enum, allowableValues, items, mostInnerItems,
                 vendorExtensions, hasValidation, isInherited, discriminatorValue, nameInCamelCase, nameInSnakeCase,
                 enumName, maxItems, minItems, isXmlAttribute, xmlPrefix, xmlName, xmlNamespace, isXmlWrapped);
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -257,7 +257,7 @@ public class DefaultCodegen implements CodegenConfig {
         return objs;
     }
 
-    /**
+   /**
      * Loop through all models to update different flags (e.g. isSelfReference), children models, etc
      *
      * @param objs Map of models
@@ -1948,6 +1948,12 @@ public class DefaultCodegen implements CodegenConfig {
             addVars(m, unaliasPropertySchema(schema.getProperties()), schema.getRequired(), null, null);
         }
 
+        if (ModelUtils.isObjectSchema(schema)) {
+            for (String reference : ModelUtils.getCircularReferencedSchemaNames(this.openAPI, name, schema)) {
+                m.circularReferences.add(toModelName(reference));
+            }
+        }
+
         // remove duplicated properties
         m.removeAllDuplicatedProperty();
 
@@ -2299,6 +2305,9 @@ public class DefaultCodegen implements CodegenConfig {
             }
             CodegenProperty cp = fromProperty(itemName, innerSchema);
             updatePropertyForArray(property, cp);
+            // set flag if container contains models
+            Schema refOrCurrent = ModelUtils.getReferencedSchema(this.openAPI, innerSchema);
+            property.isModelContainer = (ModelUtils.isComposedSchema(refOrCurrent) || ModelUtils.isObjectSchema(refOrCurrent)) && ModelUtils.isModel(refOrCurrent);
         } else if (ModelUtils.isMapSchema(p)) {
             property.isContainer = true;
             property.isMapContainer = true;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -652,6 +652,17 @@ public class ModelUtils {
         return references;
     }
 
+    /**
+     * If a Schema contains circular references, stores detected schema names in 'set', does skip self reference
+     * and supports cross reference.
+     *
+     * @param openAPI specification being checked
+     * @param name    name of the model
+     * @param model   potentially containing a '$ref'
+     * @param set     set which stores all schemas in a cycle referencing the schema of param name
+     * @param visited set which stores already visited schemas
+     * @return        'true' if a cycle for given schema is detected, false if not
+     */
     private static boolean detectCircularReferences(OpenAPI openAPI, String name, Schema model, Set<String> set, Set<String> visited) {
         boolean cycleDetected = false;
         Map<String, Schema> properties = model.getProperties();


### PR DESCRIPTION
Added a member `circularReferences` to CodegenModel which stores all circular referenced schemas. Created ModelUtils method `getCircularReferencedSchemaNames()` to call recursive `detectCircularReferences()` to store all found circular references in a Set of strings. Set gets stored in `circularReferences`.

Add a member flag to CodegenProperty which is true if an array schema consists of object schema items.

<!-- Please check the completed items below -->
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Related feature request

#4757

### Additional context

First pull request(s), hopefully doing everything right!

### technical committee

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10)
