### PR TITLE
[typescript-redux-query] Add proper modelling of allOf usage.

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/modelAllOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/modelAllOf.mustache
@@ -1,0 +1,36 @@
+{{#hasImports}}
+import {
+    {{#imports}}
+    {{{.}}},
+    {{{.}}}FromJSON,
+    {{{.}}}ToJSON,
+    {{/imports}}
+} from './';
+
+{{/hasImports}}
+/**
+ * @type {{classname}}{{#description}}
+ * {{{description}}}{{/description}}
+ * @export
+ */
+export interface {{classname}} extends {{#allOf}}{{{.}}}{{^-last}}, {{/-last}}{{/allOf}} {
+}
+
+export function {{classname}}FromJSON(json: any): {{classname}} {
+    return {
+        {{#allOf}}
+        ...{{.}}FromJSON(json),
+        {{/allOf}}
+    };
+}
+
+export function {{classname}}ToJSON(value?: {{classname}}): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    return {
+        {{#allOf}}
+        ...{{.}}ToJSON(value),
+        {{/allOf}}
+    };
+}

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/modelOneOf.mustache
@@ -34,7 +34,7 @@ export function {{classname}}ToJSON(value?: {{classname}}): any {
 
     switch (value.{{propertyName}}) {
     {{#mappedModels}}
-    case '{{mappingName}}': return {{modelName}}ToJSON(value);
+    case '{{mappingName}}': return {{modelName}}ToJSON(<{{modelName}}>value);
     {{/mappedModels}}
     default: throw new Error("Unexpected {{propertyName}} value.");
     }

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/models.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/models.mustache
@@ -11,8 +11,15 @@
 {{>modelOneOf}}
 {{/-first}}
 {{/oneOf}}
+{{#allOf}}
+{{#-first}}
+{{>modelAllOf}}
+{{/-first}}
+{{/allOf}}
 {{^oneOf}}
+{{^allOf}}
 {{>modelGeneric}}
+{{/allOf}}
 {{/oneOf}}
 {{/isEnum}}
 {{/model}}


### PR DESCRIPTION
This adds explicit proper handling of `allOf` for the `typescript-redux-query` generator, generating an interface that extends all the `allOf` entries, and implements the necessary `ToJSON`/`FromJSON` functions as well.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
