### PR TITLE
[C-libcurl] fix building error when complexType is empty.

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -633,31 +633,31 @@ fail:
     {{/isPrimitiveType}}
     {{/isListContainer}}
     {{#isMapContainer}}
-    list_t *{{{complexType}}}List;
+    list_t *{{{name}}}List;
     {{^required}}if ({{{name}}}) { {{/required}}
-    cJSON *{{{complexType}}}_local_map;
+    cJSON *{{{name}}}_local_map;
     if(!cJSON_IsObject({{{name}}})) {
         goto end;//primitive map container
     }
-    {{{complexType}}}List = list_create();
+    {{{name}}}List = list_create();
     keyValuePair_t *localMapKeyPair;
-    cJSON_ArrayForEach({{{complexType}}}_local_map, {{{name}}})
+    cJSON_ArrayForEach({{{name}}}_local_map, {{{name}}})
     {
         {{#isString}}
-        if(!cJSON_IsString({{{complexType}}}_local_map))
+        if(!cJSON_IsString({{{name}}}_local_map))
         {
             goto end;
         }
-        localMapKeyPair = keyValuePair_create(strdup({{{complexType}}}_local_map->string),strdup({{{complexType}}}_local_map->valuestring))
-        list_addElement({{{complexType}}}List , localMapKeyPair);
+        localMapKeyPair = keyValuePair_create(strdup({{{name}}}_local_map->string),strdup({{{name}}}_local_map->valuestring))
+        list_addElement({{{name}}}List , localMapKeyPair);
         {{/isString}}
         {{^isString}}
-        if(!cJSON_IsNumber({{{complexType}}}_local_map))
+        if(!cJSON_IsNumber({{{name}}}_local_map))
         {
             goto end;
         }
-        localMapKeyPair = keyValuePair_create(strdup({{{complexType}}}_local_map->string),&{{{complexType}}}_local_map->valuedouble );
-        list_addElement({{{complexType}}}List , localMapKeyPair);
+        localMapKeyPair = keyValuePair_create(strdup({{{name}}}_local_map->string),&{{{name}}}_local_map->valuedouble );
+        list_addElement({{{name}}}List , localMapKeyPair);
         {{/isString}}
     }
     {{/isMapContainer}}
@@ -731,7 +731,7 @@ fail:
         {{/isPrimitiveType}}
         {{/isListContainer}}
         {{#isMapContainer}}
-        {{^required}}{{{name}}} ? {{/required}}{{{complexType}}}List{{^required}} : NULL{{/required}}{{#hasMore}},{{/hasMore}}
+        {{^required}}{{{name}}} ? {{/required}}{{{name}}}List{{^required}} : NULL{{/required}}{{#hasMore}},{{/hasMore}}
         {{/isMapContainer}}
         {{/isContainer}}
         {{/vars}}


### PR DESCRIPTION
[C-libcurl] Change "complexType" to "name" inner "isMapContainer" to fix building error when complexType is empty.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

When generating k8s C-libcurl client,  there is a build error due to the duplicated List

They are generated by the below template code:
```
{{#isMapContainer}}
    list_t *{{{complexType}}}List;
...
{{/isMapContainer}} 
```
But for my case,  complexType is empty, so there are some duplicated List

```
list_t *List;
...
list_t *List;
...
list_t *List;

```
They will cause building error.

 I checked other parts inner the {{#isMapContainer}} and {{/isMapContainer}} in the same [file](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache), and found "complexType" should be changed to "name"

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [master](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @PowerOfCreation @zhemant