### PR TITLE
[core] Validation properties standardization

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenModel.java
@@ -19,12 +19,11 @@ package org.openapitools.codegen;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.models.ExternalDocumentation;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.*;
 
 @JsonIgnoreProperties({"parentModel", "interfaceModels"})
-public class CodegenModel {
+public class CodegenModel implements IJsonSchemaValidationProperties {
     public String parent, parentSchema;
     public List<String> interfaces;
     public List<String> allParents;
@@ -70,176 +69,57 @@ public class CodegenModel {
     //The type of the value from additional properties. Used in map like objects.
     public String additionalPropertiesType;
 
-    public String getParent() {
-        return parent;
+    private Integer maxProperties;
+    private Integer minProperties;
+    private boolean uniqueItems;
+    private Integer maxItems;
+    private Integer minItems;
+    private Integer maxLength;
+    private Integer minLength;
+    private boolean exclusiveMinimum;
+    private boolean exclusiveMaximum;
+    private String minimum;
+    private String maximum;
+    private String pattern;
+
+    public String getAdditionalPropertiesType() {
+        return additionalPropertiesType;
     }
 
-    public void setParent(String parent) {
-        this.parent = parent;
+    public void setAdditionalPropertiesType(String additionalPropertiesType) {
+        this.additionalPropertiesType = additionalPropertiesType;
     }
 
-    public String getParentSchema() {
-        return parentSchema;
+    public Set<String> getAllMandatory() {
+        return allMandatory;
     }
 
-    public void setParentSchema(String parentSchema) {
-        this.parentSchema = parentSchema;
-    }
-
-    public List<String> getInterfaces() {
-        return interfaces;
+    public void setAllMandatory(Set<String> allMandatory) {
+        this.allMandatory = allMandatory;
     }
 
     public List<String> getAllParents() {
         return allParents;
     }
 
-    public void setInterfaces(List<String> interfaces) {
-        this.interfaces = interfaces;
-    }
-
     public void setAllParents(List<String> allParents) {
         this.allParents = allParents;
     }
 
-    public CodegenModel getParentModel() {
-        return parentModel;
+    public List<CodegenProperty> getAllVars() {
+        return allVars;
     }
 
-    public void setParentModel(CodegenModel parentModel) {
-        this.parentModel = parentModel;
+    public void setAllVars(List<CodegenProperty> allVars) {
+        this.allVars = allVars;
     }
 
-    public List<CodegenModel> getInterfaceModels() {
-        return interfaceModels;
+    public Map<String, Object> getAllowableValues() {
+        return allowableValues;
     }
 
-    public void setInterfaceModels(List<CodegenModel> interfaceModels) {
-        this.interfaceModels = interfaceModels;
-    }
-
-    public List<CodegenModel> getChildren() {
-        return children;
-    }
-
-    public void setChildren(List<CodegenModel> children) {
-        this.children = children;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getClassname() {
-        return classname;
-    }
-
-    public void setClassname(String classname) {
-        this.classname = classname;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getClassVarName() {
-        return classVarName;
-    }
-
-    public void setClassVarName(String classVarName) {
-        this.classVarName = classVarName;
-    }
-
-    public String getModelJson() {
-        return modelJson;
-    }
-
-    public void setModelJson(String modelJson) {
-        this.modelJson = modelJson;
-    }
-
-    public String getDataType() {
-        return dataType;
-    }
-
-    public void setDataType(String dataType) {
-        this.dataType = dataType;
-    }
-
-    public String getXmlPrefix() {
-        return xmlPrefix;
-    }
-
-    public void setXmlPrefix(String xmlPrefix) {
-        this.xmlPrefix = xmlPrefix;
-    }
-
-    public String getXmlNamespace() {
-        return xmlNamespace;
-    }
-
-    public void setXmlNamespace(String xmlNamespace) {
-        this.xmlNamespace = xmlNamespace;
-    }
-
-    public String getXmlName() {
-        return xmlName;
-    }
-
-    public void setXmlName(String xmlName) {
-        this.xmlName = xmlName;
-    }
-
-    public String getClassFilename() {
-        return classFilename;
-    }
-
-    public void setClassFilename(String classFilename) {
-        this.classFilename = classFilename;
-    }
-
-    public String getUnescapedDescription() {
-        return unescapedDescription;
-    }
-
-    public void setUnescapedDescription(String unescapedDescription) {
-        this.unescapedDescription = unescapedDescription;
-    }
-
-    public CodegenDiscriminator getDiscriminator() {
-        return discriminator;
-    }
-
-    public String getDiscriminatorName() {
-        return discriminator == null ? null : discriminator.getPropertyName();
-    }
-
-    public void setDiscriminator(CodegenDiscriminator discriminator) {
-        this.discriminator = discriminator;
-    }
-
-    public String getDefaultValue() {
-        return defaultValue;
-    }
-
-    public void setDefaultValue(String defaultValue) {
-        this.defaultValue = defaultValue;
+    public void setAllowableValues(Map<String, Object> allowableValues) {
+        this.allowableValues = allowableValues;
     }
 
     public String getArrayModelType() {
@@ -250,20 +130,128 @@ public class CodegenModel {
         this.arrayModelType = arrayModelType;
     }
 
-    public List<CodegenProperty> getVars() {
-        return vars;
+    public List<CodegenModel> getChildren() {
+        return children;
     }
 
-    public void setVars(List<CodegenProperty> vars) {
-        this.vars = vars;
+    public void setChildren(List<CodegenModel> children) {
+        this.children = children;
     }
 
-    public List<CodegenProperty> getRequiredVars() {
-        return requiredVars;
+    public String getClassFilename() {
+        return classFilename;
     }
 
-    public void setRequiredVars(List<CodegenProperty> requiredVars) {
-        this.requiredVars = requiredVars;
+    public void setClassFilename(String classFilename) {
+        this.classFilename = classFilename;
+    }
+
+    public String getClassVarName() {
+        return classVarName;
+    }
+
+    public void setClassVarName(String classVarName) {
+        this.classVarName = classVarName;
+    }
+
+    public String getClassname() {
+        return classname;
+    }
+
+    public void setClassname(String classname) {
+        this.classname = classname;
+    }
+
+    public String getDataType() {
+        return dataType;
+    }
+
+    public void setDataType(String dataType) {
+        this.dataType = dataType;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public CodegenDiscriminator getDiscriminator() {
+        return discriminator;
+    }
+
+    public void setDiscriminator(CodegenDiscriminator discriminator) {
+        this.discriminator = discriminator;
+    }
+
+    public String getDiscriminatorName() {
+        return discriminator == null ? null : discriminator.getPropertyName();
+    }
+
+    public ExternalDocumentation getExternalDocumentation() {
+        return externalDocumentation;
+    }
+
+    public void setExternalDocumentation(ExternalDocumentation externalDocumentation) {
+        this.externalDocumentation = externalDocumentation;
+    }
+
+    public Set<String> getImports() {
+        return imports;
+    }
+
+    public void setImports(Set<String> imports) {
+        this.imports = imports;
+    }
+
+    public List<CodegenModel> getInterfaceModels() {
+        return interfaceModels;
+    }
+
+    public void setInterfaceModels(List<CodegenModel> interfaceModels) {
+        this.interfaceModels = interfaceModels;
+    }
+
+    public List<String> getInterfaces() {
+        return interfaces;
+    }
+
+    public void setInterfaces(List<String> interfaces) {
+        this.interfaces = interfaces;
+    }
+
+    public Set<String> getMandatory() {
+        return mandatory;
+    }
+
+    public void setMandatory(Set<String> mandatory) {
+        this.mandatory = mandatory;
+    }
+
+    public String getModelJson() {
+        return modelJson;
+    }
+
+    public void setModelJson(String modelJson) {
+        this.modelJson = modelJson;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public List<CodegenProperty> getOptionalVars() {
@@ -272,6 +260,158 @@ public class CodegenModel {
 
     public void setOptionalVars(List<CodegenProperty> optionalVars) {
         this.optionalVars = optionalVars;
+    }
+
+    public String getParent() {
+        return parent;
+    }
+
+    public void setParent(String parent) {
+        this.parent = parent;
+    }
+
+    public CodegenModel getParentModel() {
+        return parentModel;
+    }
+
+    public void setParentModel(CodegenModel parentModel) {
+        this.parentModel = parentModel;
+    }
+
+    public String getParentSchema() {
+        return parentSchema;
+    }
+
+    public void setParentSchema(String parentSchema) {
+        this.parentSchema = parentSchema;
+    }
+
+    public List<CodegenProperty> getParentVars() {
+        return parentVars;
+    }
+
+    public void setParentVars(List<CodegenProperty> parentVars) {
+        this.parentVars = parentVars;
+    }
+
+    @Override
+    public String getPattern() {
+        return pattern;
+    }
+
+    @Override
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public String getMaximum() {
+        return maximum;
+    }
+
+    @Override
+    public void setMaximum(String maximum) {
+        this.maximum = maximum;
+    }
+
+    @Override
+    public String getMinimum() {
+        return minimum;
+    }
+
+    @Override
+    public void setMinimum(String minimum) {
+        this.minimum = minimum;
+    }
+
+    @Override
+    public boolean getExclusiveMaximum() {
+        return exclusiveMaximum;
+    }
+
+    @Override
+    public void setExclusiveMaximum(boolean exclusiveMaximum) {
+        this.exclusiveMaximum = exclusiveMaximum;
+    }
+
+    @Override
+    public boolean getExclusiveMinimum() {
+        return exclusiveMinimum;
+    }
+
+    @Override
+    public void setExclusiveMinimum(boolean exclusiveMinimum) {
+        this.exclusiveMinimum = exclusiveMinimum;
+    }
+
+    @Override
+    public Integer getMinLength() {
+        return minLength;
+    }
+
+    @Override
+    public void setMinLength(Integer minLength) {
+        this.minLength = minLength;
+    }
+
+    @Override
+    public Integer getMaxLength() {
+        return maxLength;
+    }
+
+    @Override
+    public void setMaxLength(Integer maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    @Override
+    public Integer getMinItems() {
+        return minItems;
+    }
+
+    @Override
+    public void setMinItems(Integer minItems) {
+        this.minItems = minItems;
+    }
+
+    @Override
+    public Integer getMaxItems() {
+        return maxItems;
+    }
+
+    @Override
+    public void setMaxItems(Integer maxItems) {
+        this.maxItems = maxItems;
+    }
+
+    @Override
+    public boolean getUniqueItems() {
+        return uniqueItems;
+    }
+
+    @Override
+    public void setUniqueItems(boolean uniqueItems) {
+        this.uniqueItems = uniqueItems;
+    }
+
+    @Override
+    public Integer getMinProperties() {
+        return minProperties;
+    }
+
+    @Override
+    public void setMinProperties(Integer minProperties) {
+        this.minProperties = minProperties;
+    }
+
+    @Override
+    public Integer getMaxProperties() {
+        return maxProperties;
+    }
+
+    @Override
+    public void setMaxProperties(Integer maxProperties) {
+        this.maxProperties = maxProperties;
     }
 
     public List<CodegenProperty> getReadOnlyVars() {
@@ -290,68 +430,36 @@ public class CodegenModel {
         this.readWriteVars = readWriteVars;
     }
 
-    public List<CodegenProperty> getAllVars() {
-        return allVars;
+    public List<CodegenProperty> getRequiredVars() {
+        return requiredVars;
     }
 
-    public void setAllVars(List<CodegenProperty> allVars) {
-        this.allVars = allVars;
+    public void setRequiredVars(List<CodegenProperty> requiredVars) {
+        this.requiredVars = requiredVars;
     }
 
-    public List<CodegenProperty> getParentVars() {
-        return parentVars;
+    public String getTitle() {
+        return title;
     }
 
-    public void setParentVars(List<CodegenProperty> parentVars) {
-        this.parentVars = parentVars;
+    public void setTitle(String title) {
+        this.title = title;
     }
 
-    public Map<String, Object> getAllowableValues() {
-        return allowableValues;
+    public String getUnescapedDescription() {
+        return unescapedDescription;
     }
 
-    public void setAllowableValues(Map<String, Object> allowableValues) {
-        this.allowableValues = allowableValues;
+    public void setUnescapedDescription(String unescapedDescription) {
+        this.unescapedDescription = unescapedDescription;
     }
 
-    public Set<String> getMandatory() {
-        return mandatory;
+    public List<CodegenProperty> getVars() {
+        return vars;
     }
 
-    public void setMandatory(Set<String> mandatory) {
-        this.mandatory = mandatory;
-    }
-
-    public Set<String> getAllMandatory() {
-        return allMandatory;
-    }
-
-    public void setAllMandatory(Set<String> allMandatory) {
-        this.allMandatory = allMandatory;
-    }
-
-    public Set<String> getImports() {
-        return imports;
-    }
-
-    public void setImports(Set<String> imports) {
-        this.imports = imports;
-    }
-
-    public boolean isEmptyVars() {
-        return emptyVars;
-    }
-
-    public void setEmptyVars(boolean emptyVars) {
-        this.emptyVars = emptyVars;
-    }
-
-    public ExternalDocumentation getExternalDocumentation() {
-        return externalDocumentation;
-    }
-
-    public void setExternalDocumentation(ExternalDocumentation externalDocumentation) {
-        this.externalDocumentation = externalDocumentation;
+    public void setVars(List<CodegenProperty> vars) {
+        this.vars = vars;
     }
 
     public Map<String, Object> getVendorExtensions() {
@@ -362,12 +470,208 @@ public class CodegenModel {
         this.vendorExtensions = vendorExtensions;
     }
 
-    public String getAdditionalPropertiesType() {
-        return additionalPropertiesType;
+    public String getXmlName() {
+        return xmlName;
     }
 
-    public void setAdditionalPropertiesType(String additionalPropertiesType) {
-        this.additionalPropertiesType = additionalPropertiesType;
+    public void setXmlName(String xmlName) {
+        this.xmlName = xmlName;
+    }
+
+    public String getXmlNamespace() {
+        return xmlNamespace;
+    }
+
+    public void setXmlNamespace(String xmlNamespace) {
+        this.xmlNamespace = xmlNamespace;
+    }
+
+    public String getXmlPrefix() {
+        return xmlPrefix;
+    }
+
+    public void setXmlPrefix(String xmlPrefix) {
+        this.xmlPrefix = xmlPrefix;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CodegenModel)) return false;
+        CodegenModel that = (CodegenModel) o;
+        return isAlias == that.isAlias &&
+                isString == that.isString &&
+                isInteger == that.isInteger &&
+                isLong == that.isLong &&
+                isNumber == that.isNumber &&
+                isNumeric == that.isNumeric &&
+                isFloat == that.isFloat &&
+                isDouble == that.isDouble &&
+                hasVars == that.hasVars &&
+                emptyVars == that.emptyVars &&
+                hasMoreModels == that.hasMoreModels &&
+                hasEnums == that.hasEnums &&
+                isEnum == that.isEnum &&
+                isNullable == that.isNullable &&
+                hasRequired == that.hasRequired &&
+                hasOptional == that.hasOptional &&
+                isArrayModel == that.isArrayModel &&
+                hasChildren == that.hasChildren &&
+                isMapModel == that.isMapModel &&
+                hasOnlyReadOnly == that.hasOnlyReadOnly &&
+                getUniqueItems() == that.getUniqueItems() &&
+                getExclusiveMinimum() == that.getExclusiveMinimum() &&
+                getExclusiveMaximum() == that.getExclusiveMaximum() &&
+                Objects.equals(parent, that.parent) &&
+                Objects.equals(parentSchema, that.parentSchema) &&
+                Objects.equals(interfaces, that.interfaces) &&
+                Objects.equals(allParents, that.allParents) &&
+                Objects.equals(parentModel, that.parentModel) &&
+                Objects.equals(interfaceModels, that.interfaceModels) &&
+                Objects.equals(children, that.children) &&
+                Objects.equals(anyOf, that.anyOf) &&
+                Objects.equals(oneOf, that.oneOf) &&
+                Objects.equals(allOf, that.allOf) &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(classname, that.classname) &&
+                Objects.equals(title, that.title) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(classVarName, that.classVarName) &&
+                Objects.equals(modelJson, that.modelJson) &&
+                Objects.equals(dataType, that.dataType) &&
+                Objects.equals(xmlPrefix, that.xmlPrefix) &&
+                Objects.equals(xmlNamespace, that.xmlNamespace) &&
+                Objects.equals(xmlName, that.xmlName) &&
+                Objects.equals(classFilename, that.classFilename) &&
+                Objects.equals(unescapedDescription, that.unescapedDescription) &&
+                Objects.equals(discriminator, that.discriminator) &&
+                Objects.equals(defaultValue, that.defaultValue) &&
+                Objects.equals(arrayModelType, that.arrayModelType) &&
+                Objects.equals(vars, that.vars) &&
+                Objects.equals(allVars, that.allVars) &&
+                Objects.equals(requiredVars, that.requiredVars) &&
+                Objects.equals(optionalVars, that.optionalVars) &&
+                Objects.equals(readOnlyVars, that.readOnlyVars) &&
+                Objects.equals(readWriteVars, that.readWriteVars) &&
+                Objects.equals(parentVars, that.parentVars) &&
+                Objects.equals(allowableValues, that.allowableValues) &&
+                Objects.equals(mandatory, that.mandatory) &&
+                Objects.equals(allMandatory, that.allMandatory) &&
+                Objects.equals(imports, that.imports) &&
+                Objects.equals(externalDocumentation, that.externalDocumentation) &&
+                Objects.equals(vendorExtensions, that.vendorExtensions) &&
+                Objects.equals(additionalPropertiesType, that.additionalPropertiesType) &&
+                Objects.equals(getMaxProperties(), that.getMaxProperties()) &&
+                Objects.equals(getMinProperties(), that.getMinProperties()) &&
+                Objects.equals(getMaxItems(), that.getMaxItems()) &&
+                Objects.equals(getMinItems(), that.getMinItems()) &&
+                Objects.equals(getMaxLength(), that.getMaxLength()) &&
+                Objects.equals(getMinLength(), that.getMinLength()) &&
+                Objects.equals(getMinimum(), that.getMinimum()) &&
+                Objects.equals(getMaximum(), that.getMaximum()) &&
+                Objects.equals(getPattern(), that.getPattern());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getParent(), getParentSchema(), getInterfaces(), getAllParents(), getParentModel(),
+                getInterfaceModels(), getChildren(), anyOf, oneOf, allOf, getName(), getClassname(), getTitle(),
+                getDescription(), getClassVarName(), getModelJson(), getDataType(), getXmlPrefix(), getXmlNamespace(),
+                getXmlName(), getClassFilename(), getUnescapedDescription(), getDiscriminator(), getDefaultValue(),
+                getArrayModelType(), isAlias, isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble,
+                getVars(), getAllVars(), getRequiredVars(), getOptionalVars(), getReadOnlyVars(), getReadWriteVars(),
+                getParentVars(), getAllowableValues(), getMandatory(), getAllMandatory(), getImports(), hasVars,
+                isEmptyVars(), hasMoreModels, hasEnums, isEnum, isNullable, hasRequired, hasOptional, isArrayModel,
+                hasChildren, isMapModel, hasOnlyReadOnly, getExternalDocumentation(), getVendorExtensions(),
+                getAdditionalPropertiesType(), getMaxProperties(), getMinProperties(), getUniqueItems(), getMaxItems(),
+                getMinItems(), getMaxLength(), getMinLength(), getExclusiveMinimum(), getExclusiveMaximum(), getMinimum(),
+                getMaximum(), getPattern());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("CodegenModel{");
+        sb.append("parent='").append(parent).append('\'');
+        sb.append(", parentSchema='").append(parentSchema).append('\'');
+        sb.append(", interfaces=").append(interfaces);
+        sb.append(", allParents=").append(allParents);
+        sb.append(", parentModel=").append(parentModel);
+        sb.append(", interfaceModels=").append(interfaceModels);
+        sb.append(", children=").append(children);
+        sb.append(", anyOf=").append(anyOf);
+        sb.append(", oneOf=").append(oneOf);
+        sb.append(", allOf=").append(allOf);
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", classname='").append(classname).append('\'');
+        sb.append(", title='").append(title).append('\'');
+        sb.append(", description='").append(description).append('\'');
+        sb.append(", classVarName='").append(classVarName).append('\'');
+        sb.append(", modelJson='").append(modelJson).append('\'');
+        sb.append(", dataType='").append(dataType).append('\'');
+        sb.append(", xmlPrefix='").append(xmlPrefix).append('\'');
+        sb.append(", xmlNamespace='").append(xmlNamespace).append('\'');
+        sb.append(", xmlName='").append(xmlName).append('\'');
+        sb.append(", classFilename='").append(classFilename).append('\'');
+        sb.append(", unescapedDescription='").append(unescapedDescription).append('\'');
+        sb.append(", discriminator=").append(discriminator);
+        sb.append(", defaultValue='").append(defaultValue).append('\'');
+        sb.append(", arrayModelType='").append(arrayModelType).append('\'');
+        sb.append(", isAlias=").append(isAlias);
+        sb.append(", isString=").append(isString);
+        sb.append(", isInteger=").append(isInteger);
+        sb.append(", isLong=").append(isLong);
+        sb.append(", isNumber=").append(isNumber);
+        sb.append(", isNumeric=").append(isNumeric);
+        sb.append(", isFloat=").append(isFloat);
+        sb.append(", isDouble=").append(isDouble);
+        sb.append(", vars=").append(vars);
+        sb.append(", allVars=").append(allVars);
+        sb.append(", requiredVars=").append(requiredVars);
+        sb.append(", optionalVars=").append(optionalVars);
+        sb.append(", readOnlyVars=").append(readOnlyVars);
+        sb.append(", readWriteVars=").append(readWriteVars);
+        sb.append(", parentVars=").append(parentVars);
+        sb.append(", allowableValues=").append(allowableValues);
+        sb.append(", mandatory=").append(mandatory);
+        sb.append(", allMandatory=").append(allMandatory);
+        sb.append(", imports=").append(imports);
+        sb.append(", hasVars=").append(hasVars);
+        sb.append(", emptyVars=").append(emptyVars);
+        sb.append(", hasMoreModels=").append(hasMoreModels);
+        sb.append(", hasEnums=").append(hasEnums);
+        sb.append(", isEnum=").append(isEnum);
+        sb.append(", isNullable=").append(isNullable);
+        sb.append(", hasRequired=").append(hasRequired);
+        sb.append(", hasOptional=").append(hasOptional);
+        sb.append(", isArrayModel=").append(isArrayModel);
+        sb.append(", hasChildren=").append(hasChildren);
+        sb.append(", isMapModel=").append(isMapModel);
+        sb.append(", hasOnlyReadOnly=").append(hasOnlyReadOnly);
+        sb.append(", externalDocumentation=").append(externalDocumentation);
+        sb.append(", vendorExtensions=").append(vendorExtensions);
+        sb.append(", additionalPropertiesType='").append(additionalPropertiesType).append('\'');
+        sb.append(", maxProperties=").append(maxProperties);
+        sb.append(", minProperties=").append(minProperties);
+        sb.append(", uniqueItems=").append(uniqueItems);
+        sb.append(", maxItems=").append(maxItems);
+        sb.append(", minItems=").append(minItems);
+        sb.append(", maxLength=").append(maxLength);
+        sb.append(", minLength=").append(minLength);
+        sb.append(", exclusiveMinimum=").append(exclusiveMinimum);
+        sb.append(", exclusiveMaximum=").append(exclusiveMaximum);
+        sb.append(", minimum='").append(minimum).append('\'');
+        sb.append(", maximum='").append(maximum).append('\'');
+        sb.append(", pattern='").append(pattern).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public boolean isEmptyVars() {
+        return emptyVars;
+    }
+
+    public void setEmptyVars(boolean emptyVars) {
+        this.emptyVars = emptyVars;
     }
 
     /**
@@ -449,150 +753,5 @@ public class CodegenModel {
                 }
             }
         }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CodegenModel that = (CodegenModel) o;
-        return isAlias == that.isAlias &&
-                isString == that.isString &&
-                isInteger == that.isInteger &&
-                isLong == that.isLong &&
-                isNumber == that.isNumber &&
-                isNumeric == that.isNumeric &&
-                isFloat == that.isFloat &&
-                isDouble == that.isDouble &&
-                hasVars == that.hasVars &&
-                emptyVars == that.emptyVars &&
-                hasMoreModels == that.hasMoreModels &&
-                hasEnums == that.hasEnums &&
-                isEnum == that.isEnum &&
-                isNullable == that.isNullable &&
-                hasRequired == that.hasRequired &&
-                hasOptional == that.hasOptional &&
-                isArrayModel == that.isArrayModel &&
-                hasChildren == that.hasChildren &&
-                isMapModel == that.isMapModel &&
-                hasOnlyReadOnly == that.hasOnlyReadOnly &&
-                Objects.equals(parent, that.parent) &&
-                Objects.equals(parentSchema, that.parentSchema) &&
-                Objects.equals(interfaces, that.interfaces) &&
-                Objects.equals(allParents, that.allParents) &&
-                Objects.equals(parentModel, that.parentModel) &&
-                Objects.equals(interfaceModels, that.interfaceModels) &&
-                Objects.equals(children, that.children) &&
-                Objects.equals(anyOf, that.anyOf) &&
-                Objects.equals(oneOf, that.oneOf) &&
-                Objects.equals(allOf, that.allOf) &&
-                Objects.equals(name, that.name) &&
-                Objects.equals(classname, that.classname) &&
-                Objects.equals(title, that.title) &&
-                Objects.equals(description, that.description) &&
-                Objects.equals(classVarName, that.classVarName) &&
-                Objects.equals(modelJson, that.modelJson) &&
-                Objects.equals(dataType, that.dataType) &&
-                Objects.equals(xmlPrefix, that.xmlPrefix) &&
-                Objects.equals(xmlNamespace, that.xmlNamespace) &&
-                Objects.equals(xmlName, that.xmlName) &&
-                Objects.equals(classFilename, that.classFilename) &&
-                Objects.equals(unescapedDescription, that.unescapedDescription) &&
-                Objects.equals(discriminator, that.discriminator) &&
-                Objects.equals(defaultValue, that.defaultValue) &&
-                Objects.equals(arrayModelType, that.arrayModelType) &&
-                Objects.equals(vars, that.vars) &&
-                Objects.equals(allVars, that.allVars) &&
-                Objects.equals(requiredVars, that.requiredVars) &&
-                Objects.equals(optionalVars, that.optionalVars) &&
-                Objects.equals(readOnlyVars, that.readOnlyVars) &&
-                Objects.equals(readWriteVars, that.readWriteVars) &&
-                Objects.equals(parentVars, that.parentVars) &&
-                Objects.equals(allowableValues, that.allowableValues) &&
-                Objects.equals(mandatory, that.mandatory) &&
-                Objects.equals(allMandatory, that.allMandatory) &&
-                Objects.equals(imports, that.imports) &&
-                Objects.equals(externalDocumentation, that.externalDocumentation) &&
-                Objects.equals(vendorExtensions, that.vendorExtensions) &&
-                Objects.equals(additionalPropertiesType, that.additionalPropertiesType);
-    }
-
-    @Override
-    public int hashCode() {
-
-        return Objects.hash(parent, parentSchema, interfaces, allParents, parentModel, interfaceModels, children,
-                anyOf, oneOf, allOf, name, classname, title, description, classVarName, modelJson, dataType,
-                xmlPrefix, xmlNamespace, xmlName, classFilename, unescapedDescription, discriminator, defaultValue,
-                arrayModelType, isAlias, isString, isInteger, isLong, isNumber, isNumeric, isFloat, isDouble,
-                vars, allVars, requiredVars, optionalVars, readOnlyVars, readWriteVars, parentVars, allowableValues,
-                mandatory, allMandatory, imports, hasVars, emptyVars, hasMoreModels, hasEnums, isEnum, isNullable,
-                hasRequired, hasOptional, isArrayModel, hasChildren, isMapModel, hasOnlyReadOnly,
-                externalDocumentation, vendorExtensions, additionalPropertiesType);
-    }
-
-    @Override
-    public String toString() {
-        final StringBuffer sb = new StringBuffer("CodegenModel{");
-        sb.append("parent='").append(parent).append('\'');
-        sb.append(", parentSchema='").append(parentSchema).append('\'');
-        sb.append(", interfaces=").append(interfaces);
-        sb.append(", allParents=").append(allParents);
-        sb.append(", parentModel=").append(parentModel);
-        sb.append(", interfaceModels=").append(interfaceModels);
-        sb.append(", children=").append(children);
-        sb.append(", anyOf=").append(anyOf);
-        sb.append(", oneOf=").append(oneOf);
-        sb.append(", allOf=").append(allOf);
-        sb.append(", name='").append(name).append('\'');
-        sb.append(", classname='").append(classname).append('\'');
-        sb.append(", title='").append(title).append('\'');
-        sb.append(", description='").append(description).append('\'');
-        sb.append(", classVarName='").append(classVarName).append('\'');
-        sb.append(", modelJson='").append(modelJson).append('\'');
-        sb.append(", dataType='").append(dataType).append('\'');
-        sb.append(", xmlPrefix='").append(xmlPrefix).append('\'');
-        sb.append(", xmlNamespace='").append(xmlNamespace).append('\'');
-        sb.append(", xmlName='").append(xmlName).append('\'');
-        sb.append(", classFilename='").append(classFilename).append('\'');
-        sb.append(", unescapedDescription='").append(unescapedDescription).append('\'');
-        sb.append(", discriminator=").append(discriminator);
-        sb.append(", defaultValue='").append(defaultValue).append('\'');
-        sb.append(", arrayModelType='").append(arrayModelType).append('\'');
-        sb.append(", isAlias=").append(isAlias);
-        sb.append(", isString=").append(isString);
-        sb.append(", isInteger=").append(isInteger);
-        sb.append(", isLong=").append(isLong);
-        sb.append(", isNumber=").append(isNumber);
-        sb.append(", isNumeric=").append(isNumeric);
-        sb.append(", isFloat=").append(isFloat);
-        sb.append(", isDouble=").append(isDouble);
-        sb.append(", vars=").append(vars);
-        sb.append(", allVars=").append(allVars);
-        sb.append(", requiredVars=").append(requiredVars);
-        sb.append(", optionalVars=").append(optionalVars);
-        sb.append(", readOnlyVars=").append(readOnlyVars);
-        sb.append(", readWriteVars=").append(readWriteVars);
-        sb.append(", parentVars=").append(parentVars);
-        sb.append(", allowableValues=").append(allowableValues);
-        sb.append(", mandatory=").append(mandatory);
-        sb.append(", allMandatory=").append(allMandatory);
-        sb.append(", imports=").append(imports);
-        sb.append(", hasVars=").append(hasVars);
-        sb.append(", emptyVars=").append(emptyVars);
-        sb.append(", hasMoreModels=").append(hasMoreModels);
-        sb.append(", hasEnums=").append(hasEnums);
-        sb.append(", isEnum=").append(isEnum);
-        sb.append(", isNullable=").append(isNullable);
-        sb.append(", hasRequired=").append(hasRequired);
-        sb.append(", hasOptional=").append(hasOptional);
-        sb.append(", isArrayModel=").append(isArrayModel);
-        sb.append(", hasChildren=").append(hasChildren);
-        sb.append(", isMapModel=").append(isMapModel);
-        sb.append(", hasOnlyReadOnly=").append(hasOnlyReadOnly);
-        sb.append(", externalDocumentation=").append(externalDocumentation);
-        sb.append(", vendorExtensions=").append(vendorExtensions);
-        sb.append(", additionalPropertiesType='").append(additionalPropertiesType).append('\'');
-        sb.append('}');
-        return sb.toString();
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -17,13 +17,9 @@
 
 package org.openapitools.codegen;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
-public class CodegenParameter {
+public class CodegenParameter implements IJsonSchemaValidationProperties {
     public boolean isFormParam, isQueryParam, isPathParam, isHeaderParam,
             isCookieParam, isBodyParam, hasMore, isContainer,
             secondaryParam, isCollectionFormatMulti, isPrimitiveType, isModel, isExplode;
@@ -43,10 +39,231 @@ public class CodegenParameter {
     public CodegenProperty mostInnerItems;
     public Map<String, Object> vendorExtensions = new HashMap<String, Object>();
     public boolean hasValidation;
+    public boolean isNullable;
+    /**
+     * Determines whether this parameter is mandatory. If the parameter is in "path",
+     * this property is required and its value MUST be true. Otherwise, the property
+     * MAY be included and its default value is false.
+     */
+    public boolean required;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor17.
+     */
+    public String maximum;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor17
+     */
+    public boolean exclusiveMaximum;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor21
+     */
+    public String minimum;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor21
+     */
+    public boolean exclusiveMinimum;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor26
+     */
+    public Integer maxLength;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor29
+     */
+    public Integer minLength;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor33
+     */
+    public String pattern;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor42
+     */
+    public Integer maxItems;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor45
+     */
+    public Integer minItems;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor49
+     */
+    public boolean uniqueItems;
+    /**
+     * See http://json-schema.org/latest/json-schema-validation.html#anchor14
+     */
+    public Number multipleOf;
+    private Integer maxProperties;
+    private Integer minProperties;
+
+    public CodegenParameter copy() {
+        CodegenParameter output = new CodegenParameter();
+        output.isFile = this.isFile;
+        output.hasMore = this.hasMore;
+        output.isContainer = this.isContainer;
+        output.secondaryParam = this.secondaryParam;
+        output.baseName = this.baseName;
+        output.paramName = this.paramName;
+        output.dataType = this.dataType;
+        output.datatypeWithEnum = this.datatypeWithEnum;
+        output.enumName = this.enumName;
+        output.dataFormat = this.dataFormat;
+        output.collectionFormat = this.collectionFormat;
+        output.isCollectionFormatMulti = this.isCollectionFormatMulti;
+        output.isPrimitiveType = this.isPrimitiveType;
+        output.isModel = this.isModel;
+        output.description = this.description;
+        output.unescapedDescription = this.unescapedDescription;
+        output.baseType = this.baseType;
+        output.isFormParam = this.isFormParam;
+        output.isQueryParam = this.isQueryParam;
+        output.isPathParam = this.isPathParam;
+        output.isHeaderParam = this.isHeaderParam;
+        output.isCookieParam = this.isCookieParam;
+        output.isBodyParam = this.isBodyParam;
+        output.required = this.required;
+        output.maximum = this.maximum;
+        output.exclusiveMaximum = this.exclusiveMaximum;
+        output.minimum = this.minimum;
+        output.exclusiveMinimum = this.exclusiveMinimum;
+        output.maxLength = this.maxLength;
+        output.minLength = this.minLength;
+        output.pattern = this.pattern;
+        output.maxItems = this.maxItems;
+        output.minItems = this.minItems;
+        output.uniqueItems = this.uniqueItems;
+        output.multipleOf = this.multipleOf;
+        output.jsonSchema = this.jsonSchema;
+        output.defaultValue = this.defaultValue;
+        output.example = this.example;
+        output.isEnum = this.isEnum;
+        output.maxProperties = this.maxProperties;
+        output.minProperties = this.minProperties;
+        output.maximum = this.maximum;
+        output.minimum = this.minimum;
+        output.pattern = this.pattern;
+
+        if (this._enum != null) {
+            output._enum = new ArrayList<String>(this._enum);
+        }
+        if (this.allowableValues != null) {
+            output.allowableValues = new HashMap<String, Object>(this.allowableValues);
+        }
+        if (this.items != null) {
+            output.items = this.items;
+        }
+        if (this.mostInnerItems != null) {
+            output.mostInnerItems = this.mostInnerItems;
+        }
+        if (this.vendorExtensions != null) {
+            output.vendorExtensions = new HashMap<String, Object>(this.vendorExtensions);
+        }
+        output.hasValidation = this.hasValidation;
+        output.isNullable = this.isNullable;
+        output.isBinary = this.isBinary;
+        output.isByteArray = this.isByteArray;
+        output.isString = this.isString;
+        output.isNumeric = this.isNumeric;
+        output.isInteger = this.isInteger;
+        output.isLong = this.isLong;
+        output.isDouble = this.isDouble;
+        output.isFloat = this.isFloat;
+        output.isNumber = this.isNumber;
+        output.isBoolean = this.isBoolean;
+        output.isDate = this.isDate;
+        output.isDateTime = this.isDateTime;
+        output.isUuid = this.isUuid;
+        output.isUri = this.isUri;
+        output.isEmail = this.isEmail;
+        output.isFreeFormObject = this.isFreeFormObject;
+        output.isListContainer = this.isListContainer;
+        output.isMapContainer = this.isMapContainer;
+        output.isExplode = this.isExplode;
+        output.style = this.style;
+
+        return output;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isFormParam, isQueryParam, isPathParam, isHeaderParam, isCookieParam, isBodyParam, hasMore, isContainer, secondaryParam, isCollectionFormatMulti, isPrimitiveType, isModel, isExplode, baseName, paramName, dataType, datatypeWithEnum, dataFormat, collectionFormat, description, unescapedDescription, baseType, defaultValue, enumName, style, example, jsonSchema, isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBinary, isBoolean, isDate, isDateTime, isUuid, isUri, isEmail, isFreeFormObject, isListContainer, isMapContainer, isFile, isEnum, _enum, allowableValues, items, mostInnerItems, vendorExtensions, hasValidation, getMaxProperties(), getMinProperties(), isNullable, required, getMaximum(), getExclusiveMaximum(), getMinimum(), getExclusiveMinimum(), getMaxLength(), getMinLength(), getPattern(), getMaxItems(), getMinItems(), getUniqueItems(), multipleOf);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CodegenParameter)) return false;
+        CodegenParameter that = (CodegenParameter) o;
+        return isFormParam == that.isFormParam &&
+                isQueryParam == that.isQueryParam &&
+                isPathParam == that.isPathParam &&
+                isHeaderParam == that.isHeaderParam &&
+                isCookieParam == that.isCookieParam &&
+                isBodyParam == that.isBodyParam &&
+                hasMore == that.hasMore &&
+                isContainer == that.isContainer &&
+                secondaryParam == that.secondaryParam &&
+                isCollectionFormatMulti == that.isCollectionFormatMulti &&
+                isPrimitiveType == that.isPrimitiveType &&
+                isModel == that.isModel &&
+                isExplode == that.isExplode &&
+                isString == that.isString &&
+                isNumeric == that.isNumeric &&
+                isInteger == that.isInteger &&
+                isLong == that.isLong &&
+                isNumber == that.isNumber &&
+                isFloat == that.isFloat &&
+                isDouble == that.isDouble &&
+                isByteArray == that.isByteArray &&
+                isBinary == that.isBinary &&
+                isBoolean == that.isBoolean &&
+                isDate == that.isDate &&
+                isDateTime == that.isDateTime &&
+                isUuid == that.isUuid &&
+                isUri == that.isUri &&
+                isEmail == that.isEmail &&
+                isFreeFormObject == that.isFreeFormObject &&
+                isListContainer == that.isListContainer &&
+                isMapContainer == that.isMapContainer &&
+                isFile == that.isFile &&
+                isEnum == that.isEnum &&
+                hasValidation == that.hasValidation &&
+                isNullable == that.isNullable &&
+                required == that.required &&
+                getExclusiveMaximum() == that.getExclusiveMaximum() &&
+                getExclusiveMinimum() == that.getExclusiveMinimum() &&
+                getUniqueItems() == that.getUniqueItems() &&
+                Objects.equals(baseName, that.baseName) &&
+                Objects.equals(paramName, that.paramName) &&
+                Objects.equals(dataType, that.dataType) &&
+                Objects.equals(datatypeWithEnum, that.datatypeWithEnum) &&
+                Objects.equals(dataFormat, that.dataFormat) &&
+                Objects.equals(collectionFormat, that.collectionFormat) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(unescapedDescription, that.unescapedDescription) &&
+                Objects.equals(baseType, that.baseType) &&
+                Objects.equals(defaultValue, that.defaultValue) &&
+                Objects.equals(enumName, that.enumName) &&
+                Objects.equals(style, that.style) &&
+                Objects.equals(example, that.example) &&
+                Objects.equals(jsonSchema, that.jsonSchema) &&
+                Objects.equals(_enum, that._enum) &&
+                Objects.equals(allowableValues, that.allowableValues) &&
+                Objects.equals(items, that.items) &&
+                Objects.equals(mostInnerItems, that.mostInnerItems) &&
+                Objects.equals(vendorExtensions, that.vendorExtensions) &&
+                Objects.equals(getMaxProperties(), that.getMaxProperties()) &&
+                Objects.equals(getMinProperties(), that.getMinProperties()) &&
+                Objects.equals(getMaximum(), that.getMaximum()) &&
+                Objects.equals(getMinimum(), that.getMinimum()) &&
+                Objects.equals(getMaxLength(), that.getMaxLength()) &&
+                Objects.equals(getMinLength(), that.getMinLength()) &&
+                Objects.equals(getPattern(), that.getPattern()) &&
+                Objects.equals(getMaxItems(), that.getMaxItems()) &&
+                Objects.equals(getMinItems(), that.getMinItems()) &&
+                Objects.equals(multipleOf, that.multipleOf);
+    }
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("CodegenParameter{");
+        final StringBuilder sb = new StringBuilder("CodegenParameter{");
         sb.append("isFormParam=").append(isFormParam);
         sb.append(", isQueryParam=").append(isQueryParam);
         sb.append(", isPathParam=").append(isPathParam);
@@ -100,6 +317,8 @@ public class CodegenParameter {
         sb.append(", mostInnerItems=").append(mostInnerItems);
         sb.append(", vendorExtensions=").append(vendorExtensions);
         sb.append(", hasValidation=").append(hasValidation);
+        sb.append(", maxProperties=").append(maxProperties);
+        sb.append(", minProperties=").append(minProperties);
         sb.append(", isNullable=").append(isNullable);
         sb.append(", required=").append(required);
         sb.append(", maximum='").append(maximum).append('\'');
@@ -118,226 +337,123 @@ public class CodegenParameter {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        CodegenParameter that = (CodegenParameter) o;
-        return isFormParam == that.isFormParam &&
-                isQueryParam == that.isQueryParam &&
-                isPathParam == that.isPathParam &&
-                isHeaderParam == that.isHeaderParam &&
-                isCookieParam == that.isCookieParam &&
-                isBodyParam == that.isBodyParam &&
-                hasMore == that.hasMore &&
-                isContainer == that.isContainer &&
-                secondaryParam == that.secondaryParam &&
-                isCollectionFormatMulti == that.isCollectionFormatMulti &&
-                isPrimitiveType == that.isPrimitiveType &&
-                isModel == that.isModel &&
-                isExplode == that.isExplode &&
-                isString == that.isString &&
-                isNumeric == that.isNumeric &&
-                isInteger == that.isInteger &&
-                isLong == that.isLong &&
-                isNumber == that.isNumber &&
-                isFloat == that.isFloat &&
-                isDouble == that.isDouble &&
-                isByteArray == that.isByteArray &&
-                isBinary == that.isBinary &&
-                isBoolean == that.isBoolean &&
-                isDate == that.isDate &&
-                isDateTime == that.isDateTime &&
-                isUuid == that.isUuid &&
-                isUri == that.isUri &&
-                isEmail == that.isEmail &&
-                isFreeFormObject == that.isFreeFormObject &&
-                isListContainer == that.isListContainer &&
-                isMapContainer == that.isMapContainer &&
-                isFile == that.isFile &&
-                isEnum == that.isEnum &&
-                hasValidation == that.hasValidation &&
-                isNullable == that.isNullable &&
-                required == that.required &&
-                exclusiveMaximum == that.exclusiveMaximum &&
-                exclusiveMinimum == that.exclusiveMinimum &&
-                uniqueItems == that.uniqueItems &&
-                Objects.equals(baseName, that.baseName) &&
-                Objects.equals(paramName, that.paramName) &&
-                Objects.equals(dataType, that.dataType) &&
-                Objects.equals(datatypeWithEnum, that.datatypeWithEnum) &&
-                Objects.equals(dataFormat, that.dataFormat) &&
-                Objects.equals(collectionFormat, that.collectionFormat) &&
-                Objects.equals(description, that.description) &&
-                Objects.equals(unescapedDescription, that.unescapedDescription) &&
-                Objects.equals(baseType, that.baseType) &&
-                Objects.equals(defaultValue, that.defaultValue) &&
-                Objects.equals(enumName, that.enumName) &&
-                Objects.equals(style, that.style) &&
-                Objects.equals(example, that.example) &&
-                Objects.equals(jsonSchema, that.jsonSchema) &&
-                Objects.equals(_enum, that._enum) &&
-                Objects.equals(allowableValues, that.allowableValues) &&
-                Objects.equals(items, that.items) &&
-                Objects.equals(mostInnerItems, that.mostInnerItems) &&
-                Objects.equals(vendorExtensions, that.vendorExtensions) &&
-                Objects.equals(maximum, that.maximum) &&
-                Objects.equals(minimum, that.minimum) &&
-                Objects.equals(maxLength, that.maxLength) &&
-                Objects.equals(minLength, that.minLength) &&
-                Objects.equals(pattern, that.pattern) &&
-                Objects.equals(maxItems, that.maxItems) &&
-                Objects.equals(minItems, that.minItems) &&
-                Objects.equals(multipleOf, that.multipleOf);
+    public String getPattern() {
+        return pattern;
     }
 
     @Override
-    public int hashCode() {
-
-        return Objects.hash(isFormParam, isQueryParam, isPathParam, isHeaderParam, isCookieParam, isBodyParam, hasMore,
-                isContainer, secondaryParam, isCollectionFormatMulti, isPrimitiveType, isModel, isExplode, baseName,
-                paramName, dataType, datatypeWithEnum, dataFormat, collectionFormat, description, unescapedDescription,
-                baseType, defaultValue, enumName, style, example, jsonSchema, isString, isNumeric, isInteger, isLong,
-                isNumber, isFloat, isDouble, isByteArray, isBinary, isBoolean, isDate, isDateTime, isUuid, isUri,
-                isEmail, isFreeFormObject, isListContainer, isMapContainer, isFile, isEnum, _enum, allowableValues,
-                items, mostInnerItems, vendorExtensions, hasValidation, isNullable, required, maximum,
-                exclusiveMaximum, minimum, exclusiveMinimum, maxLength, minLength, pattern, maxItems, minItems,
-                uniqueItems, multipleOf);
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
     }
 
-    public boolean isNullable;
+    @Override
+    public String getMaximum() {
+        return maximum;
+    }
 
-    /**
-     * Determines whether this parameter is mandatory. If the parameter is in "path",
-     * this property is required and its value MUST be true. Otherwise, the property
-     * MAY be included and its default value is false.
-     */
-    public boolean required;
+    @Override
+    public void setMaximum(String maximum) {
+        this.maximum = maximum;
+    }
 
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor17.
-     */
-    public String maximum;
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor17
-     */
-    public boolean exclusiveMaximum;
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor21
-     */
-    public String minimum;
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor21
-     */
-    public boolean exclusiveMinimum;
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor26
-     */
-    public Integer maxLength;
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor29
-     */
-    public Integer minLength;
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor33
-     */
-    public String pattern;
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor42
-     */
-    public Integer maxItems;
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor45
-     */
-    public Integer minItems;
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor49
-     */
-    public boolean uniqueItems;
-    /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor14
-     */
-    public Number multipleOf;
+    @Override
+    public String getMinimum() {
+        return minimum;
+    }
 
-    public CodegenParameter copy() {
-        CodegenParameter output = new CodegenParameter();
-        output.isFile = this.isFile;
-        output.hasMore = this.hasMore;
-        output.isContainer = this.isContainer;
-        output.secondaryParam = this.secondaryParam;
-        output.baseName = this.baseName;
-        output.paramName = this.paramName;
-        output.dataType = this.dataType;
-        output.datatypeWithEnum = this.datatypeWithEnum;
-        output.enumName = this.enumName;
-        output.dataFormat = this.dataFormat;
-        output.collectionFormat = this.collectionFormat;
-        output.isCollectionFormatMulti = this.isCollectionFormatMulti;
-        output.isPrimitiveType = this.isPrimitiveType;
-        output.isModel = this.isModel;
-        output.description = this.description;
-        output.unescapedDescription = this.unescapedDescription;
-        output.baseType = this.baseType;
-        output.isFormParam = this.isFormParam;
-        output.isQueryParam = this.isQueryParam;
-        output.isPathParam = this.isPathParam;
-        output.isHeaderParam = this.isHeaderParam;
-        output.isCookieParam = this.isCookieParam;
-        output.isBodyParam = this.isBodyParam;
-        output.required = this.required;
-        output.maximum = this.maximum;
-        output.exclusiveMaximum = this.exclusiveMaximum;
-        output.minimum = this.minimum;
-        output.exclusiveMinimum = this.exclusiveMinimum;
-        output.maxLength = this.maxLength;
-        output.minLength = this.minLength;
-        output.pattern = this.pattern;
-        output.maxItems = this.maxItems;
-        output.minItems = this.minItems;
-        output.uniqueItems = this.uniqueItems;
-        output.multipleOf = this.multipleOf;
-        output.jsonSchema = this.jsonSchema;
-        output.defaultValue = this.defaultValue;
-        output.example = this.example;
-        output.isEnum = this.isEnum;
-        if (this._enum != null) {
-            output._enum = new ArrayList<String>(this._enum);
-        }
-        if (this.allowableValues != null) {
-            output.allowableValues = new HashMap<String, Object>(this.allowableValues);
-        }
-        if (this.items != null) {
-            output.items = this.items;
-        }
-        if (this.mostInnerItems != null) {
-            output.mostInnerItems = this.mostInnerItems;
-        }
-        if (this.vendorExtensions != null) {
-            output.vendorExtensions = new HashMap<String, Object>(this.vendorExtensions);
-        }
-        output.hasValidation = this.hasValidation;
-        output.isNullable = this.isNullable;
-        output.isBinary = this.isBinary;
-        output.isByteArray = this.isByteArray;
-        output.isString = this.isString;
-        output.isNumeric = this.isNumeric;
-        output.isInteger = this.isInteger;
-        output.isLong = this.isLong;
-        output.isDouble = this.isDouble;
-        output.isFloat = this.isFloat;
-        output.isNumber = this.isNumber;
-        output.isBoolean = this.isBoolean;
-        output.isDate = this.isDate;
-        output.isDateTime = this.isDateTime;
-        output.isUuid = this.isUuid;
-        output.isUri = this.isUri;
-        output.isEmail = this.isEmail;
-        output.isFreeFormObject = this.isFreeFormObject;
-        output.isListContainer = this.isListContainer;
-        output.isMapContainer = this.isMapContainer;
-        output.isExplode = this.isExplode;
-        output.style = this.style;
+    @Override
+    public void setMinimum(String minimum) {
+        this.minimum = minimum;
+    }
 
-        return output;
+    @Override
+    public boolean getExclusiveMaximum() {
+        return exclusiveMaximum;
+    }
+
+    @Override
+    public void setExclusiveMaximum(boolean exclusiveMaximum) {
+        this.exclusiveMaximum = exclusiveMaximum;
+    }
+
+    @Override
+    public boolean getExclusiveMinimum() {
+        return exclusiveMinimum;
+    }
+
+    @Override
+    public void setExclusiveMinimum(boolean exclusiveMinimum) {
+        this.exclusiveMinimum = exclusiveMinimum;
+    }
+
+    @Override
+    public Integer getMinLength() {
+        return minLength;
+    }
+
+    @Override
+    public void setMinLength(Integer minLength) {
+        this.minLength = minLength;
+    }
+
+    @Override
+    public Integer getMaxLength() {
+        return maxLength;
+    }
+
+    @Override
+    public void setMaxLength(Integer maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    @Override
+    public Integer getMinItems() {
+        return minItems;
+    }
+
+    @Override
+    public void setMinItems(Integer minItems) {
+        this.minItems = minItems;
+    }
+
+    @Override
+    public Integer getMaxItems() {
+        return maxItems;
+    }
+
+    @Override
+    public void setMaxItems(Integer maxItems) {
+        this.maxItems = maxItems;
+    }
+
+    @Override
+    public boolean getUniqueItems() {
+        return uniqueItems;
+    }
+
+    @Override
+    public void setUniqueItems(boolean uniqueItems) {
+        this.uniqueItems = uniqueItems;
+    }
+
+    @Override
+    public Integer getMinProperties() {
+        return minProperties;
+    }
+
+    @Override
+    public void setMinProperties(Integer minProperties) {
+        this.minProperties = minProperties;
+    }
+
+    @Override
+    public Integer getMaxProperties() {
+        return maxProperties;
+    }
+
+    @Override
+    public void setMaxProperties(Integer maxProperties) {
+        this.maxProperties = maxProperties;
     }
 
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenProperty.java
@@ -19,7 +19,7 @@ package org.openapitools.codegen;
 
 import java.util.*;
 
-public class CodegenProperty implements Cloneable {
+public class CodegenProperty implements Cloneable, IJsonSchemaValidationProperties {
     public String openApiType, baseName, complexType, getter, setter, description, dataType,
             datatypeWithEnum, dataFormat, name, min, max, defaultValue, defaultValueWithParam,
             baseType, containerType, title;
@@ -51,12 +51,32 @@ public class CodegenProperty implements Cloneable {
     public String maximum;
     public boolean exclusiveMinimum;
     public boolean exclusiveMaximum;
-    public boolean hasMore, required, secondaryParam;
+    public boolean hasMore;
+    public boolean required;
+    public boolean secondaryParam;
     public boolean hasMoreNonReadOnly; // for model constructor, true if next property is not readonly
-    public boolean isPrimitiveType, isModel, isContainer;
-    public boolean isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBinary, isFile,
-            isBoolean, isDate, isDateTime, isUuid, isUri, isEmail, isFreeFormObject;
-    public boolean isListContainer, isMapContainer;
+    public boolean isPrimitiveType;
+    public boolean isModel;
+    public boolean isContainer;
+    public boolean isString;
+    public boolean isNumeric;
+    public boolean isInteger;
+    public boolean isLong;
+    public boolean isNumber;
+    public boolean isFloat;
+    public boolean isDouble;
+    public boolean isByteArray;
+    public boolean isBinary;
+    public boolean isFile;
+    public boolean isBoolean;
+    public boolean isDate;
+    public boolean isDateTime;
+    public boolean isUuid;
+    public boolean isUri;
+    public boolean isEmail;
+    public boolean isFreeFormObject;
+    public boolean isListContainer;
+    public boolean isMapContainer;
     public boolean isEnum;
     public boolean isReadOnly;
     public boolean isWriteOnly;
@@ -77,6 +97,10 @@ public class CodegenProperty implements Cloneable {
     public String enumName;
     public Integer maxItems;
     public Integer minItems;
+
+    private Integer maxProperties;
+    private Integer minProperties;
+    private boolean uniqueItems;
 
     // XML
     public boolean isXmlAttribute = false;
@@ -231,26 +255,32 @@ public class CodegenProperty implements Cloneable {
         this.unescapedDescription = unescapedDescription;
     }
 
+    @Override
     public Integer getMaxLength() {
         return maxLength;
     }
 
+    @Override
     public void setMaxLength(Integer maxLength) {
         this.maxLength = maxLength;
     }
 
+    @Override
     public Integer getMinLength() {
         return minLength;
     }
 
+    @Override
     public void setMinLength(Integer minLength) {
         this.minLength = minLength;
     }
 
+    @Override
     public String getPattern() {
         return pattern;
     }
 
+    @Override
     public void setPattern(String pattern) {
         this.pattern = pattern;
     }
@@ -271,26 +301,37 @@ public class CodegenProperty implements Cloneable {
         this.jsonSchema = jsonSchema;
     }
 
+    @Override
     public String getMinimum() {
         return minimum;
     }
 
+    @Override
     public void setMinimum(String minimum) {
         this.minimum = minimum;
     }
 
+    @Override
+    public boolean getExclusiveMaximum() {
+        return this.exclusiveMaximum;
+    }
+
+    @Override
     public String getMaximum() {
         return maximum;
     }
 
+    @Override
     public void setMaximum(String maximum) {
         this.maximum = maximum;
     }
 
+    @Override
     public boolean getExclusiveMinimum() {
         return exclusiveMinimum;
     }
 
+    @Override
     public void setExclusiveMinimum(boolean exclusiveMinimum) {
         this.exclusiveMinimum = exclusiveMinimum;
     }
@@ -299,6 +340,7 @@ public class CodegenProperty implements Cloneable {
         return exclusiveMaximum;
     }
 
+    @Override
     public void setExclusiveMaximum(boolean exclusiveMaximum) {
         this.exclusiveMaximum = exclusiveMaximum;
     }
@@ -371,18 +413,22 @@ public class CodegenProperty implements Cloneable {
         this.enumName = enumName;
     }
 
+    @Override
     public Integer getMaxItems() {
         return maxItems;
     }
 
+    @Override
     public void setMaxItems(Integer maxItems) {
         this.maxItems = maxItems;
     }
 
+    @Override
     public Integer getMinItems() {
         return minItems;
     }
 
+    @Override
     public void setMinItems(Integer minItems) {
         this.minItems = minItems;
     }
@@ -437,10 +483,39 @@ public class CodegenProperty implements Cloneable {
         }
     }
 
+    @Override
+    public boolean getUniqueItems() {
+        return uniqueItems;
+    }
+
+    @Override
+    public void setUniqueItems(boolean uniqueItems) {
+        this.uniqueItems = uniqueItems;
+    }
+
+    @Override
+    public Integer getMinProperties() {
+        return minProperties;
+    }
+
+    @Override
+    public void setMinProperties(Integer minProperties) {
+        this.minProperties = minProperties;
+    }
+
+    @Override
+    public Integer getMaxProperties() {
+        return maxProperties;
+    }
+
+    @Override
+    public void setMaxProperties(Integer maxProperties) {
+        this.maxProperties = maxProperties;
+    }
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("CodegenProperty{");
+        final StringBuilder sb = new StringBuilder("CodegenProperty{");
         sb.append("openApiType='").append(openApiType).append('\'');
         sb.append(", baseName='").append(baseName).append('\'');
         sb.append(", complexType='").append(complexType).append('\'');
@@ -513,6 +588,9 @@ public class CodegenProperty implements Cloneable {
         sb.append(", enumName='").append(enumName).append('\'');
         sb.append(", maxItems=").append(maxItems);
         sb.append(", minItems=").append(minItems);
+        sb.append(", maxProperties=").append(maxProperties);
+        sb.append(", minProperties=").append(minProperties);
+        sb.append(", uniqueItems=").append(uniqueItems);
         sb.append(", isXmlAttribute=").append(isXmlAttribute);
         sb.append(", xmlPrefix='").append(xmlPrefix).append('\'');
         sb.append(", xmlName='").append(xmlName).append('\'');

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java
@@ -19,15 +19,31 @@ package org.openapitools.codegen;
 
 import java.util.*;
 
-public class CodegenResponse {
+public class CodegenResponse implements IJsonSchemaValidationProperties {
     public final List<CodegenProperty> headers = new ArrayList<CodegenProperty>();
-    public String code, message;
+    public String code;
+    public String message;
     public boolean hasMore;
     public List<Map<String, Object>> examples;
-    public String dataType, baseType, containerType, pattern;
+    public String dataType;
+    public String baseType;
+    public String containerType;
     public boolean hasHeaders;
-    public boolean isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBoolean, isDate,
-            isDateTime, isUuid, isEmail, isModel, isFreeFormObject;
+    public boolean isString;
+    public boolean isNumeric;
+    public boolean isInteger;
+    public boolean isLong;
+    public boolean isNumber;
+    public boolean isFloat;
+    public boolean isDouble;
+    public boolean isByteArray;
+    public boolean isBoolean;
+    public boolean isDate;
+    public boolean isDateTime;
+    public boolean isUuid;
+    public boolean isEmail;
+    public boolean isModel;
+    public boolean isFreeFormObject;
     public boolean isDefault;
     public boolean simpleType;
     public boolean primitiveType;
@@ -38,9 +54,27 @@ public class CodegenResponse {
     public Object schema;
     public String jsonSchema;
     public Map<String, Object> vendorExtensions = new HashMap<String, Object>();
+    private Integer maxProperties;
+    private Integer minProperties;
+    private boolean uniqueItems;
+    private Integer maxItems;
+    private Integer minItems;
+    private Integer maxLength;
+    private Integer minLength;
+    private boolean exclusiveMinimum;
+    private boolean exclusiveMaximum;
+    private String minimum;
+    private String maximum;
+    public String pattern;
 
-    public boolean isWildcard() {
-        return "0".equals(code) || "default".equals(code);
+    @Override
+    public int hashCode() {
+        return Objects.hash(headers, code, message, hasMore, examples, dataType, baseType, containerType, hasHeaders,
+                isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray, isBoolean, isDate,
+                isDateTime, isUuid, isEmail, isModel, isFreeFormObject, isDefault, simpleType, primitiveType,
+                isMapContainer, isListContainer, isBinary, isFile, schema, jsonSchema, vendorExtensions,
+                getMaxProperties(), getMinProperties(), uniqueItems, getMaxItems(), getMinItems(), getMaxLength(),
+                getMinLength(), exclusiveMinimum, exclusiveMaximum, getMinimum(), getMaximum(), getPattern());
     }
 
     @Override
@@ -79,30 +113,152 @@ public class CodegenResponse {
                 Objects.equals(dataType, that.dataType) &&
                 Objects.equals(baseType, that.baseType) &&
                 Objects.equals(containerType, that.containerType) &&
-                Objects.equals(pattern, that.pattern) &&
                 Objects.equals(schema, that.schema) &&
                 Objects.equals(jsonSchema, that.jsonSchema) &&
-                Objects.equals(vendorExtensions, that.vendorExtensions);
+                Objects.equals(vendorExtensions, that.vendorExtensions) &&
+                Objects.equals(getMaxProperties(), that.getMaxProperties()) &&
+                Objects.equals(getMinProperties(), that.getMinProperties()) &&
+                Objects.equals(uniqueItems, that.uniqueItems) &&
+                Objects.equals(getMaxItems(), that.getMaxItems()) &&
+                Objects.equals(getMinItems(), that.getMinItems()) &&
+                Objects.equals(getMaxLength(), that.getMaxLength()) &&
+                Objects.equals(getMinLength(), that.getMinLength()) &&
+                Objects.equals(exclusiveMinimum, that.exclusiveMinimum) &&
+                Objects.equals(exclusiveMaximum, that.exclusiveMaximum) &&
+                Objects.equals(getMinimum(), that.getMinimum()) &&
+                Objects.equals(getMaximum(), that.getMaximum()) &&
+                Objects.equals(getPattern(), that.getPattern());
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(headers, code, message, hasMore, examples, dataType, baseType, containerType, pattern,
-                hasHeaders, isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isByteArray,
-                isBoolean, isDate, isDateTime, isUuid, isEmail, isModel, isFreeFormObject, isDefault, simpleType,
-                primitiveType, isMapContainer, isListContainer, isBinary, isFile, schema, jsonSchema, vendorExtensions);
+    public String getPattern() {
+        return pattern;
+    }
+
+    @Override
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public String getMaximum() {
+        return maximum;
+    }
+
+    @Override
+    public void setMaximum(String maximum) {
+        this.maximum = maximum;
+    }
+
+    @Override
+    public String getMinimum() {
+        return minimum;
+    }
+
+    @Override
+    public void setMinimum(String minimum) {
+        this.minimum = minimum;
+    }
+
+    @Override
+    public boolean getExclusiveMaximum() {
+        return exclusiveMaximum;
+    }
+
+    @Override
+    public void setExclusiveMaximum(boolean exclusiveMaximum) {
+        this.exclusiveMaximum = exclusiveMaximum;
+    }
+
+    @Override
+    public boolean getExclusiveMinimum() {
+        return exclusiveMinimum;
+    }
+
+    @Override
+    public void setExclusiveMinimum(boolean exclusiveMinimum) {
+        this.exclusiveMinimum = exclusiveMinimum;
+    }
+
+    @Override
+    public Integer getMinLength() {
+        return minLength;
+    }
+
+    @Override
+    public void setMinLength(Integer minLength) {
+        this.minLength = minLength;
+    }
+
+    @Override
+    public Integer getMaxLength() {
+        return maxLength;
+    }
+
+    @Override
+    public void setMaxLength(Integer maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    @Override
+    public Integer getMinItems() {
+        return minItems;
+    }
+
+    @Override
+    public void setMinItems(Integer minItems) {
+        this.minItems = minItems;
+    }
+
+    @Override
+    public Integer getMaxItems() {
+        return maxItems;
+    }
+
+    @Override
+    public void setMaxItems(Integer maxItems) {
+        this.maxItems = maxItems;
+    }
+
+    @Override
+    public boolean getUniqueItems() {
+        return uniqueItems;
+    }
+
+    @Override
+    public void setUniqueItems(boolean uniqueItems) {
+        this.uniqueItems = uniqueItems;
+    }
+
+    @Override
+    public Integer getMinProperties() {
+        return minProperties;
+    }
+
+    @Override
+    public void setMinProperties(Integer minProperties) {
+        this.minProperties = minProperties;
+    }
+
+    @Override
+    public Integer getMaxProperties() {
+        return maxProperties;
+    }
+
+    @Override
+    public void setMaxProperties(Integer maxProperties) {
+        this.maxProperties = maxProperties;
     }
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("CodegenResponse{");
+        final StringBuilder sb = new StringBuilder("CodegenResponse{");
         sb.append("headers=").append(headers);
         sb.append(", code='").append(code).append('\'');
         sb.append(", message='").append(message).append('\'');
         sb.append(", hasMore=").append(hasMore);
         sb.append(", examples=").append(examples);
         sb.append(", dataType='").append(dataType).append('\'');
-        sb.append(", pattern='").append(pattern).append('\'');
         sb.append(", baseType='").append(baseType).append('\'');
         sb.append(", containerType='").append(containerType).append('\'');
         sb.append(", hasHeaders=").append(hasHeaders);
@@ -131,7 +287,25 @@ public class CodegenResponse {
         sb.append(", schema=").append(schema);
         sb.append(", jsonSchema='").append(jsonSchema).append('\'');
         sb.append(", vendorExtensions=").append(vendorExtensions);
+        sb.append(", maxProperties=").append(maxProperties);
+        sb.append(", minProperties=").append(minProperties);
+        sb.append(", uniqueItems=").append(uniqueItems);
+        sb.append(", maxItems=").append(maxItems);
+        sb.append(", minItems=").append(minItems);
+        sb.append(", maxLength=").append(maxLength);
+        sb.append(", minLength=").append(minLength);
+        sb.append(", exclusiveMinimum=").append(exclusiveMinimum);
+        sb.append(", exclusiveMaximum=").append(exclusiveMaximum);
+        sb.append(", minimum='").append(minimum).append('\'');
+        sb.append(", maximum='").append(maximum).append('\'');
+        sb.append(", pattern='").append(pattern).append('\'');
         sb.append('}');
         return sb.toString();
+    }
+
+    // this is used in templates. Do not remove it.
+    @SuppressWarnings("unused")
+    public boolean isWildcard() {
+        return "0".equals(code) || "default".equals(code);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -1972,6 +1972,10 @@ public class DefaultCodegen implements CodegenConfig {
                 addAdditionPropertiesToCodeGenModel(m, schema);
                 m.isMapModel = true;
             } else if (ModelUtils.isIntegerSchema(schema)) { // integer type
+                // NOTE: Integral schemas as CodegenModel is a rare use case and may be removed at a later date.
+                // Sync of properties is done for consistency with other data types like CodegenParameter/CodegenProperty.
+                ModelUtils.syncValidationProperties(schema, m);
+
                 m.isNumeric = Boolean.TRUE;
                 if (ModelUtils.isLongSchema(schema)) { // int64/long format
                     m.isLong = Boolean.TRUE;
@@ -1979,8 +1983,14 @@ public class DefaultCodegen implements CodegenConfig {
                     m.isInteger = Boolean.TRUE;
                 }
             } else if (ModelUtils.isStringSchema(schema)) {
+                // NOTE: String schemas as CodegenModel is a rare use case and may be removed at a later date.
+                // Sync of properties is done for consistency with other data types like CodegenParameter/CodegenProperty.
+                ModelUtils.syncValidationProperties(schema, m);
                 m.isString = Boolean.TRUE;
             } else if (ModelUtils.isNumberSchema(schema)) {
+                // NOTE: Number schemas as CodegenModel is a rare use case and may be removed at a later date.
+                // Sync of properties is done for consistency with other data types like CodegenParameter/CodegenProperty.
+                ModelUtils.syncValidationProperties(schema, m);
                 m.isNumeric = Boolean.TRUE;
                 if (ModelUtils.isFloatSchema(schema)) { // float
                     m.isFloat = Boolean.TRUE;
@@ -2122,6 +2132,9 @@ public class DefaultCodegen implements CodegenConfig {
         p = ModelUtils.unaliasSchema(this.openAPI, p);
 
         CodegenProperty property = CodegenModelFactory.newInstance(CodegenModelType.PROPERTY);
+
+        ModelUtils.syncValidationProperties(p, property);
+
         property.name = toVarName(name);
         property.baseName = name;
         if (p.getType() == null) {
@@ -2926,6 +2939,21 @@ public class DefaultCodegen implements CodegenConfig {
      */
     public CodegenResponse fromResponse(String responseCode, ApiResponse response) {
         CodegenResponse r = CodegenModelFactory.newInstance(CodegenModelType.RESPONSE);
+
+        if (response.getContent() != null && response.getContent().size() > 0) {
+            // Ensure validation properties from a target schema are persisted on CodegenResponse.
+            // This ignores any edge case where different schemas have different validations because we don't
+            // have a way to indicate a preference for response schema and are effective 1:1.
+            Schema contentSchema = null;
+            for (MediaType mt : response.getContent().values()) {
+                if (contentSchema != null) break;
+                contentSchema = mt.getSchema();
+            }
+            if (contentSchema != null) {
+                ModelUtils.syncValidationProperties(contentSchema, r);
+            }
+        }
+
         if ("default".equals(responseCode)) {
             r.code = "0";
         } else {
@@ -2939,7 +2967,7 @@ public class DefaultCodegen implements CodegenConfig {
         }
         r.schema = responseSchema;
         if (responseSchema != null && responseSchema.getPattern() != null) {
-            r.pattern = toRegularExpression(responseSchema.getPattern());
+            r.setPattern(toRegularExpression(responseSchema.getPattern()));
         }
 
         r.message = escapeText(response.getDescription());
@@ -3118,6 +3146,21 @@ public class DefaultCodegen implements CodegenConfig {
      */
     public CodegenParameter fromParameter(Parameter parameter, Set<String> imports) {
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
+
+        if (parameter.getContent() != null && parameter.getContent().size() > 0) {
+            // Ensure validation properties from a target schema are persisted on CodegenParameter.
+            // This ignores any edge case where different schemas have different validations because we don't
+            // have a way to indicate a preference for parameter schema and are effective 1:1.
+            Schema contentSchema = null;
+            for (MediaType mt : parameter.getContent().values()) {
+                if (contentSchema != null) break;
+                contentSchema = mt.getSchema();
+            }
+            if (contentSchema != null) {
+                ModelUtils.syncValidationProperties(contentSchema, codegenParameter);
+            }
+        }
+
         codegenParameter.baseName = parameter.getName();
         codegenParameter.description = escapeText(parameter.getDescription());
         codegenParameter.unescapedDescription = parameter.getDescription();
@@ -4785,6 +4828,8 @@ public class DefaultCodegen implements CodegenConfig {
         LOGGER.debug("Debugging fromFormProperty {}: {}", name, propertySchema);
         CodegenProperty codegenProperty = fromProperty(name, propertySchema);
 
+        ModelUtils.syncValidationProperties(propertySchema, codegenProperty);
+
         codegenParameter.isFormParam = Boolean.TRUE;
         codegenParameter.baseName = codegenProperty.baseName;
         codegenParameter.paramName = toParamName((codegenParameter.baseName));
@@ -4885,6 +4930,8 @@ public class DefaultCodegen implements CodegenConfig {
             name = ModelUtils.getSimpleRef(schema.get$ref());
         }
         schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
+
+        ModelUtils.syncValidationProperties(schema, codegenParameter);
 
         if (ModelUtils.isMapSchema(schema)) {
             Schema inner = ModelUtils.getAdditionalProperties(schema);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java
@@ -1,0 +1,41 @@
+package org.openapitools.codegen;
+
+import java.math.BigDecimal;
+
+public interface IJsonSchemaValidationProperties {
+    String getPattern();
+    void setPattern(String pattern);
+
+    String getMaximum();
+    void setMaximum(String maximum);
+
+    String getMinimum();
+    void setMinimum(String minimum);
+
+    boolean getExclusiveMaximum();
+    void setExclusiveMaximum(boolean exclusiveMaximum);
+    
+    boolean getExclusiveMinimum();
+    void setExclusiveMinimum(boolean exclusiveMinimum);
+
+    Integer getMinLength();
+    void setMinLength(Integer minLength);
+    
+    Integer getMaxLength();
+    void setMaxLength(Integer maxLength);
+
+    Integer getMinItems();
+    void setMinItems(Integer minItems);
+
+    Integer getMaxItems();
+    void setMaxItems(Integer maxItems);
+
+    boolean getUniqueItems();
+    void setUniqueItems(boolean uniqueItems);
+
+    Integer getMinProperties();
+    void setMinProperties(Integer minProperties);
+
+    Integer getMaxProperties();
+    void setMaxProperties(Integer maxProperties);
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -29,10 +29,12 @@ import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.IJsonSchemaValidationProperties;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1002,5 +1004,34 @@ public class ModelUtils {
         }
 
         return false;
+    }
+
+    public static void syncValidationProperties(Schema schema, IJsonSchemaValidationProperties target){
+        if (schema != null && target != null) {
+            target.setPattern(schema.getPattern());
+            BigDecimal minimum = schema.getMinimum();
+            BigDecimal maximum = schema.getMaximum();
+            Boolean exclusiveMinimum = schema.getExclusiveMinimum();
+            Boolean exclusiveMaximum = schema.getExclusiveMaximum();
+            Integer minLength = schema.getMinLength();
+            Integer maxLength = schema.getMaxLength();
+            Integer minItems = schema.getMinItems();
+            Integer maxItems = schema.getMaxItems();
+            Boolean uniqueItems = schema.getUniqueItems();
+            Integer minProperties = schema.getMinProperties();
+            Integer maxProperties = schema.getMaxProperties();
+
+            if (minimum != null) target.setMinimum(String.valueOf(minimum));
+            if (maximum != null) target.setMaximum(String.valueOf(maximum));
+            if (exclusiveMinimum != null) target.setExclusiveMinimum(exclusiveMinimum);
+            if (exclusiveMaximum != null) target.setExclusiveMaximum(exclusiveMaximum);
+            if (minLength != null) target.setMinLength(minLength);
+            if (maxLength != null) target.setMaxLength(maxLength);
+            if (minItems != null) target.setMinItems(minItems);
+            if (maxItems != null) target.setMaxItems(maxItems);
+            if (uniqueItems != null) target.setUniqueItems(uniqueItems);
+            if (minProperties != null) target.setMinProperties(minProperties);
+            if (maxProperties != null) target.setMaxProperties(maxProperties);
+        }
     }
 }


### PR DESCRIPTION
This should address #4653

The request was to add validation properties to CodegenModel, where CodegenModel may be used to represent reusable schemas which don't necessary result in a generated model (see `isString`, `isInteger`, etc).  Those use cases are legacy functionality from before there was a standardized structure in swagger-parser (now, `Schema`). I couldn't find any usages in template code, but that's not to say that users with customized templates aren't relying heavily on CodegenModel and legacy functionality.  I've added the set of validation properties to `CodegenModel` to address this issue, but I think we should work out a deprecation strategy if CodegenModel is no longer meant to be used for primitive schemas. That is, an OpenAPI Schema representing a primitive type should _never_ be a model in generated code.

The heart of the discussion in the linked issue is this:
* CodegenModel appears to be considered the "most proper" transformation from Schema to some type within OpenAPI Generator
* The ask is to not drop JSON Schema Validation Properties whenever we convert from a `Schema` instance to one of the `Codegen*` types in OpenAPI Generator
* The use case this would allow is model reuse in generated code which requires pre-condition and post-condition checks.

This PR will address issues in our other `Codegen*` types, such as the copy method on `CodegenParameter` would previously not copy pattern, minimum or maximum. CodegenResponse previously had not validation properties. The previous assumption seems to be that CodegenResponse, for instance, didn't require validation; that's not really the case in microservices, and especially not in OLTP where data consistency is key and something like `pattern` or `length` checks could prevent security breaches.

I'm opening this for feedback. If reviewers feel that CodegenModel does not require these validation properties, I'd prefer to remove them from that class.

cc @OpenAPITools/generator-core-team 
cc @spacether 

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
