### PR TITLE
[go-experimental] Use builder pattern for requests

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -46,6 +46,8 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     protected String packageName = "openapi";
     protected Set<String> numberTypes;
 
+    protected boolean usesOptionals = true;
+
     public AbstractGoCodegen() {
         super();
 
@@ -400,7 +402,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 }
 
                 // import "time" if the operation has a required time parameter.
-                if (param.required) {
+                if (param.required || !usesOptionals) {
                     if (!addedTimeImport && "time.Time".equals(param.dataType)) {
                         imports.add(createMapping("import", "time"));
                         addedTimeImport = true;
@@ -414,7 +416,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 }
 
                 // import "optionals" package if the parameter is optional
-                if (!param.required) {
+                if (!param.required && usesOptionals) {
                     if (!addedOptionalImport) {
                         imports.add(createMapping("import", "github.com/antihax/optional"));
                         addedOptionalImport = true;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientExperimentalCodegen.java
@@ -36,6 +36,8 @@ public class GoClientExperimentalCodegen extends GoClientCodegen {
         outputFolder = "generated-code/go-experimental";
         embeddedTemplateDir = templateDir = "go-experimental";
 
+        usesOptionals = false;
+
         generatorMetadata = GeneratorMetadata.newBuilder(generatorMetadata).stability(Stability.EXPERIMENTAL).build();
     }
 

--- a/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
@@ -80,43 +80,43 @@ func (r api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnT
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} is required and must be specified")
 	}{{/isPathParam}}
 	{{#minItems}}
-	if len(*r.{{paramName}}) < {{minItems}} {
+	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minItems}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minItems}} elements")
 	}
 	{{/minItems}}
 	{{#maxItems}}
-	if len(*r.{{paramName}}) > {{maxItems}} {
+	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxItems}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxItems}} elements")
 	}
 	{{/maxItems}}
 	{{#minLength}}
-	if strlen(*r.{{paramName}}) < {{minLength}} {
+	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minLength}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minLength}} elements")
 	}
 	{{/minLength}}
 	{{#maxLength}}
-	if strlen(*r.{{paramName}}) > {{maxLength}} {
+	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxLength}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxLength}} elements")
 	}
 	{{/maxLength}}
 	{{#minimum}}
 	{{#isString}}
-	{{paramName}}Txt, err := atoi(*r.{{paramName}})
+	{{paramName}}Txt, err := atoi({{^isPathParam}}*{{/isPathParam}}r.{{paramName}})
 	if {{paramName}}Txt < {{minimum}} {
 	{{/isString}}
 	{{^isString}}
-	if *r.{{paramName}} < {{minimum}} {
+	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} < {{minimum}} {
 	{{/isString}}
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be greater than {{minimum}}")
 	}
 	{{/minimum}}
 	{{#maximum}}
 	{{#isString}}
-	{{paramName}}Txt, err := atoi(*r.{{paramName}})
+	{{paramName}}Txt, err := atoi({{^isPathParam}}*{{/isPathParam}}r.{{paramName}})
 	if {{paramName}}Txt > {{maximum}} {
 	{{/isString}}
 	{{^isString}}
-	if *r.{{paramName}} > {{maximum}} {
+	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} > {{maximum}} {
 	{{/isString}}
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be less than {{maximum}}")
 	}
@@ -124,7 +124,6 @@ func (r api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnT
 	{{/required}}
 	{{/allParams}}
 
-	{{#hasQueryParams}}
 	{{#queryParams}}
 	{{#required}}
 	{{#isCollectionFormatMulti}}
@@ -161,7 +160,6 @@ func (r api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnT
 	}
 	{{/required}}
 	{{/queryParams}}
-	{{/hasQueryParams}}
 	// to determine the Content-Type header
 {{=<% %>=}}
 	localVarHTTPContentTypes := []string{<%#consumes%>"<%&mediaType%>"<%^-last%>, <%/-last%><%/consumes%>}
@@ -183,7 +181,6 @@ func (r api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnT
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-{{#hasHeaderParams}}
 {{#headerParams}}
 	{{#required}}
 	localVarHeaderParams["{{baseName}}"] = parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
@@ -194,8 +191,6 @@ func (r api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnT
 	}
 	{{/required}}
 {{/headerParams}}
-{{/hasHeaderParams}}
-{{#hasFormParams}}
 {{#formParams}}
 {{#isFile}}
 	localVarFormFileName = "{{baseName}}"
@@ -237,13 +232,10 @@ func (r api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnT
 {{/required}}
 {{/isFile}}
 {{/formParams}}
-{{/hasFormParams}}
-{{#hasBodyParam}}
 {{#bodyParams}}
 	// body params
 	localVarPostBody = r.{{paramName}}
 {{/bodyParams}}
-{{/hasBodyParam}}
 {{#authMethods}}
 {{#isApiKey}}
 {{^isKeyInCookie}}

--- a/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/api.mustache
@@ -18,115 +18,105 @@ var (
 
 // {{classname}}Service {{classname}} service
 type {{classname}}Service service
-{{#operation}}
 
-{{#hasOptionalParams}}
-// {{#structPrefix}}{{&classname}}{{/structPrefix}}{{{nickname}}}Opts Optional parameters for the method '{{{nickname}}}'
-type {{#structPrefix}}{{&classname}}{{/structPrefix}}{{{nickname}}}Opts struct {
-{{#allParams}}
-{{^required}}
-{{#isPrimitiveType}}
-{{^isBinary}}
-    {{vendorExtensions.x-exportParamName}} optional.{{vendorExtensions.x-optionalDataType}}
-{{/isBinary}}
-{{#isBinary}}
-    {{vendorExtensions.x-exportParamName}} optional.Interface
-{{/isBinary}}
-{{/isPrimitiveType}}
-{{^isPrimitiveType}}
-    {{vendorExtensions.x-exportParamName}} optional.Interface
-{{/isPrimitiveType}}
-{{/required}}
-{{/allParams}}
+{{#operation}}
+type api{{operationId}}Request struct {
+	ctx _context.Context
+	apiService *{{classname}}Service{{#allParams}}
+	{{paramName}} {{^isPathParam}}*{{/isPathParam}}{{{dataType}}}{{/allParams}}
 }
 
-{{/hasOptionalParams}}
+{{#allParams}}{{^isPathParam}}
+func (r api{{operationId}}Request) {{vendorExtensions.x-exportParamName}}({{paramName}} {{{dataType}}}) api{{operationId}}Request {
+	r.{{paramName}} = &{{paramName}}
+	return r
+}
+{{/isPathParam}}{{/allParams}}
 /*
 {{operationId}}{{#summary}} {{{.}}}{{/summary}}{{^summary}} Method for {{operationId}}{{/summary}}
 {{#notes}}
-{{notes}}
+{{{unescapedNotes}}}
 {{/notes}}
- * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-{{#allParams}}
-{{#required}}
- * @param {{paramName}}{{#description}} {{{.}}}{{/description}}
-{{/required}}
-{{/allParams}}
-{{#hasOptionalParams}}
- * @param optional nil or *{{#structPrefix}}{{&classname}}{{/structPrefix}}{{{nickname}}}Opts - Optional Parameters:
-{{#allParams}}
-{{^required}}
- * @param "{{vendorExtensions.x-exportParamName}}" ({{#isPrimitiveType}}{{^isBinary}}optional.{{vendorExtensions.x-optionalDataType}}{{/isBinary}}{{#isBinary}}optional.Interface of {{dataType}}{{/isBinary}}{{/isPrimitiveType}}{{^isPrimitiveType}}optional.Interface of {{dataType}}{{/isPrimitiveType}}) - {{#description}} {{{.}}}{{/description}}
-{{/required}}
-{{/allParams}}
-{{/hasOptionalParams}}
-{{#returnType}}
-@return {{{returnType}}}
-{{/returnType}}
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().{{#pathParams}}
+ * @param {{paramName}}{{#description}} {{{.}}}{{/description}}{{/pathParams}}
+@return api{{operationId}}Request
 */
-func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams}}, {{/hasParams}}{{#allParams}}{{#required}}{{paramName}} {{{dataType}}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}localVarOptionals *{{#structPrefix}}{{&classname}}{{/structPrefix}}{{{nickname}}}Opts{{/hasOptionalParams}}) ({{#returnType}}{{{returnType}}}, {{/returnType}}*_nethttp.Response, error) {
+func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParams}}, {{paramName}} {{{dataType}}}{{/pathParams}}) api{{operationId}}Request {
+	return api{{operationId}}Request{
+		apiService: a,
+		ctx: ctx,{{#pathParams}}
+		{{paramName}}: {{paramName}},{{/pathParams}}
+	}
+}
+
+/*
+Execute executes the request
+{{#returnType}} @return {{{.}}}{{/returnType}}
+*/
+func (r api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.Method{{httpMethod}}
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
-		{{#returnType}}
-		localVarReturnValue  {{{returnType}}}
-		{{/returnType}}
+		{{#returnType}}localVarReturnValue  {{{.}}}{{/returnType}}
 	)
 
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "{{{classname}}}Service.{{{nickname}}}")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "{{{classname}}}Service.{{{nickname}}}")
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "{{{path}}}"{{#pathParams}}
-	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.QueryEscape(parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")) , -1){{/pathParams}}
+	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.QueryEscape(parameterToString(r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")) , -1){{/pathParams}}
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	{{#allParams}}
-	{{#required}}
+	{{#required}}{{^isPathParam}}
+	if r.{{paramName}} == nil {
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} is required and must be specified")
+	}{{/isPathParam}}
 	{{#minItems}}
-	if len({{paramName}}) < {{minItems}} {
+	if len(*r.{{paramName}}) < {{minItems}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minItems}} elements")
 	}
 	{{/minItems}}
 	{{#maxItems}}
-	if len({{paramName}}) > {{maxItems}} {
+	if len(*r.{{paramName}}) > {{maxItems}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxItems}} elements")
 	}
 	{{/maxItems}}
 	{{#minLength}}
-	if strlen({{paramName}}) < {{minLength}} {
+	if strlen(*r.{{paramName}}) < {{minLength}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minLength}} elements")
 	}
 	{{/minLength}}
 	{{#maxLength}}
-	if strlen({{paramName}}) > {{maxLength}} {
+	if strlen(*r.{{paramName}}) > {{maxLength}} {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxLength}} elements")
 	}
 	{{/maxLength}}
 	{{#minimum}}
 	{{#isString}}
-	{{paramName}}Txt, err := atoi({{paramName}})
+	{{paramName}}Txt, err := atoi(*r.{{paramName}})
 	if {{paramName}}Txt < {{minimum}} {
 	{{/isString}}
 	{{^isString}}
-	if {{paramName}} < {{minimum}} {
+	if *r.{{paramName}} < {{minimum}} {
 	{{/isString}}
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be greater than {{minimum}}")
 	}
 	{{/minimum}}
 	{{#maximum}}
 	{{#isString}}
-	{{paramName}}Txt, err := atoi({{paramName}})
+	{{paramName}}Txt, err := atoi(*r.{{paramName}})
 	if {{paramName}}Txt > {{maximum}} {
 	{{/isString}}
 	{{^isString}}
-	if {{paramName}} > {{maximum}} {
+	if *r.{{paramName}} > {{maximum}} {
 	{{/isString}}
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be less than {{maximum}}")
 	}
@@ -138,7 +128,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 	{{#queryParams}}
 	{{#required}}
 	{{#isCollectionFormatMulti}}
-	t:={{paramName}}
+	t := *r.{{paramName}}
 	if reflect.TypeOf(t).Kind() == reflect.Slice {
 		s := reflect.ValueOf(t)
 		for i := 0; i < s.Len(); i++ {
@@ -149,13 +139,13 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 	}
 	{{/isCollectionFormatMulti}}
 	{{^isCollectionFormatMulti}}
-	localVarQueryParams.Add("{{baseName}}", parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	localVarQueryParams.Add("{{baseName}}", parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 	{{/isCollectionFormatMulti}}
 	{{/required}}
 	{{^required}}
-	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-exportParamName}}.IsSet() {
+	if r.{{paramName}} != nil {
 	{{#isCollectionFormatMulti}}
-		t:=localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value()
+		t := *r.{{paramName}}
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
@@ -166,7 +156,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 		}
 	{{/isCollectionFormatMulti}}
 	{{^isCollectionFormatMulti}}
-		localVarQueryParams.Add("{{baseName}}", parameterToString(localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+		localVarQueryParams.Add("{{baseName}}", parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 	{{/isCollectionFormatMulti}}
 	}
 	{{/required}}
@@ -196,11 +186,11 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 {{#hasHeaderParams}}
 {{#headerParams}}
 	{{#required}}
-	localVarHeaderParams["{{baseName}}"] = parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
+	localVarHeaderParams["{{baseName}}"] = parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
 	{{/required}}
 	{{^required}}
-	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-exportParamName}}.IsSet() {
-		localVarHeaderParams["{{baseName}}"] = parameterToString(localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
+	if r.{{paramName}} != nil {
+		localVarHeaderParams["{{baseName}}"] = parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}")
 	}
 	{{/required}}
 {{/headerParams}}
@@ -210,16 +200,12 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 {{#isFile}}
 	localVarFormFileName = "{{baseName}}"
 {{#required}}
-	localVarFile := {{paramName}}
+	localVarFile := *r.{{paramName}}
 {{/required}}
 {{^required}}
 	var localVarFile {{dataType}}
-	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-exportParamName}}.IsSet() {
-		localVarFileOk := false
-		localVarFile, localVarFileOk = localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value().({{dataType}})
-		if !localVarFileOk {
-				return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} should be {{dataType}}")
-		}
+	if r.{{paramName}} != nil {
+		localVarFile = *r.{{paramName}}
 	}
 {{/required}}
 	if localVarFile != nil {
@@ -231,12 +217,12 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 {{/isFile}}
 {{^isFile}}
 {{#required}}
-	localVarFormParams.Add("{{baseName}}", parameterToString({{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	localVarFormParams.Add("{{baseName}}", parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 {{/required}}
 {{^required}}
 {{#isModel}}
-	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-exportParamName}}.IsSet() {
-		paramJson, err := parameterToJson(localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value())
+	if r.{{paramName}} != nil {
+		paramJson, err := parameterToJson(*r.{{paramName}})
 		if err != nil {
 			return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
 		}
@@ -244,8 +230,8 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 	}
 {{/isModel}}
 {{^isModel}}
-	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-exportParamName}}.IsSet() {
-		localVarFormParams.Add("{{baseName}}", parameterToString(localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value(), "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
+	if r.{{paramName}} != nil {
+		localVarFormParams.Add("{{baseName}}", parameterToString(*r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"))
 	}
 {{/isModel}}
 {{/required}}
@@ -255,32 +241,15 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 {{#hasBodyParam}}
 {{#bodyParams}}
 	// body params
-{{#required}}
-	localVarPostBody = &{{paramName}}
-{{/required}}
-{{^required}}
-	if localVarOptionals != nil && localVarOptionals.{{vendorExtensions.x-exportParamName}}.IsSet() {
-		{{#isPrimitiveType}}
-		localVarPostBody = localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value()
-		{{/isPrimitiveType}}
-		{{^isPrimitiveType}}
-		localVarOptional{{vendorExtensions.x-exportParamName}}, localVarOptional{{vendorExtensions.x-exportParamName}}ok := localVarOptionals.{{vendorExtensions.x-exportParamName}}.Value().({{{dataType}}})
-		if !localVarOptional{{vendorExtensions.x-exportParamName}}ok {
-			return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} should be {{dataType}}")
-		}
-		localVarPostBody = &localVarOptional{{vendorExtensions.x-exportParamName}}
-		{{/isPrimitiveType}}
-	}
-
-{{/required}}
+	localVarPostBody = r.{{paramName}}
 {{/bodyParams}}
 {{/hasBodyParam}}
 {{#authMethods}}
 {{#isApiKey}}
 {{^isKeyInCookie}}
-	if ctx != nil {
+	if r.ctx != nil {
 		// API Key Authentication
-		if auth, ok := ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
 			if auth, ok := auth["{{keyParamName}}"]; ok {
 				var key string
 				if auth.Prefix != "" {
@@ -300,12 +269,12 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 {{/isKeyInCookie}}
 {{/isApiKey}}
 {{/authMethods}}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}
@@ -327,7 +296,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 		if localVarHTTPResponse.StatusCode == {{{code}}} {
 		{{/wildcard}}
 			var v {{{dataType}}}
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
@@ -345,7 +314,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#hasParams
 	}
 
 	{{#returnType}}
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/modules/openapi-generator/src/main/resources/go-experimental/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/go-experimental/api_doc.mustache
@@ -14,29 +14,28 @@ Method | HTTP request | Description
 
 ## {{{operationId}}}
 
-> {{#returnType}}{{{returnType}}} {{/returnType}}{{{operationId}}}(ctx, {{#allParams}}{{#required}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/required}}{{/allParams}}{{#hasOptionalParams}}optional{{/hasOptionalParams}})
+> {{#returnType}}{{{.}}} {{/returnType}}{{{operationId}}}(ctx{{#pathParams}}, {{paramName}}{{/pathParams}}){{#allParams}}{{^isPathParam}}.{{vendorExtensions.x-exportParamName}}({{paramName}}){{/isPathParam}}{{/allParams}}.Execute()
 
 {{{summary}}}{{#notes}}
 
-{{{notes}}}{{/notes}}
+{{{unespacedNotes}}}{{/notes}}
 
-### Required Parameters
+### Path Parameters
 
-{{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
+{{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#pathParams}}{{#-last}}
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.{{/-last}}{{/allParams}}{{#allParams}}{{#required}}
-**{{paramName}}** | {{#isFile}}**{{dataType}}**{{/isFile}}{{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**{{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/required}}{{/allParams}}{{#hasOptionalParams}}
- **optional** | ***{{{nickname}}}Opts** | optional parameters | nil if no parameters
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.{{/-last}}{{/pathParams}}{{#pathParams}}
+**{{paramName}}** | {{^isPrimitiveType}}{{^isFile}}[{{/isFile}}{{/isPrimitiveType}}**{{dataType}}**{{^isPrimitiveType}}{{^isFile}}]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}} | {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/pathParams}}
 
-### Optional Parameters
+### Other Parameters
 
-Optional parameters are passed through a pointer to a {{{nickname}}}Opts struct
+Other parameters are passed through a pointer to a api{{{nickname}}}Request struct via the builder pattern
 {{#allParams}}{{#-last}}
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}{{#allParams}}
-{{^required}} **{{paramName}}** | {{#isFile}}**optional.Interface of {{dataType}}**{{/isFile}}{{#isPrimitiveType}}**optional.{{vendorExtensions.x-optionalDataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}{{^isFile}}[**optional.Interface of {{dataType}}**]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}}| {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/required}}{{/allParams}}{{/hasOptionalParams}}
+{{^isPathParam}} **{{paramName}}** | {{^isPrimitiveType}}{{^isFile}}[{{/isFile}}{{/isPrimitiveType}}**{{dataType}}**{{^isPrimitiveType}}{{^isFile}}]({{baseType}}.md){{/isFile}}{{/isPrimitiveType}} | {{description}} | {{#defaultValue}}[default to {{defaultValue}}]{{/defaultValue}}{{/isPathParam}}{{/allParams}}
 
 ### Return type
 

--- a/samples/client/petstore/go-experimental/auth_test.go
+++ b/samples/client/petstore/go-experimental/auth_test.go
@@ -228,7 +228,7 @@ func TestDefaultHeader(t *testing.T) {
 }
 
 func TestHostOverride(t *testing.T) {
-	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Execute()
+	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)
@@ -240,7 +240,7 @@ func TestHostOverride(t *testing.T) {
 }
 
 func TestSchemeOverride(t *testing.T) {
-	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Execute()
+	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)

--- a/samples/client/petstore/go-experimental/auth_test.go
+++ b/samples/client/petstore/go-experimental/auth_test.go
@@ -41,7 +41,7 @@ func TestOAuth2(t *testing.T) {
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: sw.PtrString("pending"),
 		Tags: &[]sw.Tag{sw.Tag{Id: sw.PtrInt64(1), Name: sw.PtrString("tag2")}}})
 
-	r, err := client.PetApi.AddPet(context.Background(), newPet)
+	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
@@ -50,7 +50,7 @@ func TestOAuth2(t *testing.T) {
 		t.Log(r)
 	}
 
-	r, err = client.PetApi.DeletePet(auth, 12992, nil)
+	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
@@ -76,7 +76,7 @@ func TestBasicAuth(t *testing.T) {
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: sw.PtrString("pending"),
 		Tags: &[]sw.Tag{sw.Tag{Id: sw.PtrInt64(1), Name: sw.PtrString("tag2")}}})
 
-	r, err := client.PetApi.AddPet(auth, newPet)
+	r, err := client.PetApi.AddPet(auth).Body(newPet).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
@@ -85,7 +85,7 @@ func TestBasicAuth(t *testing.T) {
 		t.Log(r)
 	}
 
-	r, err = client.PetApi.DeletePet(auth, 12992, nil)
+	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
@@ -106,7 +106,7 @@ func TestAccessToken(t *testing.T) {
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: sw.PtrString("pending"),
 		Tags: &[]sw.Tag{sw.Tag{Id: sw.PtrInt64(1), Name: sw.PtrString("tag2")}}})
 
-	r, err := client.PetApi.AddPet(nil, newPet)
+	r, err := client.PetApi.AddPet(nil).Body(newPet).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
@@ -115,7 +115,7 @@ func TestAccessToken(t *testing.T) {
 		t.Log(r)
 	}
 
-	r, err = client.PetApi.DeletePet(auth, 12992, nil)
+	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
@@ -136,7 +136,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: sw.PtrString("pending"),
 		Tags: &[]sw.Tag{sw.Tag{Id: sw.PtrInt64(1), Name: sw.PtrString("tag2")}}})
 
-	r, err := client.PetApi.AddPet(context.Background(), newPet)
+	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
@@ -145,7 +145,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 		t.Log(r)
 	}
 
-	_, r, err = client.PetApi.GetPetById(auth, 12992)
+	_, r, err = client.PetApi.GetPetById(auth, 12992).Execute()
 	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestAPIKeyNoPrefix(t *testing.T) {
 		t.Errorf("APIKey Authentication is missing")
 	}
 
-	r, err = client.PetApi.DeletePet(auth, 12992, nil)
+	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: sw.PtrString("pending"),
 		Tags: &[]sw.Tag{sw.Tag{Id: sw.PtrInt64(1), Name: sw.PtrString("tag2")}}})
 
-	r, err := client.PetApi.AddPet(nil, newPet)
+	r, err := client.PetApi.AddPet(nil).Body(newPet).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
@@ -180,7 +180,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 		t.Log(r)
 	}
 
-	_, r, err = client.PetApi.GetPetById(auth, 12992)
+	_, r, err = client.PetApi.GetPetById(auth, 12992).Execute()
 	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestAPIKeyWithPrefix(t *testing.T) {
 		t.Errorf("APIKey Authentication is missing")
 	}
 
-	r, err = client.PetApi.DeletePet(auth, 12992, nil)
+	r, err = client.PetApi.DeletePet(auth, 12992).Execute()
 	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestDefaultHeader(t *testing.T) {
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: sw.PtrString("pending"),
 		Tags: &[]sw.Tag{sw.Tag{Id: sw.PtrInt64(1), Name: sw.PtrString("tag2")}}})
 
-	r, err := client.PetApi.AddPet(context.Background(), newPet)
+	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
@@ -213,7 +213,7 @@ func TestDefaultHeader(t *testing.T) {
 		t.Log(r)
 	}
 
-	r, err = client.PetApi.DeletePet(context.Background(), 12992, nil)
+	r, err = client.PetApi.DeletePet(context.Background(), 12992).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
@@ -228,7 +228,7 @@ func TestDefaultHeader(t *testing.T) {
 }
 
 func TestHostOverride(t *testing.T) {
-	_, r, err := client.PetApi.FindPetsByStatus(context.Background(), nil)
+	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)
@@ -240,7 +240,7 @@ func TestHostOverride(t *testing.T) {
 }
 
 func TestSchemeOverride(t *testing.T) {
-	_, r, err := client.PetApi.FindPetsByStatus(context.Background(), nil)
+	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while finding pets by status: %v", err)

--- a/samples/client/petstore/go-experimental/fake_api_test.go
+++ b/samples/client/petstore/go-experimental/fake_api_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	sw "./go-petstore"
-	"golang.org/x/net/context"
 )
 
 // TestPutBodyWithFileSchema ensures a model with the name 'File'
@@ -17,7 +17,7 @@ func TestPutBodyWithFileSchema(t *testing.T) {
 		File:  &sw.File{SourceURI: sw.PtrString("https://example.com/image.png")},
 		Files: &[]sw.File{{SourceURI: sw.PtrString("https://example.com/image.png")}}}
 
-	r, err := client.FakeApi.TestBodyWithFileSchema(context.Background(), schema)
+	r, err := client.FakeApi.TestBodyWithFileSchema(context.Background()).Body(schema).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)

--- a/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -25,15 +25,15 @@ var (
 type AnotherFakeApiService service
 
 type apiCall123TestSpecialTagsRequest struct {
-    ctx _context.Context
-    apiService *AnotherFakeApiService
-    body *Client
+	ctx _context.Context
+	apiService *AnotherFakeApiService
+	body *Client
 }
 
 
 func (r apiCall123TestSpecialTagsRequest) Body(body Client) apiCall123TestSpecialTagsRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -43,10 +43,10 @@ To test special tags and operation ID starting with number
 @return apiCall123TestSpecialTagsRequest
 */
 func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context) apiCall123TestSpecialTagsRequest {
-    return apiCall123TestSpecialTagsRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiCall123TestSpecialTagsRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -63,25 +63,20 @@ func (r apiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response,
 		localVarReturnValue  Client
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "AnotherFakeApiService.Call123TestSpecialTags")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "AnotherFakeApiService.Call123TestSpecialTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/another-fake/dummy"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/another-fake/dummy"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.body == nil {
-        return localVarReturnValue, nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -101,7 +96,7 @@ func (r apiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response,
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -24,14 +24,36 @@ var (
 // AnotherFakeApiService AnotherFakeApi service
 type AnotherFakeApiService service
 
+type apiCall123TestSpecialTagsRequest struct {
+    ctx _context.Context
+    apiService *AnotherFakeApiService
+    body *Client
+}
+
+
+func (r apiCall123TestSpecialTagsRequest) Body(body Client) apiCall123TestSpecialTagsRequest {
+    r.body = &body
+    return r
+}
+
 /*
 Call123TestSpecialTags To test special tags
 To test special tags and operation ID starting with number
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body client model
-@return Client
+@return apiCall123TestSpecialTagsRequest
 */
-func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, body Client) (Client, *_nethttp.Response, error) {
+func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context) apiCall123TestSpecialTagsRequest {
+    return apiCall123TestSpecialTagsRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return Client
+*/
+func (r apiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -41,6 +63,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 		localVarReturnValue  Client
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "AnotherFakeApiService.Call123TestSpecialTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -48,9 +71,17 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 
 	localVarPath := localBasePath + "/another-fake/dummy"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/another-fake/dummy"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.body == nil {
+        return localVarReturnValue, nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -70,13 +101,13 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -94,7 +125,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Client
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -104,7 +135,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, bod
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -14,8 +14,8 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"github.com/antihax/optional"
 	"os"
+	"time"
 	"reflect"
 )
 
@@ -27,21 +27,46 @@ var (
 // FakeApiService FakeApi service
 type FakeApiService service
 
+type apiCreateXmlItemRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    xmlItem *XmlItem
+}
+
+
+func (r apiCreateXmlItemRequest) XmlItem(xmlItem XmlItem) apiCreateXmlItemRequest {
+    r.xmlItem = &xmlItem
+    return r
+}
+
 /*
 CreateXmlItem creates an XmlItem
 this route creates an XmlItem
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param xmlItem XmlItem Body
+@return apiCreateXmlItemRequest
 */
-func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*_nethttp.Response, error) {
+func (a *FakeApiService) CreateXmlItem(ctx _context.Context) apiCreateXmlItemRequest {
+    return apiCreateXmlItemRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiCreateXmlItemRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.CreateXmlItem")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -49,9 +74,17 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*
 
 	localVarPath := localBasePath + "/fake/create_xml_item"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/create_xml_item"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.xmlItem == nil {
+        return nil, reportError("xmlItem is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/xml", "application/xml; charset=utf-8", "application/xml; charset=utf-16", "text/xml", "text/xml; charset=utf-8", "text/xml; charset=utf-16"}
@@ -71,13 +104,13 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &xmlItem
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.xmlItem
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -98,21 +131,36 @@ func (a *FakeApiService) CreateXmlItem(ctx _context.Context, xmlItem XmlItem) (*
 
 	return localVarHTTPResponse, nil
 }
+type apiFakeOuterBooleanSerializeRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    body *bool
+}
 
-// FakeOuterBooleanSerializeOpts Optional parameters for the method 'FakeOuterBooleanSerialize'
-type FakeOuterBooleanSerializeOpts struct {
-    Body optional.Bool
+
+func (r apiFakeOuterBooleanSerializeRequest) Body(body bool) apiFakeOuterBooleanSerializeRequest {
+    r.body = &body
+    return r
 }
 
 /*
 FakeOuterBooleanSerialize Method for FakeOuterBooleanSerialize
 Test serialization of outer boolean types
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *FakeOuterBooleanSerializeOpts - Optional Parameters:
- * @param "Body" (optional.Bool) -  Input boolean as post body
-@return bool
+@return apiFakeOuterBooleanSerializeRequest
 */
-func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVarOptionals *FakeOuterBooleanSerializeOpts) (bool, *_nethttp.Response, error) {
+func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context) apiFakeOuterBooleanSerializeRequest {
+    return apiFakeOuterBooleanSerializeRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return bool
+*/
+func (r apiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -122,6 +170,7 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		localVarReturnValue  bool
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterBooleanSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -129,10 +178,14 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 
 	localVarPath := localBasePath + "/fake/outer/boolean"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/boolean"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -151,16 +204,13 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
-		localVarPostBody = localVarOptionals.Body.Value()
-	}
-
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -178,7 +228,7 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v bool
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -188,7 +238,7 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -199,21 +249,36 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiFakeOuterCompositeSerializeRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    body *OuterComposite
+}
 
-// FakeOuterCompositeSerializeOpts Optional parameters for the method 'FakeOuterCompositeSerialize'
-type FakeOuterCompositeSerializeOpts struct {
-    Body optional.Interface
+
+func (r apiFakeOuterCompositeSerializeRequest) Body(body OuterComposite) apiFakeOuterCompositeSerializeRequest {
+    r.body = &body
+    return r
 }
 
 /*
 FakeOuterCompositeSerialize Method for FakeOuterCompositeSerialize
 Test serialization of object with outer number type
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *FakeOuterCompositeSerializeOpts - Optional Parameters:
- * @param "Body" (optional.Interface of OuterComposite) -  Input composite as post body
-@return OuterComposite
+@return apiFakeOuterCompositeSerializeRequest
 */
-func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, localVarOptionals *FakeOuterCompositeSerializeOpts) (OuterComposite, *_nethttp.Response, error) {
+func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context) apiFakeOuterCompositeSerializeRequest {
+    return apiFakeOuterCompositeSerializeRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return OuterComposite
+*/
+func (r apiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -223,6 +288,7 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		localVarReturnValue  OuterComposite
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterCompositeSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -230,10 +296,14 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 
 	localVarPath := localBasePath + "/fake/outer/composite"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/composite"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -252,20 +322,13 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
-		localVarOptionalBody, localVarOptionalBodyok := localVarOptionals.Body.Value().(OuterComposite)
-		if !localVarOptionalBodyok {
-			return localVarReturnValue, nil, reportError("body should be OuterComposite")
-		}
-		localVarPostBody = &localVarOptionalBody
-	}
-
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -283,7 +346,7 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v OuterComposite
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -293,7 +356,7 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -304,21 +367,36 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiFakeOuterNumberSerializeRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    body *float32
+}
 
-// FakeOuterNumberSerializeOpts Optional parameters for the method 'FakeOuterNumberSerialize'
-type FakeOuterNumberSerializeOpts struct {
-    Body optional.Float32
+
+func (r apiFakeOuterNumberSerializeRequest) Body(body float32) apiFakeOuterNumberSerializeRequest {
+    r.body = &body
+    return r
 }
 
 /*
 FakeOuterNumberSerialize Method for FakeOuterNumberSerialize
 Test serialization of outer number types
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *FakeOuterNumberSerializeOpts - Optional Parameters:
- * @param "Body" (optional.Float32) -  Input number as post body
-@return float32
+@return apiFakeOuterNumberSerializeRequest
 */
-func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVarOptionals *FakeOuterNumberSerializeOpts) (float32, *_nethttp.Response, error) {
+func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context) apiFakeOuterNumberSerializeRequest {
+    return apiFakeOuterNumberSerializeRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return float32
+*/
+func (r apiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -328,6 +406,7 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		localVarReturnValue  float32
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterNumberSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -335,10 +414,14 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 
 	localVarPath := localBasePath + "/fake/outer/number"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/number"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -357,16 +440,13 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
-		localVarPostBody = localVarOptionals.Body.Value()
-	}
-
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -384,7 +464,7 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v float32
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -394,7 +474,7 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -405,21 +485,36 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiFakeOuterStringSerializeRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    body *string
+}
 
-// FakeOuterStringSerializeOpts Optional parameters for the method 'FakeOuterStringSerialize'
-type FakeOuterStringSerializeOpts struct {
-    Body optional.String
+
+func (r apiFakeOuterStringSerializeRequest) Body(body string) apiFakeOuterStringSerializeRequest {
+    r.body = &body
+    return r
 }
 
 /*
 FakeOuterStringSerialize Method for FakeOuterStringSerialize
 Test serialization of outer string types
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *FakeOuterStringSerializeOpts - Optional Parameters:
- * @param "Body" (optional.String) -  Input string as post body
-@return string
+@return apiFakeOuterStringSerializeRequest
 */
-func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVarOptionals *FakeOuterStringSerializeOpts) (string, *_nethttp.Response, error) {
+func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context) apiFakeOuterStringSerializeRequest {
+    return apiFakeOuterStringSerializeRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return string
+*/
+func (r apiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -429,6 +524,7 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		localVarReturnValue  string
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterStringSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -436,10 +532,14 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 
 	localVarPath := localBasePath + "/fake/outer/string"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/string"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -458,16 +558,13 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
-		localVarPostBody = localVarOptionals.Body.Value()
-	}
-
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -485,7 +582,7 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v string
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -495,7 +592,7 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -506,22 +603,46 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiTestBodyWithFileSchemaRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    body *FileSchemaTestClass
+}
+
+
+func (r apiTestBodyWithFileSchemaRequest) Body(body FileSchemaTestClass) apiTestBodyWithFileSchemaRequest {
+    r.body = &body
+    return r
+}
 
 /*
 TestBodyWithFileSchema Method for TestBodyWithFileSchema
-For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+For this test, the body for this request much reference a schema named `File`.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body
+@return apiTestBodyWithFileSchemaRequest
 */
-func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileSchemaTestClass) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context) apiTestBodyWithFileSchemaRequest {
+    return apiTestBodyWithFileSchemaRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithFileSchema")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -529,9 +650,17 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileS
 
 	localVarPath := localBasePath + "/fake/body-with-file-schema"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/body-with-file-schema"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.body == nil {
+        return nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -551,13 +680,13 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileS
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -578,22 +707,51 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, body FileS
 
 	return localVarHTTPResponse, nil
 }
+type apiTestBodyWithQueryParamsRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    query *string
+    body *User
+}
+
+
+func (r apiTestBodyWithQueryParamsRequest) Query(query string) apiTestBodyWithQueryParamsRequest {
+    r.query = &query
+    return r
+}
+
+func (r apiTestBodyWithQueryParamsRequest) Body(body User) apiTestBodyWithQueryParamsRequest {
+    r.body = &body
+    return r
+}
 
 /*
 TestBodyWithQueryParams Method for TestBodyWithQueryParams
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param query
- * @param body
+@return apiTestBodyWithQueryParamsRequest
 */
-func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query string, body User) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context) apiTestBodyWithQueryParamsRequest {
+    return apiTestBodyWithQueryParamsRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithQueryParams")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -601,11 +759,23 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 
 	localVarPath := localBasePath + "/fake/body-with-query-params"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/body-with-query-params"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.query == nil {
+        return nil, reportError("query is required and must be specified")
+    }
+	
+    if r.body == nil {
+        return nil, reportError("body is required and must be specified")
+    }
 
-	localVarQueryParams.Add("query", parameterToString(query, ""))
+	localVarQueryParams.Add("query", parameterToString(*r.query, ""))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
 
@@ -624,13 +794,13 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -651,15 +821,36 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 
 	return localVarHTTPResponse, nil
 }
+type apiTestClientModelRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    body *Client
+}
+
+
+func (r apiTestClientModelRequest) Body(body Client) apiTestClientModelRequest {
+    r.body = &body
+    return r
+}
 
 /*
 TestClientModel To test \"client\" model
-To test \&quot;client\&quot; model
+To test "client" model
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body client model
-@return Client
+@return apiTestClientModelRequest
 */
-func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Client, *_nethttp.Response, error) {
+func (a *FakeApiService) TestClientModel(ctx _context.Context) apiTestClientModelRequest {
+    return apiTestClientModelRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return Client
+*/
+func (r apiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -669,6 +860,7 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 		localVarReturnValue  Client
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestClientModel")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -676,9 +868,17 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 
 	localVarPath := localBasePath + "/fake"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.body == nil {
+        return localVarReturnValue, nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -698,13 +898,13 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -722,7 +922,7 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Client
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -732,7 +932,7 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -743,50 +943,133 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, body Client) (Cli
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiTestEndpointParametersRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    number *float32
+    double *float64
+    patternWithoutDelimiter *string
+    byte_ *string
+    integer *int32
+    int32_ *int32
+    int64_ *int64
+    float *float32
+    string_ *string
+    binary **os.File
+    date *string
+    dateTime *time.Time
+    password *string
+    callback *string
+}
 
-// TestEndpointParametersOpts Optional parameters for the method 'TestEndpointParameters'
-type TestEndpointParametersOpts struct {
-    Integer optional.Int32
-    Int32_ optional.Int32
-    Int64_ optional.Int64
-    Float optional.Float32
-    String_ optional.String
-    Binary optional.Interface
-    Date optional.String
-    DateTime optional.Time
-    Password optional.String
-    Callback optional.String
+
+func (r apiTestEndpointParametersRequest) Number(number float32) apiTestEndpointParametersRequest {
+    r.number = &number
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Double(double float64) apiTestEndpointParametersRequest {
+    r.double = &double
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithoutDelimiter string) apiTestEndpointParametersRequest {
+    r.patternWithoutDelimiter = &patternWithoutDelimiter
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Byte_(byte_ string) apiTestEndpointParametersRequest {
+    r.byte_ = &byte_
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Integer(integer int32) apiTestEndpointParametersRequest {
+    r.integer = &integer
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Int32_(int32_ int32) apiTestEndpointParametersRequest {
+    r.int32_ = &int32_
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Int64_(int64_ int64) apiTestEndpointParametersRequest {
+    r.int64_ = &int64_
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Float(float float32) apiTestEndpointParametersRequest {
+    r.float = &float
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) String_(string_ string) apiTestEndpointParametersRequest {
+    r.string_ = &string_
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Binary(binary *os.File) apiTestEndpointParametersRequest {
+    r.binary = &binary
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Date(date string) apiTestEndpointParametersRequest {
+    r.date = &date
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) DateTime(dateTime time.Time) apiTestEndpointParametersRequest {
+    r.dateTime = &dateTime
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Password(password string) apiTestEndpointParametersRequest {
+    r.password = &password
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Callback(callback string) apiTestEndpointParametersRequest {
+    r.callback = &callback
+    return r
 }
 
 /*
+<<<<<<< HEAD
 TestEndpointParameters Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+=======
+TestEndpointParameters Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+Fake endpoint for testing various parameters
+假端點
+偽のエンドポイント
+가짜 엔드 포인트
+
+>>>>>>> [go-experimental] Use builder pattern for requests
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param number None
- * @param double None
- * @param patternWithoutDelimiter None
- * @param byte_ None
- * @param optional nil or *TestEndpointParametersOpts - Optional Parameters:
- * @param "Integer" (optional.Int32) -  None
- * @param "Int32_" (optional.Int32) -  None
- * @param "Int64_" (optional.Int64) -  None
- * @param "Float" (optional.Float32) -  None
- * @param "String_" (optional.String) -  None
- * @param "Binary" (optional.Interface of *os.File) -  None
- * @param "Date" (optional.String) -  None
- * @param "DateTime" (optional.Time) -  None
- * @param "Password" (optional.String) -  None
- * @param "Callback" (optional.String) -  None
+@return apiTestEndpointParametersRequest
 */
-func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number float32, double float64, patternWithoutDelimiter string, byte_ string, localVarOptionals *TestEndpointParametersOpts) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestEndpointParameters(ctx _context.Context) apiTestEndpointParametersRequest {
+    return apiTestEndpointParametersRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEndpointParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -794,22 +1077,42 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 
 	localVarPath := localBasePath + "/fake"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if number < 32.1 {
+	
+    if r.number == nil {
+        return nil, reportError("number is required and must be specified")
+    }
+	if *r.number < 32.1 {
 		return nil, reportError("number must be greater than 32.1")
 	}
-	if number > 543.2 {
+	if *r.number > 543.2 {
 		return nil, reportError("number must be less than 543.2")
 	}
-	if double < 67.8 {
+	
+    if r.double == nil {
+        return nil, reportError("double is required and must be specified")
+    }
+	if *r.double < 67.8 {
 		return nil, reportError("double must be greater than 67.8")
 	}
-	if double > 123.4 {
+	if *r.double > 123.4 {
 		return nil, reportError("double must be less than 123.4")
 	}
-
+	
+    if r.patternWithoutDelimiter == nil {
+        return nil, reportError("patternWithoutDelimiter is required and must be specified")
+    }
+	
+    if r.byte_ == nil {
+        return nil, reportError("byte_ is required and must be specified")
+    }
+										
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
 
@@ -827,33 +1130,29 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.Integer.IsSet() {
-		localVarFormParams.Add("integer", parameterToString(localVarOptionals.Integer.Value(), ""))
+	if r.integer != nil {
+		localVarFormParams.Add("integer", parameterToString(*r.integer, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Int32_.IsSet() {
-		localVarFormParams.Add("int32", parameterToString(localVarOptionals.Int32_.Value(), ""))
+	if r.int32_ != nil {
+		localVarFormParams.Add("int32", parameterToString(*r.int32_, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Int64_.IsSet() {
-		localVarFormParams.Add("int64", parameterToString(localVarOptionals.Int64_.Value(), ""))
+	if r.int64_ != nil {
+		localVarFormParams.Add("int64", parameterToString(*r.int64_, ""))
 	}
-	localVarFormParams.Add("number", parameterToString(number, ""))
-	if localVarOptionals != nil && localVarOptionals.Float.IsSet() {
-		localVarFormParams.Add("float", parameterToString(localVarOptionals.Float.Value(), ""))
+	localVarFormParams.Add("number", parameterToString(*r.number, ""))
+	if r.float != nil {
+		localVarFormParams.Add("float", parameterToString(*r.float, ""))
 	}
-	localVarFormParams.Add("double", parameterToString(double, ""))
-	if localVarOptionals != nil && localVarOptionals.String_.IsSet() {
-		localVarFormParams.Add("string", parameterToString(localVarOptionals.String_.Value(), ""))
+	localVarFormParams.Add("double", parameterToString(*r.double, ""))
+	if r.string_ != nil {
+		localVarFormParams.Add("string", parameterToString(*r.string_, ""))
 	}
-	localVarFormParams.Add("pattern_without_delimiter", parameterToString(patternWithoutDelimiter, ""))
-	localVarFormParams.Add("byte", parameterToString(byte_, ""))
+	localVarFormParams.Add("pattern_without_delimiter", parameterToString(*r.patternWithoutDelimiter, ""))
+	localVarFormParams.Add("byte", parameterToString(*r.byte_, ""))
 	localVarFormFileName = "binary"
 	var localVarFile *os.File
-	if localVarOptionals != nil && localVarOptionals.Binary.IsSet() {
-		localVarFileOk := false
-		localVarFile, localVarFileOk = localVarOptionals.Binary.Value().(*os.File)
-		if !localVarFileOk {
-				return nil, reportError("binary should be *os.File")
-		}
+	if r.binary != nil {
+		localVarFile = *r.binary
 	}
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
@@ -861,24 +1160,24 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 		localVarFileName = localVarFile.Name()
 		localVarFile.Close()
 	}
-	if localVarOptionals != nil && localVarOptionals.Date.IsSet() {
-		localVarFormParams.Add("date", parameterToString(localVarOptionals.Date.Value(), ""))
+	if r.date != nil {
+		localVarFormParams.Add("date", parameterToString(*r.date, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.DateTime.IsSet() {
-		localVarFormParams.Add("dateTime", parameterToString(localVarOptionals.DateTime.Value(), ""))
+	if r.dateTime != nil {
+		localVarFormParams.Add("dateTime", parameterToString(*r.dateTime, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Password.IsSet() {
-		localVarFormParams.Add("password", parameterToString(localVarOptionals.Password.Value(), ""))
+	if r.password != nil {
+		localVarFormParams.Add("password", parameterToString(*r.password, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Callback.IsSet() {
-		localVarFormParams.Add("callback", parameterToString(localVarOptionals.Callback.Value(), ""))
+	if r.callback != nil {
+		localVarFormParams.Add("callback", parameterToString(*r.callback, ""))
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -899,42 +1198,88 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 
 	return localVarHTTPResponse, nil
 }
+type apiTestEnumParametersRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    enumHeaderStringArray *[]string
+    enumHeaderString *string
+    enumQueryStringArray *[]string
+    enumQueryString *string
+    enumQueryInteger *int32
+    enumQueryDouble *float64
+    enumFormStringArray *[]string
+    enumFormString *string
+}
 
-// TestEnumParametersOpts Optional parameters for the method 'TestEnumParameters'
-type TestEnumParametersOpts struct {
-    EnumHeaderStringArray optional.Interface
-    EnumHeaderString optional.String
-    EnumQueryStringArray optional.Interface
-    EnumQueryString optional.String
-    EnumQueryInteger optional.Int32
-    EnumQueryDouble optional.Float64
-    EnumFormStringArray optional.Interface
-    EnumFormString optional.String
+
+func (r apiTestEnumParametersRequest) EnumHeaderStringArray(enumHeaderStringArray []string) apiTestEnumParametersRequest {
+    r.enumHeaderStringArray = &enumHeaderStringArray
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumHeaderString(enumHeaderString string) apiTestEnumParametersRequest {
+    r.enumHeaderString = &enumHeaderString
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumQueryStringArray(enumQueryStringArray []string) apiTestEnumParametersRequest {
+    r.enumQueryStringArray = &enumQueryStringArray
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumQueryString(enumQueryString string) apiTestEnumParametersRequest {
+    r.enumQueryString = &enumQueryString
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumQueryInteger(enumQueryInteger int32) apiTestEnumParametersRequest {
+    r.enumQueryInteger = &enumQueryInteger
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumQueryDouble(enumQueryDouble float64) apiTestEnumParametersRequest {
+    r.enumQueryDouble = &enumQueryDouble
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumFormStringArray(enumFormStringArray []string) apiTestEnumParametersRequest {
+    r.enumFormStringArray = &enumFormStringArray
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumFormString(enumFormString string) apiTestEnumParametersRequest {
+    r.enumFormString = &enumFormString
+    return r
 }
 
 /*
 TestEnumParameters To test enum parameters
 To test enum parameters
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *TestEnumParametersOpts - Optional Parameters:
- * @param "EnumHeaderStringArray" (optional.Interface of []string) -  Header parameter enum test (string array)
- * @param "EnumHeaderString" (optional.String) -  Header parameter enum test (string)
- * @param "EnumQueryStringArray" (optional.Interface of []string) -  Query parameter enum test (string array)
- * @param "EnumQueryString" (optional.String) -  Query parameter enum test (string)
- * @param "EnumQueryInteger" (optional.Int32) -  Query parameter enum test (double)
- * @param "EnumQueryDouble" (optional.Float64) -  Query parameter enum test (double)
- * @param "EnumFormStringArray" (optional.Interface of []string) -  Form parameter enum test (string array)
- * @param "EnumFormString" (optional.String) -  Form parameter enum test (string)
+@return apiTestEnumParametersRequest
 */
-func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOptionals *TestEnumParametersOpts) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestEnumParameters(ctx _context.Context) apiTestEnumParametersRequest {
+    return apiTestEnumParametersRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEnumParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -942,21 +1287,25 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 
 	localVarPath := localBasePath + "/fake"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
-	if localVarOptionals != nil && localVarOptionals.EnumQueryStringArray.IsSet() {
-		localVarQueryParams.Add("enum_query_string_array", parameterToString(localVarOptionals.EnumQueryStringArray.Value(), "csv"))
+								
+	if r.enumQueryStringArray != nil {
+		localVarQueryParams.Add("enum_query_string_array", parameterToString(*r.enumQueryStringArray, "csv"))
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumQueryString.IsSet() {
-		localVarQueryParams.Add("enum_query_string", parameterToString(localVarOptionals.EnumQueryString.Value(), ""))
+	if r.enumQueryString != nil {
+		localVarQueryParams.Add("enum_query_string", parameterToString(*r.enumQueryString, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumQueryInteger.IsSet() {
-		localVarQueryParams.Add("enum_query_integer", parameterToString(localVarOptionals.EnumQueryInteger.Value(), ""))
+	if r.enumQueryInteger != nil {
+		localVarQueryParams.Add("enum_query_integer", parameterToString(*r.enumQueryInteger, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumQueryDouble.IsSet() {
-		localVarQueryParams.Add("enum_query_double", parameterToString(localVarOptionals.EnumQueryDouble.Value(), ""))
+	if r.enumQueryDouble != nil {
+		localVarQueryParams.Add("enum_query_double", parameterToString(*r.enumQueryDouble, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -975,24 +1324,24 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumHeaderStringArray.IsSet() {
-		localVarHeaderParams["enum_header_string_array"] = parameterToString(localVarOptionals.EnumHeaderStringArray.Value(), "csv")
+	if r.enumHeaderStringArray != nil {
+		localVarHeaderParams["enum_header_string_array"] = parameterToString(*r.enumHeaderStringArray, "csv")
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumHeaderString.IsSet() {
-		localVarHeaderParams["enum_header_string"] = parameterToString(localVarOptionals.EnumHeaderString.Value(), "")
+	if r.enumHeaderString != nil {
+		localVarHeaderParams["enum_header_string"] = parameterToString(*r.enumHeaderString, "")
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumFormStringArray.IsSet() {
-		localVarFormParams.Add("enum_form_string_array", parameterToString(localVarOptionals.EnumFormStringArray.Value(), "csv"))
+	if r.enumFormStringArray != nil {
+		localVarFormParams.Add("enum_form_string_array", parameterToString(*r.enumFormStringArray, "csv"))
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumFormString.IsSet() {
-		localVarFormParams.Add("enum_form_string", parameterToString(localVarOptionals.EnumFormString.Value(), ""))
+	if r.enumFormString != nil {
+		localVarFormParams.Add("enum_form_string", parameterToString(*r.enumFormString, ""))
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -1013,35 +1362,76 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 
 	return localVarHTTPResponse, nil
 }
+type apiTestGroupParametersRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    requiredStringGroup *int32
+    requiredBooleanGroup *bool
+    requiredInt64Group *int64
+    stringGroup *int32
+    booleanGroup *bool
+    int64Group *int64
+}
 
-// TestGroupParametersOpts Optional parameters for the method 'TestGroupParameters'
-type TestGroupParametersOpts struct {
-    StringGroup optional.Int32
-    BooleanGroup optional.Bool
-    Int64Group optional.Int64
+
+func (r apiTestGroupParametersRequest) RequiredStringGroup(requiredStringGroup int32) apiTestGroupParametersRequest {
+    r.requiredStringGroup = &requiredStringGroup
+    return r
+}
+
+func (r apiTestGroupParametersRequest) RequiredBooleanGroup(requiredBooleanGroup bool) apiTestGroupParametersRequest {
+    r.requiredBooleanGroup = &requiredBooleanGroup
+    return r
+}
+
+func (r apiTestGroupParametersRequest) RequiredInt64Group(requiredInt64Group int64) apiTestGroupParametersRequest {
+    r.requiredInt64Group = &requiredInt64Group
+    return r
+}
+
+func (r apiTestGroupParametersRequest) StringGroup(stringGroup int32) apiTestGroupParametersRequest {
+    r.stringGroup = &stringGroup
+    return r
+}
+
+func (r apiTestGroupParametersRequest) BooleanGroup(booleanGroup bool) apiTestGroupParametersRequest {
+    r.booleanGroup = &booleanGroup
+    return r
+}
+
+func (r apiTestGroupParametersRequest) Int64Group(int64Group int64) apiTestGroupParametersRequest {
+    r.int64Group = &int64Group
+    return r
 }
 
 /*
 TestGroupParameters Fake endpoint to test group parameters (optional)
 Fake endpoint to test group parameters (optional)
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param requiredStringGroup Required String in group parameters
- * @param requiredBooleanGroup Required Boolean in group parameters
- * @param requiredInt64Group Required Integer in group parameters
- * @param optional nil or *TestGroupParametersOpts - Optional Parameters:
- * @param "StringGroup" (optional.Int32) -  String in group parameters
- * @param "BooleanGroup" (optional.Bool) -  Boolean in group parameters
- * @param "Int64Group" (optional.Int64) -  Integer in group parameters
+@return apiTestGroupParametersRequest
 */
-func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStringGroup int32, requiredBooleanGroup bool, requiredInt64Group int64, localVarOptionals *TestGroupParametersOpts) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestGroupParameters(ctx _context.Context) apiTestGroupParametersRequest {
+    return apiTestGroupParametersRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestGroupParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -1049,17 +1439,33 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 
 	localVarPath := localBasePath + "/fake"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
-	localVarQueryParams.Add("required_string_group", parameterToString(requiredStringGroup, ""))
-	localVarQueryParams.Add("required_int64_group", parameterToString(requiredInt64Group, ""))
-	if localVarOptionals != nil && localVarOptionals.StringGroup.IsSet() {
-		localVarQueryParams.Add("string_group", parameterToString(localVarOptionals.StringGroup.Value(), ""))
+	
+    if r.requiredStringGroup == nil {
+        return nil, reportError("requiredStringGroup is required and must be specified")
+    }
+	
+    if r.requiredBooleanGroup == nil {
+        return nil, reportError("requiredBooleanGroup is required and must be specified")
+    }
+	
+    if r.requiredInt64Group == nil {
+        return nil, reportError("requiredInt64Group is required and must be specified")
+    }
+			
+	localVarQueryParams.Add("required_string_group", parameterToString(*r.requiredStringGroup, ""))
+	localVarQueryParams.Add("required_int64_group", parameterToString(*r.requiredInt64Group, ""))
+	if r.stringGroup != nil {
+		localVarQueryParams.Add("string_group", parameterToString(*r.stringGroup, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Int64Group.IsSet() {
-		localVarQueryParams.Add("int64_group", parameterToString(localVarOptionals.Int64Group.Value(), ""))
+	if r.int64Group != nil {
+		localVarQueryParams.Add("int64_group", parameterToString(*r.int64Group, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -1078,16 +1484,16 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	localVarHeaderParams["required_boolean_group"] = parameterToString(requiredBooleanGroup, "")
-	if localVarOptionals != nil && localVarOptionals.BooleanGroup.IsSet() {
-		localVarHeaderParams["boolean_group"] = parameterToString(localVarOptionals.BooleanGroup.Value(), "")
+	localVarHeaderParams["required_boolean_group"] = parameterToString(*r.requiredBooleanGroup, "")
+	if r.booleanGroup != nil {
+		localVarHeaderParams["boolean_group"] = parameterToString(*r.booleanGroup, "")
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -1108,21 +1514,45 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 
 	return localVarHTTPResponse, nil
 }
+type apiTestInlineAdditionalPropertiesRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    param *map[string]string
+}
+
+
+func (r apiTestInlineAdditionalPropertiesRequest) Param(param map[string]string) apiTestInlineAdditionalPropertiesRequest {
+    r.param = &param
+    return r
+}
 
 /*
 TestInlineAdditionalProperties test inline additionalProperties
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param param request body
+@return apiTestInlineAdditionalPropertiesRequest
 */
-func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, param map[string]string) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context) apiTestInlineAdditionalPropertiesRequest {
+    return apiTestInlineAdditionalPropertiesRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestInlineAdditionalProperties")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -1130,9 +1560,17 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, pa
 
 	localVarPath := localBasePath + "/fake/inline-additionalProperties"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/inline-additionalProperties"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.param == nil {
+        return nil, reportError("param is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -1152,13 +1590,13 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, pa
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &param
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.param
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -1179,22 +1617,51 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, pa
 
 	return localVarHTTPResponse, nil
 }
+type apiTestJsonFormDataRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    param *string
+    param2 *string
+}
+
+
+func (r apiTestJsonFormDataRequest) Param(param string) apiTestJsonFormDataRequest {
+    r.param = &param
+    return r
+}
+
+func (r apiTestJsonFormDataRequest) Param2(param2 string) apiTestJsonFormDataRequest {
+    r.param2 = &param2
+    return r
+}
 
 /*
 TestJsonFormData test json serialization of form data
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param param field1
- * @param param2 field2
+@return apiTestJsonFormDataRequest
 */
-func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, param2 string) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestJsonFormData(ctx _context.Context) apiTestJsonFormDataRequest {
+    return apiTestJsonFormDataRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestJsonFormData")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -1202,9 +1669,21 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 
 	localVarPath := localBasePath + "/fake/jsonFormData"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/jsonFormData"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.param == nil {
+        return nil, reportError("param is required and must be specified")
+    }
+	
+    if r.param2 == nil {
+        return nil, reportError("param2 is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -1223,14 +1702,14 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	localVarFormParams.Add("param", parameterToString(param, ""))
-	localVarFormParams.Add("param2", parameterToString(param2, ""))
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarFormParams.Add("param", parameterToString(*r.param, ""))
+	localVarFormParams.Add("param2", parameterToString(*r.param2, ""))
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -1251,26 +1730,70 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 
 	return localVarHTTPResponse, nil
 }
+type apiTestQueryParameterCollectionFormatRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    pipe *[]string
+    ioutil *[]string
+    http *[]string
+    url *[]string
+    context *[]string
+}
+
+
+func (r apiTestQueryParameterCollectionFormatRequest) Pipe(pipe []string) apiTestQueryParameterCollectionFormatRequest {
+    r.pipe = &pipe
+    return r
+}
+
+func (r apiTestQueryParameterCollectionFormatRequest) Ioutil(ioutil []string) apiTestQueryParameterCollectionFormatRequest {
+    r.ioutil = &ioutil
+    return r
+}
+
+func (r apiTestQueryParameterCollectionFormatRequest) Http(http []string) apiTestQueryParameterCollectionFormatRequest {
+    r.http = &http
+    return r
+}
+
+func (r apiTestQueryParameterCollectionFormatRequest) Url(url []string) apiTestQueryParameterCollectionFormatRequest {
+    r.url = &url
+    return r
+}
+
+func (r apiTestQueryParameterCollectionFormatRequest) Context(context []string) apiTestQueryParameterCollectionFormatRequest {
+    r.context = &context
+    return r
+}
 
 /*
 TestQueryParameterCollectionFormat Method for TestQueryParameterCollectionFormat
 To test the collection format in query parameters
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param pipe
- * @param ioutil
- * @param http
- * @param url
- * @param context
+@return apiTestQueryParameterCollectionFormatRequest
 */
-func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context, pipe []string, ioutil []string, http []string, url []string, context []string) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context) apiTestQueryParameterCollectionFormatRequest {
+    return apiTestQueryParameterCollectionFormatRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestQueryParameterCollectionFormat")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -1278,15 +1801,39 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 
 	localVarPath := localBasePath + "/fake/test-query-paramters"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/test-query-paramters"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.pipe == nil {
+        return nil, reportError("pipe is required and must be specified")
+    }
+	
+    if r.ioutil == nil {
+        return nil, reportError("ioutil is required and must be specified")
+    }
+	
+    if r.http == nil {
+        return nil, reportError("http is required and must be specified")
+    }
+	
+    if r.url == nil {
+        return nil, reportError("url is required and must be specified")
+    }
+	
+    if r.context == nil {
+        return nil, reportError("context is required and must be specified")
+    }
 
-	localVarQueryParams.Add("pipe", parameterToString(pipe, "csv"))
-	localVarQueryParams.Add("ioutil", parameterToString(ioutil, "csv"))
-	localVarQueryParams.Add("http", parameterToString(http, "space"))
-	localVarQueryParams.Add("url", parameterToString(url, "csv"))
-	t:=context
+	localVarQueryParams.Add("pipe", parameterToString(*r.pipe, "csv"))
+	localVarQueryParams.Add("ioutil", parameterToString(*r.ioutil, "csv"))
+	localVarQueryParams.Add("http", parameterToString(*r.http, "space"))
+	localVarQueryParams.Add("url", parameterToString(*r.url, "csv"))
+	t := *r.context
 	if reflect.TypeOf(t).Kind() == reflect.Slice {
 		s := reflect.ValueOf(t)
 		for i := 0; i < s.Len(); i++ {
@@ -1312,12 +1859,12 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -28,15 +28,15 @@ var (
 type FakeApiService service
 
 type apiCreateXmlItemRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    xmlItem *XmlItem
+	ctx _context.Context
+	apiService *FakeApiService
+	xmlItem *XmlItem
 }
 
 
 func (r apiCreateXmlItemRequest) XmlItem(xmlItem XmlItem) apiCreateXmlItemRequest {
-    r.xmlItem = &xmlItem
-    return r
+	r.xmlItem = &xmlItem
+	return r
 }
 
 /*
@@ -46,10 +46,10 @@ this route creates an XmlItem
 @return apiCreateXmlItemRequest
 */
 func (a *FakeApiService) CreateXmlItem(ctx _context.Context) apiCreateXmlItemRequest {
-    return apiCreateXmlItemRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiCreateXmlItemRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -66,25 +66,20 @@ func (r apiCreateXmlItemRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.CreateXmlItem")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.CreateXmlItem")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/create_xml_item"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/create_xml_item"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.xmlItem == nil {
-        return nil, reportError("xmlItem is required and must be specified")
-    }
+	if r.xmlItem == nil {
+		return nil, reportError("xmlItem is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/xml", "application/xml; charset=utf-8", "application/xml; charset=utf-16", "text/xml", "text/xml; charset=utf-8", "text/xml; charset=utf-16"}
@@ -104,7 +99,7 @@ func (r apiCreateXmlItemRequest) Execute() (*_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.xmlItem
+	localVarPostBody = r.xmlItem
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -132,15 +127,15 @@ func (r apiCreateXmlItemRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiFakeOuterBooleanSerializeRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    body *bool
+	ctx _context.Context
+	apiService *FakeApiService
+	body *bool
 }
 
 
 func (r apiFakeOuterBooleanSerializeRequest) Body(body bool) apiFakeOuterBooleanSerializeRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -150,10 +145,10 @@ Test serialization of outer boolean types
 @return apiFakeOuterBooleanSerializeRequest
 */
 func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context) apiFakeOuterBooleanSerializeRequest {
-    return apiFakeOuterBooleanSerializeRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFakeOuterBooleanSerializeRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -170,18 +165,13 @@ func (r apiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response
 		localVarReturnValue  bool
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterBooleanSerialize")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterBooleanSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/boolean"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/boolean"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -204,7 +194,7 @@ func (r apiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -250,15 +240,15 @@ func (r apiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiFakeOuterCompositeSerializeRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    body *OuterComposite
+	ctx _context.Context
+	apiService *FakeApiService
+	body *OuterComposite
 }
 
 
 func (r apiFakeOuterCompositeSerializeRequest) Body(body OuterComposite) apiFakeOuterCompositeSerializeRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -268,10 +258,10 @@ Test serialization of object with outer number type
 @return apiFakeOuterCompositeSerializeRequest
 */
 func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context) apiFakeOuterCompositeSerializeRequest {
-    return apiFakeOuterCompositeSerializeRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFakeOuterCompositeSerializeRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -288,18 +278,13 @@ func (r apiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_neth
 		localVarReturnValue  OuterComposite
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterCompositeSerialize")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterCompositeSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/composite"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/composite"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -322,7 +307,7 @@ func (r apiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_neth
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -368,15 +353,15 @@ func (r apiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_neth
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiFakeOuterNumberSerializeRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    body *float32
+	ctx _context.Context
+	apiService *FakeApiService
+	body *float32
 }
 
 
 func (r apiFakeOuterNumberSerializeRequest) Body(body float32) apiFakeOuterNumberSerializeRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -386,10 +371,10 @@ Test serialization of outer number types
 @return apiFakeOuterNumberSerializeRequest
 */
 func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context) apiFakeOuterNumberSerializeRequest {
-    return apiFakeOuterNumberSerializeRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFakeOuterNumberSerializeRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -406,18 +391,13 @@ func (r apiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Respon
 		localVarReturnValue  float32
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterNumberSerialize")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterNumberSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/number"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/number"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -440,7 +420,7 @@ func (r apiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Respon
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -486,15 +466,15 @@ func (r apiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Respon
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiFakeOuterStringSerializeRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    body *string
+	ctx _context.Context
+	apiService *FakeApiService
+	body *string
 }
 
 
 func (r apiFakeOuterStringSerializeRequest) Body(body string) apiFakeOuterStringSerializeRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -504,10 +484,10 @@ Test serialization of outer string types
 @return apiFakeOuterStringSerializeRequest
 */
 func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context) apiFakeOuterStringSerializeRequest {
-    return apiFakeOuterStringSerializeRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFakeOuterStringSerializeRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -524,18 +504,13 @@ func (r apiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Respons
 		localVarReturnValue  string
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterStringSerialize")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterStringSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/string"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/string"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -558,7 +533,7 @@ func (r apiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Respons
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -604,15 +579,15 @@ func (r apiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Respons
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiTestBodyWithFileSchemaRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    body *FileSchemaTestClass
+	ctx _context.Context
+	apiService *FakeApiService
+	body *FileSchemaTestClass
 }
 
 
 func (r apiTestBodyWithFileSchemaRequest) Body(body FileSchemaTestClass) apiTestBodyWithFileSchemaRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -622,10 +597,10 @@ For this test, the body for this request much reference a schema named `File`.
 @return apiTestBodyWithFileSchemaRequest
 */
 func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context) apiTestBodyWithFileSchemaRequest {
-    return apiTestBodyWithFileSchemaRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestBodyWithFileSchemaRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -642,25 +617,20 @@ func (r apiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) 
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithFileSchema")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithFileSchema")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-file-schema"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/body-with-file-schema"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.body == nil {
-        return nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -680,7 +650,7 @@ func (r apiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) 
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -708,21 +678,21 @@ func (r apiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) 
 	return localVarHTTPResponse, nil
 }
 type apiTestBodyWithQueryParamsRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    query *string
-    body *User
+	ctx _context.Context
+	apiService *FakeApiService
+	query *string
+	body *User
 }
 
 
 func (r apiTestBodyWithQueryParamsRequest) Query(query string) apiTestBodyWithQueryParamsRequest {
-    r.query = &query
-    return r
+	r.query = &query
+	return r
 }
 
 func (r apiTestBodyWithQueryParamsRequest) Body(body User) apiTestBodyWithQueryParamsRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -731,10 +701,10 @@ TestBodyWithQueryParams Method for TestBodyWithQueryParams
 @return apiTestBodyWithQueryParamsRequest
 */
 func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context) apiTestBodyWithQueryParamsRequest {
-    return apiTestBodyWithQueryParamsRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestBodyWithQueryParamsRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -751,29 +721,24 @@ func (r apiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error)
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithQueryParams")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithQueryParams")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-query-params"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/body-with-query-params"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.query == nil {
-        return nil, reportError("query is required and must be specified")
-    }
+	if r.query == nil {
+		return nil, reportError("query is required and must be specified")
+	}
 	
-    if r.body == nil {
-        return nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return nil, reportError("body is required and must be specified")
+	}
 
 	localVarQueryParams.Add("query", parameterToString(*r.query, ""))
 	// to determine the Content-Type header
@@ -794,7 +759,7 @@ func (r apiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error)
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -822,15 +787,15 @@ func (r apiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error)
 	return localVarHTTPResponse, nil
 }
 type apiTestClientModelRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    body *Client
+	ctx _context.Context
+	apiService *FakeApiService
+	body *Client
 }
 
 
 func (r apiTestClientModelRequest) Body(body Client) apiTestClientModelRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -840,10 +805,10 @@ To test "client" model
 @return apiTestClientModelRequest
 */
 func (a *FakeApiService) TestClientModel(ctx _context.Context) apiTestClientModelRequest {
-    return apiTestClientModelRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestClientModelRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -860,25 +825,20 @@ func (r apiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error)
 		localVarReturnValue  Client
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestClientModel")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestClientModel")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.body == nil {
-        return localVarReturnValue, nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -898,7 +858,7 @@ func (r apiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error)
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -944,93 +904,93 @@ func (r apiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error)
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiTestEndpointParametersRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    number *float32
-    double *float64
-    patternWithoutDelimiter *string
-    byte_ *string
-    integer *int32
-    int32_ *int32
-    int64_ *int64
-    float *float32
-    string_ *string
-    binary **os.File
-    date *string
-    dateTime *time.Time
-    password *string
-    callback *string
+	ctx _context.Context
+	apiService *FakeApiService
+	number *float32
+	double *float64
+	patternWithoutDelimiter *string
+	byte_ *string
+	integer *int32
+	int32_ *int32
+	int64_ *int64
+	float *float32
+	string_ *string
+	binary **os.File
+	date *string
+	dateTime *time.Time
+	password *string
+	callback *string
 }
 
 
 func (r apiTestEndpointParametersRequest) Number(number float32) apiTestEndpointParametersRequest {
-    r.number = &number
-    return r
+	r.number = &number
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Double(double float64) apiTestEndpointParametersRequest {
-    r.double = &double
-    return r
+	r.double = &double
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithoutDelimiter string) apiTestEndpointParametersRequest {
-    r.patternWithoutDelimiter = &patternWithoutDelimiter
-    return r
+	r.patternWithoutDelimiter = &patternWithoutDelimiter
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Byte_(byte_ string) apiTestEndpointParametersRequest {
-    r.byte_ = &byte_
-    return r
+	r.byte_ = &byte_
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Integer(integer int32) apiTestEndpointParametersRequest {
-    r.integer = &integer
-    return r
+	r.integer = &integer
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Int32_(int32_ int32) apiTestEndpointParametersRequest {
-    r.int32_ = &int32_
-    return r
+	r.int32_ = &int32_
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Int64_(int64_ int64) apiTestEndpointParametersRequest {
-    r.int64_ = &int64_
-    return r
+	r.int64_ = &int64_
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Float(float float32) apiTestEndpointParametersRequest {
-    r.float = &float
-    return r
+	r.float = &float
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) String_(string_ string) apiTestEndpointParametersRequest {
-    r.string_ = &string_
-    return r
+	r.string_ = &string_
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Binary(binary *os.File) apiTestEndpointParametersRequest {
-    r.binary = &binary
-    return r
+	r.binary = &binary
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Date(date string) apiTestEndpointParametersRequest {
-    r.date = &date
-    return r
+	r.date = &date
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) DateTime(dateTime time.Time) apiTestEndpointParametersRequest {
-    r.dateTime = &dateTime
-    return r
+	r.dateTime = &dateTime
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Password(password string) apiTestEndpointParametersRequest {
-    r.password = &password
-    return r
+	r.password = &password
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Callback(callback string) apiTestEndpointParametersRequest {
-    r.callback = &callback
-    return r
+	r.callback = &callback
+	return r
 }
 
 /*
@@ -1049,10 +1009,10 @@ Fake endpoint for testing various parameters
 @return apiTestEndpointParametersRequest
 */
 func (a *FakeApiService) TestEndpointParameters(ctx _context.Context) apiTestEndpointParametersRequest {
-    return apiTestEndpointParametersRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestEndpointParametersRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1069,25 +1029,20 @@ func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) 
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEndpointParameters")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEndpointParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.number == nil {
-        return nil, reportError("number is required and must be specified")
-    }
+	if r.number == nil {
+		return nil, reportError("number is required and must be specified")
+	}
 	if *r.number < 32.1 {
 		return nil, reportError("number must be greater than 32.1")
 	}
@@ -1095,9 +1050,9 @@ func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) 
 		return nil, reportError("number must be less than 543.2")
 	}
 	
-    if r.double == nil {
-        return nil, reportError("double is required and must be specified")
-    }
+	if r.double == nil {
+		return nil, reportError("double is required and must be specified")
+	}
 	if *r.double < 67.8 {
 		return nil, reportError("double must be greater than 67.8")
 	}
@@ -1105,13 +1060,13 @@ func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) 
 		return nil, reportError("double must be less than 123.4")
 	}
 	
-    if r.patternWithoutDelimiter == nil {
-        return nil, reportError("patternWithoutDelimiter is required and must be specified")
-    }
+	if r.patternWithoutDelimiter == nil {
+		return nil, reportError("patternWithoutDelimiter is required and must be specified")
+	}
 	
-    if r.byte_ == nil {
-        return nil, reportError("byte_ is required and must be specified")
-    }
+	if r.byte_ == nil {
+		return nil, reportError("byte_ is required and must be specified")
+	}
 										
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -1199,57 +1154,57 @@ func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) 
 	return localVarHTTPResponse, nil
 }
 type apiTestEnumParametersRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    enumHeaderStringArray *[]string
-    enumHeaderString *string
-    enumQueryStringArray *[]string
-    enumQueryString *string
-    enumQueryInteger *int32
-    enumQueryDouble *float64
-    enumFormStringArray *[]string
-    enumFormString *string
+	ctx _context.Context
+	apiService *FakeApiService
+	enumHeaderStringArray *[]string
+	enumHeaderString *string
+	enumQueryStringArray *[]string
+	enumQueryString *string
+	enumQueryInteger *int32
+	enumQueryDouble *float64
+	enumFormStringArray *[]string
+	enumFormString *string
 }
 
 
 func (r apiTestEnumParametersRequest) EnumHeaderStringArray(enumHeaderStringArray []string) apiTestEnumParametersRequest {
-    r.enumHeaderStringArray = &enumHeaderStringArray
-    return r
+	r.enumHeaderStringArray = &enumHeaderStringArray
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumHeaderString(enumHeaderString string) apiTestEnumParametersRequest {
-    r.enumHeaderString = &enumHeaderString
-    return r
+	r.enumHeaderString = &enumHeaderString
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumQueryStringArray(enumQueryStringArray []string) apiTestEnumParametersRequest {
-    r.enumQueryStringArray = &enumQueryStringArray
-    return r
+	r.enumQueryStringArray = &enumQueryStringArray
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumQueryString(enumQueryString string) apiTestEnumParametersRequest {
-    r.enumQueryString = &enumQueryString
-    return r
+	r.enumQueryString = &enumQueryString
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumQueryInteger(enumQueryInteger int32) apiTestEnumParametersRequest {
-    r.enumQueryInteger = &enumQueryInteger
-    return r
+	r.enumQueryInteger = &enumQueryInteger
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumQueryDouble(enumQueryDouble float64) apiTestEnumParametersRequest {
-    r.enumQueryDouble = &enumQueryDouble
-    return r
+	r.enumQueryDouble = &enumQueryDouble
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumFormStringArray(enumFormStringArray []string) apiTestEnumParametersRequest {
-    r.enumFormStringArray = &enumFormStringArray
-    return r
+	r.enumFormStringArray = &enumFormStringArray
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumFormString(enumFormString string) apiTestEnumParametersRequest {
-    r.enumFormString = &enumFormString
-    return r
+	r.enumFormString = &enumFormString
+	return r
 }
 
 /*
@@ -1259,10 +1214,10 @@ To test enum parameters
 @return apiTestEnumParametersRequest
 */
 func (a *FakeApiService) TestEnumParameters(ctx _context.Context) apiTestEnumParametersRequest {
-    return apiTestEnumParametersRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestEnumParametersRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1279,18 +1234,13 @@ func (r apiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEnumParameters")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEnumParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1363,45 +1313,45 @@ func (r apiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiTestGroupParametersRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    requiredStringGroup *int32
-    requiredBooleanGroup *bool
-    requiredInt64Group *int64
-    stringGroup *int32
-    booleanGroup *bool
-    int64Group *int64
+	ctx _context.Context
+	apiService *FakeApiService
+	requiredStringGroup *int32
+	requiredBooleanGroup *bool
+	requiredInt64Group *int64
+	stringGroup *int32
+	booleanGroup *bool
+	int64Group *int64
 }
 
 
 func (r apiTestGroupParametersRequest) RequiredStringGroup(requiredStringGroup int32) apiTestGroupParametersRequest {
-    r.requiredStringGroup = &requiredStringGroup
-    return r
+	r.requiredStringGroup = &requiredStringGroup
+	return r
 }
 
 func (r apiTestGroupParametersRequest) RequiredBooleanGroup(requiredBooleanGroup bool) apiTestGroupParametersRequest {
-    r.requiredBooleanGroup = &requiredBooleanGroup
-    return r
+	r.requiredBooleanGroup = &requiredBooleanGroup
+	return r
 }
 
 func (r apiTestGroupParametersRequest) RequiredInt64Group(requiredInt64Group int64) apiTestGroupParametersRequest {
-    r.requiredInt64Group = &requiredInt64Group
-    return r
+	r.requiredInt64Group = &requiredInt64Group
+	return r
 }
 
 func (r apiTestGroupParametersRequest) StringGroup(stringGroup int32) apiTestGroupParametersRequest {
-    r.stringGroup = &stringGroup
-    return r
+	r.stringGroup = &stringGroup
+	return r
 }
 
 func (r apiTestGroupParametersRequest) BooleanGroup(booleanGroup bool) apiTestGroupParametersRequest {
-    r.booleanGroup = &booleanGroup
-    return r
+	r.booleanGroup = &booleanGroup
+	return r
 }
 
 func (r apiTestGroupParametersRequest) Int64Group(int64Group int64) apiTestGroupParametersRequest {
-    r.int64Group = &int64Group
-    return r
+	r.int64Group = &int64Group
+	return r
 }
 
 /*
@@ -1411,10 +1361,10 @@ Fake endpoint to test group parameters (optional)
 @return apiTestGroupParametersRequest
 */
 func (a *FakeApiService) TestGroupParameters(ctx _context.Context) apiTestGroupParametersRequest {
-    return apiTestGroupParametersRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestGroupParametersRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1431,33 +1381,28 @@ func (r apiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestGroupParameters")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestGroupParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.requiredStringGroup == nil {
-        return nil, reportError("requiredStringGroup is required and must be specified")
-    }
+	if r.requiredStringGroup == nil {
+		return nil, reportError("requiredStringGroup is required and must be specified")
+	}
 	
-    if r.requiredBooleanGroup == nil {
-        return nil, reportError("requiredBooleanGroup is required and must be specified")
-    }
+	if r.requiredBooleanGroup == nil {
+		return nil, reportError("requiredBooleanGroup is required and must be specified")
+	}
 	
-    if r.requiredInt64Group == nil {
-        return nil, reportError("requiredInt64Group is required and must be specified")
-    }
+	if r.requiredInt64Group == nil {
+		return nil, reportError("requiredInt64Group is required and must be specified")
+	}
 			
 	localVarQueryParams.Add("required_string_group", parameterToString(*r.requiredStringGroup, ""))
 	localVarQueryParams.Add("required_int64_group", parameterToString(*r.requiredInt64Group, ""))
@@ -1515,15 +1460,15 @@ func (r apiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiTestInlineAdditionalPropertiesRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    param *map[string]string
+	ctx _context.Context
+	apiService *FakeApiService
+	param *map[string]string
 }
 
 
 func (r apiTestInlineAdditionalPropertiesRequest) Param(param map[string]string) apiTestInlineAdditionalPropertiesRequest {
-    r.param = &param
-    return r
+	r.param = &param
+	return r
 }
 
 /*
@@ -1532,10 +1477,10 @@ TestInlineAdditionalProperties test inline additionalProperties
 @return apiTestInlineAdditionalPropertiesRequest
 */
 func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context) apiTestInlineAdditionalPropertiesRequest {
-    return apiTestInlineAdditionalPropertiesRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestInlineAdditionalPropertiesRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1552,25 +1497,20 @@ func (r apiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response,
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestInlineAdditionalProperties")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestInlineAdditionalProperties")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/inline-additionalProperties"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/inline-additionalProperties"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.param == nil {
-        return nil, reportError("param is required and must be specified")
-    }
+	if r.param == nil {
+		return nil, reportError("param is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -1590,7 +1530,7 @@ func (r apiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response,
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.param
+	localVarPostBody = r.param
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -1618,21 +1558,21 @@ func (r apiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response,
 	return localVarHTTPResponse, nil
 }
 type apiTestJsonFormDataRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    param *string
-    param2 *string
+	ctx _context.Context
+	apiService *FakeApiService
+	param *string
+	param2 *string
 }
 
 
 func (r apiTestJsonFormDataRequest) Param(param string) apiTestJsonFormDataRequest {
-    r.param = &param
-    return r
+	r.param = &param
+	return r
 }
 
 func (r apiTestJsonFormDataRequest) Param2(param2 string) apiTestJsonFormDataRequest {
-    r.param2 = &param2
-    return r
+	r.param2 = &param2
+	return r
 }
 
 /*
@@ -1641,10 +1581,10 @@ TestJsonFormData test json serialization of form data
 @return apiTestJsonFormDataRequest
 */
 func (a *FakeApiService) TestJsonFormData(ctx _context.Context) apiTestJsonFormDataRequest {
-    return apiTestJsonFormDataRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestJsonFormDataRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1661,29 +1601,24 @@ func (r apiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestJsonFormData")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestJsonFormData")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/jsonFormData"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/jsonFormData"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.param == nil {
-        return nil, reportError("param is required and must be specified")
-    }
+	if r.param == nil {
+		return nil, reportError("param is required and must be specified")
+	}
 	
-    if r.param2 == nil {
-        return nil, reportError("param2 is required and must be specified")
-    }
+	if r.param2 == nil {
+		return nil, reportError("param2 is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -1731,39 +1666,39 @@ func (r apiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiTestQueryParameterCollectionFormatRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    pipe *[]string
-    ioutil *[]string
-    http *[]string
-    url *[]string
-    context *[]string
+	ctx _context.Context
+	apiService *FakeApiService
+	pipe *[]string
+	ioutil *[]string
+	http *[]string
+	url *[]string
+	context *[]string
 }
 
 
 func (r apiTestQueryParameterCollectionFormatRequest) Pipe(pipe []string) apiTestQueryParameterCollectionFormatRequest {
-    r.pipe = &pipe
-    return r
+	r.pipe = &pipe
+	return r
 }
 
 func (r apiTestQueryParameterCollectionFormatRequest) Ioutil(ioutil []string) apiTestQueryParameterCollectionFormatRequest {
-    r.ioutil = &ioutil
-    return r
+	r.ioutil = &ioutil
+	return r
 }
 
 func (r apiTestQueryParameterCollectionFormatRequest) Http(http []string) apiTestQueryParameterCollectionFormatRequest {
-    r.http = &http
-    return r
+	r.http = &http
+	return r
 }
 
 func (r apiTestQueryParameterCollectionFormatRequest) Url(url []string) apiTestQueryParameterCollectionFormatRequest {
-    r.url = &url
-    return r
+	r.url = &url
+	return r
 }
 
 func (r apiTestQueryParameterCollectionFormatRequest) Context(context []string) apiTestQueryParameterCollectionFormatRequest {
-    r.context = &context
-    return r
+	r.context = &context
+	return r
 }
 
 /*
@@ -1773,10 +1708,10 @@ To test the collection format in query parameters
 @return apiTestQueryParameterCollectionFormatRequest
 */
 func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context) apiTestQueryParameterCollectionFormatRequest {
-    return apiTestQueryParameterCollectionFormatRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestQueryParameterCollectionFormatRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1793,41 +1728,36 @@ func (r apiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Respo
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestQueryParameterCollectionFormat")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestQueryParameterCollectionFormat")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/test-query-paramters"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/test-query-paramters"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.pipe == nil {
-        return nil, reportError("pipe is required and must be specified")
-    }
+	if r.pipe == nil {
+		return nil, reportError("pipe is required and must be specified")
+	}
 	
-    if r.ioutil == nil {
-        return nil, reportError("ioutil is required and must be specified")
-    }
+	if r.ioutil == nil {
+		return nil, reportError("ioutil is required and must be specified")
+	}
 	
-    if r.http == nil {
-        return nil, reportError("http is required and must be specified")
-    }
+	if r.http == nil {
+		return nil, reportError("http is required and must be specified")
+	}
 	
-    if r.url == nil {
-        return nil, reportError("url is required and must be specified")
-    }
+	if r.url == nil {
+		return nil, reportError("url is required and must be specified")
+	}
 	
-    if r.context == nil {
-        return nil, reportError("context is required and must be specified")
-    }
+	if r.context == nil {
+		return nil, reportError("context is required and must be specified")
+	}
 
 	localVarQueryParams.Add("pipe", parameterToString(*r.pipe, "csv"))
 	localVarQueryParams.Add("ioutil", parameterToString(*r.ioutil, "csv"))

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -994,17 +994,11 @@ func (r apiTestEndpointParametersRequest) Callback(callback string) apiTestEndpo
 }
 
 /*
-<<<<<<< HEAD
 TestEndpointParameters Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-=======
-TestEndpointParameters Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 Fake endpoint for testing various parameters
-假端點
-偽のエンドポイント
-가짜 엔드 포인트
-
->>>>>>> [go-experimental] Use builder pattern for requests
+ 假端點
+ 偽のエンドポイント
+ 가짜 엔드 포인트
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 @return apiTestEndpointParametersRequest
 */

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -25,15 +25,15 @@ var (
 type FakeClassnameTags123ApiService service
 
 type apiTestClassnameRequest struct {
-    ctx _context.Context
-    apiService *FakeClassnameTags123ApiService
-    body *Client
+	ctx _context.Context
+	apiService *FakeClassnameTags123ApiService
+	body *Client
 }
 
 
 func (r apiTestClassnameRequest) Body(body Client) apiTestClassnameRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -43,10 +43,10 @@ To test class name in snake case
 @return apiTestClassnameRequest
 */
 func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context) apiTestClassnameRequest {
-    return apiTestClassnameRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestClassnameRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -63,25 +63,20 @@ func (r apiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 		localVarReturnValue  Client
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeClassnameTags123ApiService.TestClassname")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeClassnameTags123ApiService.TestClassname")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake_classname_test"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake_classname_test"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.body == nil {
-        return localVarReturnValue, nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -101,7 +96,7 @@ func (r apiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	if r.ctx != nil {
 		// API Key Authentication
 		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {

--- a/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -24,14 +24,36 @@ var (
 // FakeClassnameTags123ApiService FakeClassnameTags123Api service
 type FakeClassnameTags123ApiService service
 
+type apiTestClassnameRequest struct {
+    ctx _context.Context
+    apiService *FakeClassnameTags123ApiService
+    body *Client
+}
+
+
+func (r apiTestClassnameRequest) Body(body Client) apiTestClassnameRequest {
+    r.body = &body
+    return r
+}
+
 /*
 TestClassname To test class name in snake case
 To test class name in snake case
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body client model
-@return Client
+@return apiTestClassnameRequest
 */
-func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, body Client) (Client, *_nethttp.Response, error) {
+func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context) apiTestClassnameRequest {
+    return apiTestClassnameRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return Client
+*/
+func (r apiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -41,6 +63,7 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 		localVarReturnValue  Client
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeClassnameTags123ApiService.TestClassname")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -48,9 +71,17 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 
 	localVarPath := localBasePath + "/fake_classname_test"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake_classname_test"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.body == nil {
+        return localVarReturnValue, nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -70,10 +101,10 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	if ctx != nil {
+	localVarPostBody = *r.body
+	if r.ctx != nil {
 		// API Key Authentication
-		if auth, ok := ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
 			if auth, ok := auth["api_key_query"]; ok {
 				var key string
 				if auth.Prefix != "" {
@@ -85,12 +116,12 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 			}
 		}
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -108,7 +139,7 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Client
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -118,7 +149,7 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, bod
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/samples/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -15,7 +15,6 @@ import (
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
-	"github.com/antihax/optional"
 	"os"
 )
 
@@ -27,20 +26,45 @@ var (
 // PetApiService PetApi service
 type PetApiService service
 
+type apiAddPetRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    body *Pet
+}
+
+
+func (r apiAddPetRequest) Body(body Pet) apiAddPetRequest {
+    r.body = &body
+    return r
+}
+
 /*
 AddPet Add a new pet to the store
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body Pet object that needs to be added to the store
+@return apiAddPetRequest
 */
-func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Response, error) {
+func (a *PetApiService) AddPet(ctx _context.Context) apiAddPetRequest {
+    return apiAddPetRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiAddPetRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.AddPet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -48,9 +72,17 @@ func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Respon
 
 	localVarPath := localBasePath + "/pet"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.body == nil {
+        return nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json", "application/xml"}
@@ -70,13 +102,13 @@ func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Respon
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -97,28 +129,48 @@ func (a *PetApiService) AddPet(ctx _context.Context, body Pet) (*_nethttp.Respon
 
 	return localVarHTTPResponse, nil
 }
+type apiDeletePetRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    petId int64
+    apiKey *string
+}
 
-// DeletePetOpts Optional parameters for the method 'DeletePet'
-type DeletePetOpts struct {
-    ApiKey optional.String
+
+func (r apiDeletePetRequest) ApiKey(apiKey string) apiDeletePetRequest {
+    r.apiKey = &apiKey
+    return r
 }
 
 /*
 DeletePet Deletes a pet
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param petId Pet id to delete
- * @param optional nil or *DeletePetOpts - Optional Parameters:
- * @param "ApiKey" (optional.String) - 
+@return apiDeletePetRequest
 */
-func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOptionals *DeletePetOpts) (*_nethttp.Response, error) {
+func (a *PetApiService) DeletePet(ctx _context.Context, petId int64) apiDeletePetRequest {
+    return apiDeletePetRequest{
+        apiService: a,
+        ctx: ctx,
+        petId: petId,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.DeletePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -126,11 +178,17 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 
 	localVarPath := localBasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -148,15 +206,15 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.ApiKey.IsSet() {
-		localVarHeaderParams["api_key"] = parameterToString(localVarOptionals.ApiKey.Value(), "")
+	if r.apiKey != nil {
+		localVarHeaderParams["api_key"] = parameterToString(*r.apiKey, "")
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -177,15 +235,36 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 
 	return localVarHTTPResponse, nil
 }
+type apiFindPetsByStatusRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    status *[]string
+}
+
+
+func (r apiFindPetsByStatusRequest) Status(status []string) apiFindPetsByStatusRequest {
+    r.status = &status
+    return r
+}
 
 /*
 FindPetsByStatus Finds Pets by status
 Multiple status values can be provided with comma separated strings
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param status Status values that need to be considered for filter
-@return []Pet
+@return apiFindPetsByStatusRequest
 */
-func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) ([]Pet, *_nethttp.Response, error) {
+func (a *PetApiService) FindPetsByStatus(ctx _context.Context) apiFindPetsByStatusRequest {
+    return apiFindPetsByStatusRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return []Pet
+*/
+func (r apiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -195,6 +274,7 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 		localVarReturnValue  []Pet
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByStatus")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -202,11 +282,19 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 
 	localVarPath := localBasePath + "/pet/findByStatus"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/findByStatus"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.status == nil {
+        return localVarReturnValue, nil, reportError("status is required and must be specified")
+    }
 
-	localVarQueryParams.Add("status", parameterToString(status, "csv"))
+	localVarQueryParams.Add("status", parameterToString(*r.status, "csv"))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -224,12 +312,12 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -247,7 +335,7 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v []Pet
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -258,7 +346,7 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -269,15 +357,36 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiFindPetsByTagsRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    tags *[]string
+}
+
+
+func (r apiFindPetsByTagsRequest) Tags(tags []string) apiFindPetsByTagsRequest {
+    r.tags = &tags
+    return r
+}
 
 /*
 FindPetsByTags Finds Pets by tags
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param tags Tags to filter by
-@return []Pet
+@return apiFindPetsByTagsRequest
 */
-func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]Pet, *_nethttp.Response, error) {
+func (a *PetApiService) FindPetsByTags(ctx _context.Context) apiFindPetsByTagsRequest {
+    return apiFindPetsByTagsRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return []Pet
+*/
+func (r apiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -287,6 +396,7 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 		localVarReturnValue  []Pet
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -294,11 +404,19 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 
 	localVarPath := localBasePath + "/pet/findByTags"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/findByTags"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.tags == nil {
+        return localVarReturnValue, nil, reportError("tags is required and must be specified")
+    }
 
-	localVarQueryParams.Add("tags", parameterToString(tags, "csv"))
+	localVarQueryParams.Add("tags", parameterToString(*r.tags, "csv"))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -316,12 +434,12 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -339,7 +457,7 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v []Pet
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -350,7 +468,7 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -361,15 +479,33 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiGetPetByIdRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    petId int64
+}
+
 
 /*
 GetPetById Find pet by ID
 Returns a single pet
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param petId ID of pet to return
-@return Pet
+@return apiGetPetByIdRequest
 */
-func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_nethttp.Response, error) {
+func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) apiGetPetByIdRequest {
+    return apiGetPetByIdRequest{
+        apiService: a,
+        ctx: ctx,
+        petId: petId,
+    }
+}
+
+/*
+Execute executes the request
+ @return Pet
+*/
+func (r apiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -379,6 +515,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 		localVarReturnValue  Pet
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.GetPetById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -386,10 +523,16 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 
 	localVarPath := localBasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -408,9 +551,9 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if ctx != nil {
+	if r.ctx != nil {
 		// API Key Authentication
-		if auth, ok := ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
 			if auth, ok := auth["api_key"]; ok {
 				var key string
 				if auth.Prefix != "" {
@@ -422,12 +565,12 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 			}
 		}
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -445,7 +588,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Pet
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -456,7 +599,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -467,21 +610,45 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiUpdatePetRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    body *Pet
+}
+
+
+func (r apiUpdatePetRequest) Body(body Pet) apiUpdatePetRequest {
+    r.body = &body
+    return r
+}
 
 /*
 UpdatePet Update an existing pet
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body Pet object that needs to be added to the store
+@return apiUpdatePetRequest
 */
-func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Response, error) {
+func (a *PetApiService) UpdatePet(ctx _context.Context) apiUpdatePetRequest {
+    return apiUpdatePetRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -489,9 +656,17 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Res
 
 	localVarPath := localBasePath + "/pet"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.body == nil {
+        return nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json", "application/xml"}
@@ -511,13 +686,13 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Res
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -538,30 +713,54 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, body Pet) (*_nethttp.Res
 
 	return localVarHTTPResponse, nil
 }
+type apiUpdatePetWithFormRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    petId int64
+    name *string
+    status *string
+}
 
-// UpdatePetWithFormOpts Optional parameters for the method 'UpdatePetWithForm'
-type UpdatePetWithFormOpts struct {
-    Name optional.String
-    Status optional.String
+
+func (r apiUpdatePetWithFormRequest) Name(name string) apiUpdatePetWithFormRequest {
+    r.name = &name
+    return r
+}
+
+func (r apiUpdatePetWithFormRequest) Status(status string) apiUpdatePetWithFormRequest {
+    r.status = &status
+    return r
 }
 
 /*
 UpdatePetWithForm Updates a pet in the store with form data
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param petId ID of pet that needs to be updated
- * @param optional nil or *UpdatePetWithFormOpts - Optional Parameters:
- * @param "Name" (optional.String) -  Updated name of the pet
- * @param "Status" (optional.String) -  Updated status of the pet
+@return apiUpdatePetWithFormRequest
 */
-func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, localVarOptionals *UpdatePetWithFormOpts) (*_nethttp.Response, error) {
+func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64) apiUpdatePetWithFormRequest {
+    return apiUpdatePetWithFormRequest{
+        apiService: a,
+        ctx: ctx,
+        petId: petId,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePetWithForm")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -569,11 +768,17 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 
 	localVarPath := localBasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
+		
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
 
@@ -591,18 +796,18 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.Name.IsSet() {
-		localVarFormParams.Add("name", parameterToString(localVarOptionals.Name.Value(), ""))
+	if r.name != nil {
+		localVarFormParams.Add("name", parameterToString(*r.name, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Status.IsSet() {
-		localVarFormParams.Add("status", parameterToString(localVarOptionals.Status.Value(), ""))
+	if r.status != nil {
+		localVarFormParams.Add("status", parameterToString(*r.status, ""))
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -623,23 +828,44 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 
 	return localVarHTTPResponse, nil
 }
+type apiUploadFileRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    petId int64
+    additionalMetadata *string
+    file **os.File
+}
 
-// UploadFileOpts Optional parameters for the method 'UploadFile'
-type UploadFileOpts struct {
-    AdditionalMetadata optional.String
-    File optional.Interface
+
+func (r apiUploadFileRequest) AdditionalMetadata(additionalMetadata string) apiUploadFileRequest {
+    r.additionalMetadata = &additionalMetadata
+    return r
+}
+
+func (r apiUploadFileRequest) File(file *os.File) apiUploadFileRequest {
+    r.file = &file
+    return r
 }
 
 /*
 UploadFile uploads an image
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param petId ID of pet to update
- * @param optional nil or *UploadFileOpts - Optional Parameters:
- * @param "AdditionalMetadata" (optional.String) -  Additional data to pass to server
- * @param "File" (optional.Interface of *os.File) -  file to upload
-@return ApiResponse
+@return apiUploadFileRequest
 */
-func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOptionals *UploadFileOpts) (ApiResponse, *_nethttp.Response, error) {
+func (a *PetApiService) UploadFile(ctx _context.Context, petId int64) apiUploadFileRequest {
+    return apiUploadFileRequest{
+        apiService: a,
+        ctx: ctx,
+        petId: petId,
+    }
+}
+
+/*
+Execute executes the request
+ @return ApiResponse
+*/
+func (r apiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -649,6 +875,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		localVarReturnValue  ApiResponse
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -656,11 +883,17 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 
 	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}/uploadImage"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
+		
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"multipart/form-data"}
 
@@ -678,17 +911,13 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.AdditionalMetadata.IsSet() {
-		localVarFormParams.Add("additionalMetadata", parameterToString(localVarOptionals.AdditionalMetadata.Value(), ""))
+	if r.additionalMetadata != nil {
+		localVarFormParams.Add("additionalMetadata", parameterToString(*r.additionalMetadata, ""))
 	}
 	localVarFormFileName = "file"
 	var localVarFile *os.File
-	if localVarOptionals != nil && localVarOptionals.File.IsSet() {
-		localVarFileOk := false
-		localVarFile, localVarFileOk = localVarOptionals.File.Value().(*os.File)
-		if !localVarFileOk {
-				return localVarReturnValue, nil, reportError("file should be *os.File")
-		}
+	if r.file != nil {
+		localVarFile = *r.file
 	}
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
@@ -696,12 +925,12 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		localVarFileName = localVarFile.Name()
 		localVarFile.Close()
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -719,7 +948,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v ApiResponse
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -729,7 +958,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -740,22 +969,44 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiUploadFileWithRequiredFileRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    petId int64
+    requiredFile **os.File
+    additionalMetadata *string
+}
 
-// UploadFileWithRequiredFileOpts Optional parameters for the method 'UploadFileWithRequiredFile'
-type UploadFileWithRequiredFileOpts struct {
-    AdditionalMetadata optional.String
+
+func (r apiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) apiUploadFileWithRequiredFileRequest {
+    r.requiredFile = &requiredFile
+    return r
+}
+
+func (r apiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetadata string) apiUploadFileWithRequiredFileRequest {
+    r.additionalMetadata = &additionalMetadata
+    return r
 }
 
 /*
 UploadFileWithRequiredFile uploads an image (required)
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param petId ID of pet to update
- * @param requiredFile file to upload
- * @param optional nil or *UploadFileWithRequiredFileOpts - Optional Parameters:
- * @param "AdditionalMetadata" (optional.String) -  Additional data to pass to server
-@return ApiResponse
+@return apiUploadFileWithRequiredFileRequest
 */
-func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId int64, requiredFile *os.File, localVarOptionals *UploadFileWithRequiredFileOpts) (ApiResponse, *_nethttp.Response, error) {
+func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId int64) apiUploadFileWithRequiredFileRequest {
+    return apiUploadFileWithRequiredFileRequest{
+        apiService: a,
+        ctx: ctx,
+        petId: petId,
+    }
+}
+
+/*
+Execute executes the request
+ @return ApiResponse
+*/
+func (r apiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -765,6 +1016,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 		localVarReturnValue  ApiResponse
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFileWithRequiredFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -772,11 +1024,21 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 
 	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/{petId}/uploadImageWithRequiredFile"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
+	
+    if r.requiredFile == nil {
+        return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
+    }
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"multipart/form-data"}
 
@@ -794,23 +1056,23 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.AdditionalMetadata.IsSet() {
-		localVarFormParams.Add("additionalMetadata", parameterToString(localVarOptionals.AdditionalMetadata.Value(), ""))
+	if r.additionalMetadata != nil {
+		localVarFormParams.Add("additionalMetadata", parameterToString(*r.additionalMetadata, ""))
 	}
 	localVarFormFileName = "requiredFile"
-	localVarFile := requiredFile
+	localVarFile := *r.requiredFile
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
 		localVarFileBytes = fbs
 		localVarFileName = localVarFile.Name()
 		localVarFile.Close()
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -828,7 +1090,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v ApiResponse
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -838,7 +1100,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/samples/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -27,15 +27,15 @@ var (
 type PetApiService service
 
 type apiAddPetRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    body *Pet
+	ctx _context.Context
+	apiService *PetApiService
+	body *Pet
 }
 
 
 func (r apiAddPetRequest) Body(body Pet) apiAddPetRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -44,10 +44,10 @@ AddPet Add a new pet to the store
 @return apiAddPetRequest
 */
 func (a *PetApiService) AddPet(ctx _context.Context) apiAddPetRequest {
-    return apiAddPetRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiAddPetRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -64,25 +64,20 @@ func (r apiAddPetRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.AddPet")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.AddPet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.body == nil {
-        return nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json", "application/xml"}
@@ -102,7 +97,7 @@ func (r apiAddPetRequest) Execute() (*_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -130,16 +125,16 @@ func (r apiAddPetRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiDeletePetRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    petId int64
-    apiKey *string
+	ctx _context.Context
+	apiService *PetApiService
+	petId int64
+	apiKey *string
 }
 
 
 func (r apiDeletePetRequest) ApiKey(apiKey string) apiDeletePetRequest {
-    r.apiKey = &apiKey
-    return r
+	r.apiKey = &apiKey
+	return r
 }
 
 /*
@@ -149,11 +144,11 @@ DeletePet Deletes a pet
 @return apiDeletePetRequest
 */
 func (a *PetApiService) DeletePet(ctx _context.Context, petId int64) apiDeletePetRequest {
-    return apiDeletePetRequest{
-        apiService: a,
-        ctx: ctx,
-        petId: petId,
-    }
+	return apiDeletePetRequest{
+		apiService: a,
+		ctx: ctx,
+		petId: petId,
+	}
 }
 
 /*
@@ -170,19 +165,13 @@ func (r apiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.DeletePet")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.DeletePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -236,15 +225,15 @@ func (r apiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiFindPetsByStatusRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    status *[]string
+	ctx _context.Context
+	apiService *PetApiService
+	status *[]string
 }
 
 
 func (r apiFindPetsByStatusRequest) Status(status []string) apiFindPetsByStatusRequest {
-    r.status = &status
-    return r
+	r.status = &status
+	return r
 }
 
 /*
@@ -254,10 +243,10 @@ Multiple status values can be provided with comma separated strings
 @return apiFindPetsByStatusRequest
 */
 func (a *PetApiService) FindPetsByStatus(ctx _context.Context) apiFindPetsByStatusRequest {
-    return apiFindPetsByStatusRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFindPetsByStatusRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -274,25 +263,20 @@ func (r apiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error)
 		localVarReturnValue  []Pet
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByStatus")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByStatus")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByStatus"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/findByStatus"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.status == nil {
-        return localVarReturnValue, nil, reportError("status is required and must be specified")
-    }
+	if r.status == nil {
+		return localVarReturnValue, nil, reportError("status is required and must be specified")
+	}
 
 	localVarQueryParams.Add("status", parameterToString(*r.status, "csv"))
 	// to determine the Content-Type header
@@ -358,15 +342,15 @@ func (r apiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error)
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiFindPetsByTagsRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    tags *[]string
+	ctx _context.Context
+	apiService *PetApiService
+	tags *[]string
 }
 
 
 func (r apiFindPetsByTagsRequest) Tags(tags []string) apiFindPetsByTagsRequest {
-    r.tags = &tags
-    return r
+	r.tags = &tags
+	return r
 }
 
 /*
@@ -376,10 +360,10 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 @return apiFindPetsByTagsRequest
 */
 func (a *PetApiService) FindPetsByTags(ctx _context.Context) apiFindPetsByTagsRequest {
-    return apiFindPetsByTagsRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFindPetsByTagsRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -396,25 +380,20 @@ func (r apiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 		localVarReturnValue  []Pet
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByTags")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByTags"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/findByTags"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.tags == nil {
-        return localVarReturnValue, nil, reportError("tags is required and must be specified")
-    }
+	if r.tags == nil {
+		return localVarReturnValue, nil, reportError("tags is required and must be specified")
+	}
 
 	localVarQueryParams.Add("tags", parameterToString(*r.tags, "csv"))
 	// to determine the Content-Type header
@@ -480,9 +459,9 @@ func (r apiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiGetPetByIdRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    petId int64
+	ctx _context.Context
+	apiService *PetApiService
+	petId int64
 }
 
 
@@ -494,11 +473,11 @@ Returns a single pet
 @return apiGetPetByIdRequest
 */
 func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) apiGetPetByIdRequest {
-    return apiGetPetByIdRequest{
-        apiService: a,
-        ctx: ctx,
-        petId: petId,
-    }
+	return apiGetPetByIdRequest{
+		apiService: a,
+		ctx: ctx,
+		petId: petId,
+	}
 }
 
 /*
@@ -515,19 +494,13 @@ func (r apiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 		localVarReturnValue  Pet
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.GetPetById")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.GetPetById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -611,15 +584,15 @@ func (r apiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiUpdatePetRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    body *Pet
+	ctx _context.Context
+	apiService *PetApiService
+	body *Pet
 }
 
 
 func (r apiUpdatePetRequest) Body(body Pet) apiUpdatePetRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -628,10 +601,10 @@ UpdatePet Update an existing pet
 @return apiUpdatePetRequest
 */
 func (a *PetApiService) UpdatePet(ctx _context.Context) apiUpdatePetRequest {
-    return apiUpdatePetRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiUpdatePetRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -648,25 +621,20 @@ func (r apiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePet")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.body == nil {
-        return nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json", "application/xml"}
@@ -686,7 +654,7 @@ func (r apiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -714,22 +682,22 @@ func (r apiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiUpdatePetWithFormRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    petId int64
-    name *string
-    status *string
+	ctx _context.Context
+	apiService *PetApiService
+	petId int64
+	name *string
+	status *string
 }
 
 
 func (r apiUpdatePetWithFormRequest) Name(name string) apiUpdatePetWithFormRequest {
-    r.name = &name
-    return r
+	r.name = &name
+	return r
 }
 
 func (r apiUpdatePetWithFormRequest) Status(status string) apiUpdatePetWithFormRequest {
-    r.status = &status
-    return r
+	r.status = &status
+	return r
 }
 
 /*
@@ -739,11 +707,11 @@ UpdatePetWithForm Updates a pet in the store with form data
 @return apiUpdatePetWithFormRequest
 */
 func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64) apiUpdatePetWithFormRequest {
-    return apiUpdatePetWithFormRequest{
-        apiService: a,
-        ctx: ctx,
-        petId: petId,
-    }
+	return apiUpdatePetWithFormRequest{
+		apiService: a,
+		ctx: ctx,
+		petId: petId,
+	}
 }
 
 /*
@@ -760,19 +728,13 @@ func (r apiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePetWithForm")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePetWithForm")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -829,22 +791,22 @@ func (r apiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiUploadFileRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    petId int64
-    additionalMetadata *string
-    file **os.File
+	ctx _context.Context
+	apiService *PetApiService
+	petId int64
+	additionalMetadata *string
+	file **os.File
 }
 
 
 func (r apiUploadFileRequest) AdditionalMetadata(additionalMetadata string) apiUploadFileRequest {
-    r.additionalMetadata = &additionalMetadata
-    return r
+	r.additionalMetadata = &additionalMetadata
+	return r
 }
 
 func (r apiUploadFileRequest) File(file *os.File) apiUploadFileRequest {
-    r.file = &file
-    return r
+	r.file = &file
+	return r
 }
 
 /*
@@ -854,11 +816,11 @@ UploadFile uploads an image
 @return apiUploadFileRequest
 */
 func (a *PetApiService) UploadFile(ctx _context.Context, petId int64) apiUploadFileRequest {
-    return apiUploadFileRequest{
-        apiService: a,
-        ctx: ctx,
-        petId: petId,
-    }
+	return apiUploadFileRequest{
+		apiService: a,
+		ctx: ctx,
+		petId: petId,
+	}
 }
 
 /*
@@ -875,19 +837,13 @@ func (r apiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error)
 		localVarReturnValue  ApiResponse
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFile")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}/uploadImage"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -970,22 +926,22 @@ func (r apiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error)
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiUploadFileWithRequiredFileRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    petId int64
-    requiredFile **os.File
-    additionalMetadata *string
+	ctx _context.Context
+	apiService *PetApiService
+	petId int64
+	requiredFile **os.File
+	additionalMetadata *string
 }
 
 
 func (r apiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) apiUploadFileWithRequiredFileRequest {
-    r.requiredFile = &requiredFile
-    return r
+	r.requiredFile = &requiredFile
+	return r
 }
 
 func (r apiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetadata string) apiUploadFileWithRequiredFileRequest {
-    r.additionalMetadata = &additionalMetadata
-    return r
+	r.additionalMetadata = &additionalMetadata
+	return r
 }
 
 /*
@@ -995,11 +951,11 @@ UploadFileWithRequiredFile uploads an image (required)
 @return apiUploadFileWithRequiredFileRequest
 */
 func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId int64) apiUploadFileWithRequiredFileRequest {
-    return apiUploadFileWithRequiredFileRequest{
-        apiService: a,
-        ctx: ctx,
-        petId: petId,
-    }
+	return apiUploadFileWithRequiredFileRequest{
+		apiService: a,
+		ctx: ctx,
+		petId: petId,
+	}
 }
 
 /*
@@ -1016,28 +972,22 @@ func (r apiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.
 		localVarReturnValue  ApiResponse
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFileWithRequiredFile")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFileWithRequiredFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/{petId}/uploadImageWithRequiredFile"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
 	
-    if r.requiredFile == nil {
-        return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
-    }
+	if r.requiredFile == nil {
+		return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
+	}
 	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"multipart/form-data"}

--- a/samples/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_store.go
@@ -26,9 +26,9 @@ var (
 type StoreApiService service
 
 type apiDeleteOrderRequest struct {
-    ctx _context.Context
-    apiService *StoreApiService
-    orderId string
+	ctx _context.Context
+	apiService *StoreApiService
+	orderId string
 }
 
 
@@ -40,11 +40,11 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 @return apiDeleteOrderRequest
 */
 func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) apiDeleteOrderRequest {
-    return apiDeleteOrderRequest{
-        apiService: a,
-        ctx: ctx,
-        orderId: orderId,
-    }
+	return apiDeleteOrderRequest{
+		apiService: a,
+		ctx: ctx,
+		orderId: orderId,
+	}
 }
 
 /*
@@ -61,19 +61,13 @@ func (r apiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.DeleteOrder")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.DeleteOrder")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/store/order/{order_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(r.orderId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -124,8 +118,8 @@ func (r apiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiGetInventoryRequest struct {
-    ctx _context.Context
-    apiService *StoreApiService
+	ctx _context.Context
+	apiService *StoreApiService
 }
 
 
@@ -136,10 +130,10 @@ Returns a map of status codes to quantities
 @return apiGetInventoryRequest
 */
 func (a *StoreApiService) GetInventory(ctx _context.Context) apiGetInventoryRequest {
-    return apiGetInventoryRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiGetInventoryRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -156,18 +150,13 @@ func (r apiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response,
 		localVarReturnValue  map[string]int32
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetInventory")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetInventory")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/inventory"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/store/inventory"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -248,9 +237,9 @@ func (r apiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response,
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiGetOrderByIdRequest struct {
-    ctx _context.Context
-    apiService *StoreApiService
-    orderId int64
+	ctx _context.Context
+	apiService *StoreApiService
+	orderId int64
 }
 
 
@@ -262,11 +251,11 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 @return apiGetOrderByIdRequest
 */
 func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) apiGetOrderByIdRequest {
-    return apiGetOrderByIdRequest{
-        apiService: a,
-        ctx: ctx,
-        orderId: orderId,
-    }
+	return apiGetOrderByIdRequest{
+		apiService: a,
+		ctx: ctx,
+		orderId: orderId,
+	}
 }
 
 /*
@@ -283,28 +272,22 @@ func (r apiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 		localVarReturnValue  Order
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetOrderById")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetOrderById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/store/order/{order_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(r.orderId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-	if *r.orderId < 1 {
+	if r.orderId < 1 {
 		return localVarReturnValue, nil, reportError("orderId must be greater than 1")
 	}
-	if *r.orderId > 5 {
+	if r.orderId > 5 {
 		return localVarReturnValue, nil, reportError("orderId must be less than 5")
 	}
 
@@ -371,15 +354,15 @@ func (r apiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiPlaceOrderRequest struct {
-    ctx _context.Context
-    apiService *StoreApiService
-    body *Order
+	ctx _context.Context
+	apiService *StoreApiService
+	body *Order
 }
 
 
 func (r apiPlaceOrderRequest) Body(body Order) apiPlaceOrderRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -388,10 +371,10 @@ PlaceOrder Place an order for a pet
 @return apiPlaceOrderRequest
 */
 func (a *StoreApiService) PlaceOrder(ctx _context.Context) apiPlaceOrderRequest {
-    return apiPlaceOrderRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiPlaceOrderRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -408,25 +391,20 @@ func (r apiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 		localVarReturnValue  Order
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.PlaceOrder")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.PlaceOrder")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/store/order"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.body == nil {
-        return localVarReturnValue, nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -446,7 +424,7 @@ func (r apiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/samples/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_store.go
@@ -25,21 +25,43 @@ var (
 // StoreApiService StoreApi service
 type StoreApiService service
 
+type apiDeleteOrderRequest struct {
+    ctx _context.Context
+    apiService *StoreApiService
+    orderId string
+}
+
+
 /*
 DeleteOrder Delete purchase order by ID
-For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param orderId ID of the order that needs to be deleted
+@return apiDeleteOrderRequest
 */
-func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_nethttp.Response, error) {
+func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) apiDeleteOrderRequest {
+    return apiDeleteOrderRequest{
+        apiService: a,
+        ctx: ctx,
+        orderId: orderId,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.DeleteOrder")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -47,10 +69,16 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/store/order/{order_id}"
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(r.orderId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -69,12 +97,12 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -95,14 +123,30 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 
 	return localVarHTTPResponse, nil
 }
+type apiGetInventoryRequest struct {
+    ctx _context.Context
+    apiService *StoreApiService
+}
+
 
 /*
 GetInventory Returns pet inventories by status
 Returns a map of status codes to quantities
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-@return map[string]int32
+@return apiGetInventoryRequest
 */
-func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, *_nethttp.Response, error) {
+func (a *StoreApiService) GetInventory(ctx _context.Context) apiGetInventoryRequest {
+    return apiGetInventoryRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return map[string]int32
+*/
+func (r apiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -112,6 +156,7 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 		localVarReturnValue  map[string]int32
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetInventory")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -119,6 +164,10 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 
 	localVarPath := localBasePath + "/store/inventory"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/store/inventory"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -140,9 +189,9 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if ctx != nil {
+	if r.ctx != nil {
 		// API Key Authentication
-		if auth, ok := ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
 			if auth, ok := auth["api_key"]; ok {
 				var key string
 				if auth.Prefix != "" {
@@ -154,12 +203,12 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 			}
 		}
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -177,7 +226,7 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v map[string]int32
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -187,7 +236,7 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -198,15 +247,33 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiGetOrderByIdRequest struct {
+    ctx _context.Context
+    apiService *StoreApiService
+    orderId int64
+}
+
 
 /*
 GetOrderById Find purchase order by ID
-For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param orderId ID of pet that needs to be fetched
-@return Order
+@return apiGetOrderByIdRequest
 */
-func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Order, *_nethttp.Response, error) {
+func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) apiGetOrderByIdRequest {
+    return apiGetOrderByIdRequest{
+        apiService: a,
+        ctx: ctx,
+        orderId: orderId,
+    }
+}
+
+/*
+Execute executes the request
+ @return Order
+*/
+func (r apiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -216,6 +283,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 		localVarReturnValue  Order
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetOrderById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -223,14 +291,20 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/store/order/{order_id}"
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(r.orderId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if orderId < 1 {
+	
+	if *r.orderId < 1 {
 		return localVarReturnValue, nil, reportError("orderId must be greater than 1")
 	}
-	if orderId > 5 {
+	if *r.orderId > 5 {
 		return localVarReturnValue, nil, reportError("orderId must be less than 5")
 	}
 
@@ -251,12 +325,12 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -274,7 +348,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Order
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -285,7 +359,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -296,14 +370,35 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiPlaceOrderRequest struct {
+    ctx _context.Context
+    apiService *StoreApiService
+    body *Order
+}
+
+
+func (r apiPlaceOrderRequest) Body(body Order) apiPlaceOrderRequest {
+    r.body = &body
+    return r
+}
 
 /*
 PlaceOrder Place an order for a pet
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body order placed for purchasing the pet
-@return Order
+@return apiPlaceOrderRequest
 */
-func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *_nethttp.Response, error) {
+func (a *StoreApiService) PlaceOrder(ctx _context.Context) apiPlaceOrderRequest {
+    return apiPlaceOrderRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return Order
+*/
+func (r apiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -313,6 +408,7 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 		localVarReturnValue  Order
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.PlaceOrder")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -320,9 +416,17 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 
 	localVarPath := localBasePath + "/store/order"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/store/order"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.body == nil {
+        return localVarReturnValue, nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -342,13 +446,13 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -366,7 +470,7 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Order
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -377,7 +481,7 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, body Order) (Order, *
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/samples/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_user.go
@@ -25,21 +25,46 @@ var (
 // UserApiService UserApi service
 type UserApiService service
 
+type apiCreateUserRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    body *User
+}
+
+
+func (r apiCreateUserRequest) Body(body User) apiCreateUserRequest {
+    r.body = &body
+    return r
+}
+
 /*
 CreateUser Create user
 This can only be done by the logged in user.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body Created user object
+@return apiCreateUserRequest
 */
-func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.Response, error) {
+func (a *UserApiService) CreateUser(ctx _context.Context) apiCreateUserRequest {
+    return apiCreateUserRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -47,9 +72,17 @@ func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.
 
 	localVarPath := localBasePath + "/user"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.body == nil {
+        return nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -69,13 +102,13 @@ func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -96,21 +129,45 @@ func (a *UserApiService) CreateUser(ctx _context.Context, body User) (*_nethttp.
 
 	return localVarHTTPResponse, nil
 }
+type apiCreateUsersWithArrayInputRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    body *[]User
+}
+
+
+func (r apiCreateUsersWithArrayInputRequest) Body(body []User) apiCreateUsersWithArrayInputRequest {
+    r.body = &body
+    return r
+}
 
 /*
 CreateUsersWithArrayInput Creates list of users with given input array
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body List of user object
+@return apiCreateUsersWithArrayInputRequest
 */
-func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []User) (*_nethttp.Response, error) {
+func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context) apiCreateUsersWithArrayInputRequest {
+    return apiCreateUsersWithArrayInputRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithArrayInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -118,9 +175,17 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []
 
 	localVarPath := localBasePath + "/user/createWithArray"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/createWithArray"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.body == nil {
+        return nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -140,13 +205,13 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -167,21 +232,45 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, body []
 
 	return localVarHTTPResponse, nil
 }
+type apiCreateUsersWithListInputRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    body *[]User
+}
+
+
+func (r apiCreateUsersWithListInputRequest) Body(body []User) apiCreateUsersWithListInputRequest {
+    r.body = &body
+    return r
+}
 
 /*
 CreateUsersWithListInput Creates list of users with given input array
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body List of user object
+@return apiCreateUsersWithListInputRequest
 */
-func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []User) (*_nethttp.Response, error) {
+func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context) apiCreateUsersWithListInputRequest {
+    return apiCreateUsersWithListInputRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithListInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -189,9 +278,17 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []U
 
 	localVarPath := localBasePath + "/user/createWithList"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/createWithList"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.body == nil {
+        return nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -211,13 +308,13 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []U
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -238,22 +335,43 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, body []U
 
 	return localVarHTTPResponse, nil
 }
+type apiDeleteUserRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    username string
+}
+
 
 /*
 DeleteUser Delete user
 This can only be done by the logged in user.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param username The name that needs to be deleted
+@return apiDeleteUserRequest
 */
-func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_nethttp.Response, error) {
+func (a *UserApiService) DeleteUser(ctx _context.Context, username string) apiDeleteUserRequest {
+    return apiDeleteUserRequest{
+        apiService: a,
+        ctx: ctx,
+        username: username,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.DeleteUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -261,10 +379,16 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 
 	localVarPath := localBasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -283,12 +407,12 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -309,14 +433,32 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 
 	return localVarHTTPResponse, nil
 }
+type apiGetUserByNameRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    username string
+}
+
 
 /*
 GetUserByName Get user by user name
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param username The name that needs to be fetched. Use user1 for testing.
-@return User
+@return apiGetUserByNameRequest
 */
-func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (User, *_nethttp.Response, error) {
+func (a *UserApiService) GetUserByName(ctx _context.Context, username string) apiGetUserByNameRequest {
+    return apiGetUserByNameRequest{
+        apiService: a,
+        ctx: ctx,
+        username: username,
+    }
+}
+
+/*
+Execute executes the request
+ @return User
+*/
+func (r apiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -326,6 +468,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 		localVarReturnValue  User
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.GetUserByName")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -333,10 +476,16 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 
 	localVarPath := localBasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -355,12 +504,12 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -378,7 +527,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v User
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -389,7 +538,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -400,15 +549,41 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiLoginUserRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    username *string
+    password *string
+}
+
+
+func (r apiLoginUserRequest) Username(username string) apiLoginUserRequest {
+    r.username = &username
+    return r
+}
+
+func (r apiLoginUserRequest) Password(password string) apiLoginUserRequest {
+    r.password = &password
+    return r
+}
 
 /*
 LoginUser Logs user into the system
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param username The user name for login
- * @param password The password for login in clear text
-@return string
+@return apiLoginUserRequest
 */
-func (a *UserApiService) LoginUser(ctx _context.Context, username string, password string) (string, *_nethttp.Response, error) {
+func (a *UserApiService) LoginUser(ctx _context.Context) apiLoginUserRequest {
+    return apiLoginUserRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return string
+*/
+func (r apiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -418,6 +593,7 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 		localVarReturnValue  string
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LoginUser")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -425,12 +601,24 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 
 	localVarPath := localBasePath + "/user/login"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/login"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.username == nil {
+        return localVarReturnValue, nil, reportError("username is required and must be specified")
+    }
+	
+    if r.password == nil {
+        return localVarReturnValue, nil, reportError("password is required and must be specified")
+    }
 
-	localVarQueryParams.Add("username", parameterToString(username, ""))
-	localVarQueryParams.Add("password", parameterToString(password, ""))
+	localVarQueryParams.Add("username", parameterToString(*r.username, ""))
+	localVarQueryParams.Add("password", parameterToString(*r.password, ""))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -448,12 +636,12 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -471,7 +659,7 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v string
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -482,7 +670,7 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -493,20 +681,39 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiLogoutUserRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+}
+
 
 /*
 LogoutUser Logs out current logged in user session
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+@return apiLogoutUserRequest
 */
-func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, error) {
+func (a *UserApiService) LogoutUser(ctx _context.Context) apiLogoutUserRequest {
+    return apiLogoutUserRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LogoutUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -514,6 +721,10 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 
 	localVarPath := localBasePath + "/user/logout"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/logout"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -535,12 +746,12 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -561,23 +772,49 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 
 	return localVarHTTPResponse, nil
 }
+type apiUpdateUserRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    username string
+    body *User
+}
+
+
+func (r apiUpdateUserRequest) Body(body User) apiUpdateUserRequest {
+    r.body = &body
+    return r
+}
 
 /*
 UpdateUser Updated user
 This can only be done by the logged in user.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param username name that need to be deleted
- * @param body Updated user object
+@return apiUpdateUserRequest
 */
-func (a *UserApiService) UpdateUser(ctx _context.Context, username string, body User) (*_nethttp.Response, error) {
+func (a *UserApiService) UpdateUser(ctx _context.Context, username string) apiUpdateUserRequest {
+    return apiUpdateUserRequest{
+        apiService: a,
+        ctx: ctx,
+        username: username,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.UpdateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -585,10 +822,20 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, body 
 
 	localVarPath := localBasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+	
+    if r.body == nil {
+        return nil, reportError("body is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -608,13 +855,13 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, body 
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &body
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/client/petstore/go-experimental/go-petstore/api_user.go
@@ -26,15 +26,15 @@ var (
 type UserApiService service
 
 type apiCreateUserRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    body *User
+	ctx _context.Context
+	apiService *UserApiService
+	body *User
 }
 
 
 func (r apiCreateUserRequest) Body(body User) apiCreateUserRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -44,10 +44,10 @@ This can only be done by the logged in user.
 @return apiCreateUserRequest
 */
 func (a *UserApiService) CreateUser(ctx _context.Context) apiCreateUserRequest {
-    return apiCreateUserRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiCreateUserRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -64,25 +64,20 @@ func (r apiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUser")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.body == nil {
-        return nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -102,7 +97,7 @@ func (r apiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -130,15 +125,15 @@ func (r apiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiCreateUsersWithArrayInputRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    body *[]User
+	ctx _context.Context
+	apiService *UserApiService
+	body *[]User
 }
 
 
 func (r apiCreateUsersWithArrayInputRequest) Body(body []User) apiCreateUsersWithArrayInputRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -147,10 +142,10 @@ CreateUsersWithArrayInput Creates list of users with given input array
 @return apiCreateUsersWithArrayInputRequest
 */
 func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context) apiCreateUsersWithArrayInputRequest {
-    return apiCreateUsersWithArrayInputRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiCreateUsersWithArrayInputRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -167,25 +162,20 @@ func (r apiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, erro
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithArrayInput")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithArrayInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithArray"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/createWithArray"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.body == nil {
-        return nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -205,7 +195,7 @@ func (r apiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, erro
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -233,15 +223,15 @@ func (r apiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, erro
 	return localVarHTTPResponse, nil
 }
 type apiCreateUsersWithListInputRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    body *[]User
+	ctx _context.Context
+	apiService *UserApiService
+	body *[]User
 }
 
 
 func (r apiCreateUsersWithListInputRequest) Body(body []User) apiCreateUsersWithListInputRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -250,10 +240,10 @@ CreateUsersWithListInput Creates list of users with given input array
 @return apiCreateUsersWithListInputRequest
 */
 func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context) apiCreateUsersWithListInputRequest {
-    return apiCreateUsersWithListInputRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiCreateUsersWithListInputRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -270,25 +260,20 @@ func (r apiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithListInput")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithListInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithList"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/createWithList"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.body == nil {
-        return nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -308,7 +293,7 @@ func (r apiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -336,9 +321,9 @@ func (r apiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error
 	return localVarHTTPResponse, nil
 }
 type apiDeleteUserRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    username string
+	ctx _context.Context
+	apiService *UserApiService
+	username string
 }
 
 
@@ -350,11 +335,11 @@ This can only be done by the logged in user.
 @return apiDeleteUserRequest
 */
 func (a *UserApiService) DeleteUser(ctx _context.Context, username string) apiDeleteUserRequest {
-    return apiDeleteUserRequest{
-        apiService: a,
-        ctx: ctx,
-        username: username,
-    }
+	return apiDeleteUserRequest{
+		apiService: a,
+		ctx: ctx,
+		username: username,
+	}
 }
 
 /*
@@ -371,19 +356,13 @@ func (r apiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.DeleteUser")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.DeleteUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -434,9 +413,9 @@ func (r apiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiGetUserByNameRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    username string
+	ctx _context.Context
+	apiService *UserApiService
+	username string
 }
 
 
@@ -447,11 +426,11 @@ GetUserByName Get user by user name
 @return apiGetUserByNameRequest
 */
 func (a *UserApiService) GetUserByName(ctx _context.Context, username string) apiGetUserByNameRequest {
-    return apiGetUserByNameRequest{
-        apiService: a,
-        ctx: ctx,
-        username: username,
-    }
+	return apiGetUserByNameRequest{
+		apiService: a,
+		ctx: ctx,
+		username: username,
+	}
 }
 
 /*
@@ -468,19 +447,13 @@ func (r apiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 		localVarReturnValue  User
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.GetUserByName")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.GetUserByName")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -550,21 +523,21 @@ func (r apiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiLoginUserRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    username *string
-    password *string
+	ctx _context.Context
+	apiService *UserApiService
+	username *string
+	password *string
 }
 
 
 func (r apiLoginUserRequest) Username(username string) apiLoginUserRequest {
-    r.username = &username
-    return r
+	r.username = &username
+	return r
 }
 
 func (r apiLoginUserRequest) Password(password string) apiLoginUserRequest {
-    r.password = &password
-    return r
+	r.password = &password
+	return r
 }
 
 /*
@@ -573,10 +546,10 @@ LoginUser Logs user into the system
 @return apiLoginUserRequest
 */
 func (a *UserApiService) LoginUser(ctx _context.Context) apiLoginUserRequest {
-    return apiLoginUserRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiLoginUserRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -593,29 +566,24 @@ func (r apiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 		localVarReturnValue  string
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LoginUser")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LoginUser")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/login"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/login"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.username == nil {
-        return localVarReturnValue, nil, reportError("username is required and must be specified")
-    }
+	if r.username == nil {
+		return localVarReturnValue, nil, reportError("username is required and must be specified")
+	}
 	
-    if r.password == nil {
-        return localVarReturnValue, nil, reportError("password is required and must be specified")
-    }
+	if r.password == nil {
+		return localVarReturnValue, nil, reportError("password is required and must be specified")
+	}
 
 	localVarQueryParams.Add("username", parameterToString(*r.username, ""))
 	localVarQueryParams.Add("password", parameterToString(*r.password, ""))
@@ -682,8 +650,8 @@ func (r apiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiLogoutUserRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
+	ctx _context.Context
+	apiService *UserApiService
 }
 
 
@@ -693,10 +661,10 @@ LogoutUser Logs out current logged in user session
 @return apiLogoutUserRequest
 */
 func (a *UserApiService) LogoutUser(ctx _context.Context) apiLogoutUserRequest {
-    return apiLogoutUserRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiLogoutUserRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -713,18 +681,13 @@ func (r apiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LogoutUser")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LogoutUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/logout"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/logout"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -773,16 +736,16 @@ func (r apiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiUpdateUserRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    username string
-    body *User
+	ctx _context.Context
+	apiService *UserApiService
+	username string
+	body *User
 }
 
 
 func (r apiUpdateUserRequest) Body(body User) apiUpdateUserRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -793,11 +756,11 @@ This can only be done by the logged in user.
 @return apiUpdateUserRequest
 */
 func (a *UserApiService) UpdateUser(ctx _context.Context, username string) apiUpdateUserRequest {
-    return apiUpdateUserRequest{
-        apiService: a,
-        ctx: ctx,
-        username: username,
-    }
+	return apiUpdateUserRequest{
+		apiService: a,
+		ctx: ctx,
+		username: username,
+	}
 }
 
 /*
@@ -814,28 +777,22 @@ func (r apiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.UpdateUser")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.UpdateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
 	
-    if r.body == nil {
-        return nil, reportError("body is required and must be specified")
-    }
+	if r.body == nil {
+		return nil, reportError("body is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -855,7 +812,7 @@ func (r apiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err

--- a/samples/client/petstore/go-experimental/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/AnotherFakeApi.md
@@ -10,19 +10,24 @@ Method | HTTP request | Description
 
 ## Call123TestSpecialTags
 
-> Client Call123TestSpecialTags(ctx, body)
+> Client Call123TestSpecialTags(ctx).Body(body).Execute()
 
 To test special tags
 
-To test special tags and operation ID starting with number
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCall123TestSpecialTagsRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**body** | [**Client**](Client.md)| client model | 
+ **body** | [**Client**](Client.md) | client model | 
 
 ### Return type
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/FakeApi.md
@@ -23,19 +23,24 @@ Method | HTTP request | Description
 
 ## CreateXmlItem
 
-> CreateXmlItem(ctx, xmlItem)
+> CreateXmlItem(ctx).XmlItem(xmlItem).Execute()
 
 creates an XmlItem
 
-this route creates an XmlItem
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCreateXmlItemRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**xmlItem** | [**XmlItem**](XmlItem.md)| XmlItem Body | 
+ **xmlItem** | [**XmlItem**](XmlItem.md) | XmlItem Body | 
 
 ### Return type
 
@@ -57,28 +62,24 @@ No authorization required
 
 ## FakeOuterBooleanSerialize
 
-> bool FakeOuterBooleanSerialize(ctx, optional)
+> bool FakeOuterBooleanSerialize(ctx).Body(body).Execute()
 
 
 
-Test serialization of outer boolean types
-
-### Required Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
- **optional** | ***FakeOuterBooleanSerializeOpts** | optional parameters | nil if no parameters
+### Path Parameters
 
-### Optional Parameters
 
-Optional parameters are passed through a pointer to a FakeOuterBooleanSerializeOpts struct
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFakeOuterBooleanSerializeRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | **optional.Bool**| Input boolean as post body | 
+ **body** | **bool** | Input boolean as post body | 
 
 ### Return type
 
@@ -100,28 +101,24 @@ No authorization required
 
 ## FakeOuterCompositeSerialize
 
-> OuterComposite FakeOuterCompositeSerialize(ctx, optional)
+> OuterComposite FakeOuterCompositeSerialize(ctx).Body(body).Execute()
 
 
 
-Test serialization of object with outer number type
-
-### Required Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
- **optional** | ***FakeOuterCompositeSerializeOpts** | optional parameters | nil if no parameters
+### Path Parameters
 
-### Optional Parameters
 
-Optional parameters are passed through a pointer to a FakeOuterCompositeSerializeOpts struct
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFakeOuterCompositeSerializeRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | [**optional.Interface of OuterComposite**](OuterComposite.md)| Input composite as post body | 
+ **body** | [**OuterComposite**](OuterComposite.md) | Input composite as post body | 
 
 ### Return type
 
@@ -143,28 +140,24 @@ No authorization required
 
 ## FakeOuterNumberSerialize
 
-> float32 FakeOuterNumberSerialize(ctx, optional)
+> float32 FakeOuterNumberSerialize(ctx).Body(body).Execute()
 
 
 
-Test serialization of outer number types
-
-### Required Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
- **optional** | ***FakeOuterNumberSerializeOpts** | optional parameters | nil if no parameters
+### Path Parameters
 
-### Optional Parameters
 
-Optional parameters are passed through a pointer to a FakeOuterNumberSerializeOpts struct
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFakeOuterNumberSerializeRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | **optional.Float32**| Input number as post body | 
+ **body** | **float32** | Input number as post body | 
 
 ### Return type
 
@@ -186,28 +179,24 @@ No authorization required
 
 ## FakeOuterStringSerialize
 
-> string FakeOuterStringSerialize(ctx, optional)
+> string FakeOuterStringSerialize(ctx).Body(body).Execute()
 
 
 
-Test serialization of outer string types
-
-### Required Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
- **optional** | ***FakeOuterStringSerializeOpts** | optional parameters | nil if no parameters
+### Path Parameters
 
-### Optional Parameters
 
-Optional parameters are passed through a pointer to a FakeOuterStringSerializeOpts struct
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFakeOuterStringSerializeRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | **optional.String**| Input string as post body | 
+ **body** | **string** | Input string as post body | 
 
 ### Return type
 
@@ -229,19 +218,24 @@ No authorization required
 
 ## TestBodyWithFileSchema
 
-> TestBodyWithFileSchema(ctx, body)
+> TestBodyWithFileSchema(ctx).Body(body).Execute()
 
 
 
-For this test, the body for this request much reference a schema named `File`.
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestBodyWithFileSchemaRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**body** | [**FileSchemaTestClass**](FileSchemaTestClass.md)|  | 
+ **body** | [**FileSchemaTestClass**](FileSchemaTestClass.md) |  | 
 
 ### Return type
 
@@ -263,18 +257,23 @@ No authorization required
 
 ## TestBodyWithQueryParams
 
-> TestBodyWithQueryParams(ctx, query, body)
+> TestBodyWithQueryParams(ctx).Query(query).Body(body).Execute()
 
 
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestBodyWithQueryParamsRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**query** | **string**|  | 
-**body** | [**User**](User.md)|  | 
+ **query** | **string** |  | 
+ **body** | [**User**](User.md) |  | 
 
 ### Return type
 
@@ -296,19 +295,24 @@ No authorization required
 
 ## TestClientModel
 
-> Client TestClientModel(ctx, body)
+> Client TestClientModel(ctx).Body(body).Execute()
 
 To test \"client\" model
 
-To test \"client\" model
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestClientModelRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**body** | [**Client**](Client.md)| client model | 
+ **body** | [**Client**](Client.md) | client model | 
 
 ### Return type
 
@@ -330,45 +334,41 @@ No authorization required
 
 ## TestEndpointParameters
 
-> TestEndpointParameters(ctx, number, double, patternWithoutDelimiter, byte_, optional)
+> TestEndpointParameters(ctx).Number(number).Double(double).PatternWithoutDelimiter(patternWithoutDelimiter).Byte_(byte_).Integer(integer).Int32_(int32_).Int64_(int64_).Float(float).String_(string_).Binary(binary).Date(date).DateTime(dateTime).Password(password).Callback(callback).Execute()
 
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 
+<<<<<<< HEAD
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+=======
+>>>>>>> [go-experimental] Use builder pattern for requests
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestEndpointParametersRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**number** | **float32**| None | 
-**double** | **float64**| None | 
-**patternWithoutDelimiter** | **string**| None | 
-**byte_** | **string**| None | 
- **optional** | ***TestEndpointParametersOpts** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a pointer to a TestEndpointParametersOpts struct
-
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-
-
-
-
- **integer** | **optional.Int32**| None | 
- **int32_** | **optional.Int32**| None | 
- **int64_** | **optional.Int64**| None | 
- **float** | **optional.Float32**| None | 
- **string_** | **optional.String**| None | 
- **binary** | **optional.Interface of *os.File****optional.*os.File**| None | 
- **date** | **optional.String**| None | 
- **dateTime** | **optional.Time**| None | 
- **password** | **optional.String**| None | 
- **callback** | **optional.String**| None | 
+ **number** | **float32** | None | 
+ **double** | **float64** | None | 
+ **patternWithoutDelimiter** | **string** | None | 
+ **byte_** | **string** | None | 
+ **integer** | **int32** | None | 
+ **int32_** | **int32** | None | 
+ **int64_** | **int64** | None | 
+ **float** | **float32** | None | 
+ **string_** | **string** | None | 
+ **binary** | ***os.File** | None | 
+ **date** | **string** | None | 
+ **dateTime** | **time.Time** | None | 
+ **password** | **string** | None | 
+ **callback** | **string** | None | 
 
 ### Return type
 
@@ -390,35 +390,31 @@ Name | Type | Description  | Notes
 
 ## TestEnumParameters
 
-> TestEnumParameters(ctx, optional)
+> TestEnumParameters(ctx).EnumHeaderStringArray(enumHeaderStringArray).EnumHeaderString(enumHeaderString).EnumQueryStringArray(enumQueryStringArray).EnumQueryString(enumQueryString).EnumQueryInteger(enumQueryInteger).EnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
 
 To test enum parameters
 
-To test enum parameters
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestEnumParametersRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
- **optional** | ***TestEnumParametersOpts** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a pointer to a TestEnumParametersOpts struct
-
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **enumHeaderStringArray** | [**optional.Interface of []string**](string.md)| Header parameter enum test (string array) | 
- **enumHeaderString** | **optional.String**| Header parameter enum test (string) | [default to -efg]
- **enumQueryStringArray** | [**optional.Interface of []string**](string.md)| Query parameter enum test (string array) | 
- **enumQueryString** | **optional.String**| Query parameter enum test (string) | [default to -efg]
- **enumQueryInteger** | **optional.Int32**| Query parameter enum test (double) | 
- **enumQueryDouble** | **optional.Float64**| Query parameter enum test (double) | 
- **enumFormStringArray** | [**optional.Interface of []string**](string.md)| Form parameter enum test (string array) | [default to $]
- **enumFormString** | **optional.String**| Form parameter enum test (string) | [default to -efg]
+ **enumHeaderStringArray** | [**[]string**](string.md) | Header parameter enum test (string array) | 
+ **enumHeaderString** | **string** | Header parameter enum test (string) | [default to -efg]
+ **enumQueryStringArray** | [**[]string**](string.md) | Query parameter enum test (string array) | 
+ **enumQueryString** | **string** | Query parameter enum test (string) | [default to -efg]
+ **enumQueryInteger** | **int32** | Query parameter enum test (double) | 
+ **enumQueryDouble** | **float64** | Query parameter enum test (double) | 
+ **enumFormStringArray** | [**[]string**](string.md) | Form parameter enum test (string array) | [default to $]
+ **enumFormString** | **string** | Form parameter enum test (string) | [default to -efg]
 
 ### Return type
 
@@ -440,36 +436,29 @@ No authorization required
 
 ## TestGroupParameters
 
-> TestGroupParameters(ctx, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, optional)
+> TestGroupParameters(ctx).RequiredStringGroup(requiredStringGroup).RequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).BooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
 
 Fake endpoint to test group parameters (optional)
 
-Fake endpoint to test group parameters (optional)
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestGroupParametersRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**requiredStringGroup** | **int32**| Required String in group parameters | 
-**requiredBooleanGroup** | **bool**| Required Boolean in group parameters | 
-**requiredInt64Group** | **int64**| Required Integer in group parameters | 
- **optional** | ***TestGroupParametersOpts** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a pointer to a TestGroupParametersOpts struct
-
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-
-
-
- **stringGroup** | **optional.Int32**| String in group parameters | 
- **booleanGroup** | **optional.Bool**| Boolean in group parameters | 
- **int64Group** | **optional.Int64**| Integer in group parameters | 
+ **requiredStringGroup** | **int32** | Required String in group parameters | 
+ **requiredBooleanGroup** | **bool** | Required Boolean in group parameters | 
+ **requiredInt64Group** | **int64** | Required Integer in group parameters | 
+ **stringGroup** | **int32** | String in group parameters | 
+ **booleanGroup** | **bool** | Boolean in group parameters | 
+ **int64Group** | **int64** | Integer in group parameters | 
 
 ### Return type
 
@@ -491,17 +480,22 @@ No authorization required
 
 ## TestInlineAdditionalProperties
 
-> TestInlineAdditionalProperties(ctx, param)
+> TestInlineAdditionalProperties(ctx).Param(param).Execute()
 
 test inline additionalProperties
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestInlineAdditionalPropertiesRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**param** | [**map[string]string**](string.md)| request body | 
+ **param** | [**map[string]string**](string.md) | request body | 
 
 ### Return type
 
@@ -523,18 +517,23 @@ No authorization required
 
 ## TestJsonFormData
 
-> TestJsonFormData(ctx, param, param2)
+> TestJsonFormData(ctx).Param(param).Param2(param2).Execute()
 
 test json serialization of form data
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestJsonFormDataRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**param** | **string**| field1 | 
-**param2** | **string**| field2 | 
+ **param** | **string** | field1 | 
+ **param2** | **string** | field2 | 
 
 ### Return type
 
@@ -556,23 +555,28 @@ No authorization required
 
 ## TestQueryParameterCollectionFormat
 
-> TestQueryParameterCollectionFormat(ctx, pipe, ioutil, http, url, context)
+> TestQueryParameterCollectionFormat(ctx).Pipe(pipe).Ioutil(ioutil).Http(http).Url(url).Context(context).Execute()
 
 
 
-To test the collection format in query parameters
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestQueryParameterCollectionFormatRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**pipe** | [**[]string**](string.md)|  | 
-**ioutil** | [**[]string**](string.md)|  | 
-**http** | [**[]string**](string.md)|  | 
-**url** | [**[]string**](string.md)|  | 
-**context** | [**[]string**](string.md)|  | 
+ **pipe** | [**[]string**](string.md) |  | 
+ **ioutil** | [**[]string**](string.md) |  | 
+ **http** | [**[]string**](string.md) |  | 
+ **url** | [**[]string**](string.md) |  | 
+ **context** | [**[]string**](string.md) |  | 
 
 ### Return type
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/FakeApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/FakeApi.md
@@ -338,10 +338,6 @@ No authorization required
 
 Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
 
-<<<<<<< HEAD
-Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
-=======
->>>>>>> [go-experimental] Use builder pattern for requests
 
 
 ### Path Parameters

--- a/samples/client/petstore/go-experimental/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/FakeClassnameTags123Api.md
@@ -10,19 +10,24 @@ Method | HTTP request | Description
 
 ## TestClassname
 
-> Client TestClassname(ctx, body)
+> Client TestClassname(ctx).Body(body).Execute()
 
 To test class name in snake case
 
-To test class name in snake case
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestClassnameRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**body** | [**Client**](Client.md)| client model | 
+ **body** | [**Client**](Client.md) | client model | 
 
 ### Return type
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/PetApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/PetApi.md
@@ -18,17 +18,22 @@ Method | HTTP request | Description
 
 ## AddPet
 
-> AddPet(ctx, body)
+> AddPet(ctx).Body(body).Execute()
 
 Add a new pet to the store
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiAddPetRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **body** | [**Pet**](Pet.md) | Pet object that needs to be added to the store | 
 
 ### Return type
 
@@ -50,28 +55,27 @@ Name | Type | Description  | Notes
 
 ## DeletePet
 
-> DeletePet(ctx, petId, optional)
+> DeletePet(ctx, petId).ApiKey(apiKey).Execute()
 
 Deletes a pet
 
-### Required Parameters
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**petId** | **int64**| Pet id to delete | 
- **optional** | ***DeletePetOpts** | optional parameters | nil if no parameters
+**petId** | **int64** | Pet id to delete | 
 
-### Optional Parameters
+### Other Parameters
 
-Optional parameters are passed through a pointer to a DeletePetOpts struct
+Other parameters are passed through a pointer to a apiDeletePetRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **apiKey** | **optional.String**|  | 
+ **apiKey** | **string** |  | 
 
 ### Return type
 
@@ -93,19 +97,24 @@ Name | Type | Description  | Notes
 
 ## FindPetsByStatus
 
-> []Pet FindPetsByStatus(ctx, status)
+> []Pet FindPetsByStatus(ctx).Status(status).Execute()
 
 Finds Pets by status
 
-Multiple status values can be provided with comma separated strings
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFindPetsByStatusRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**status** | [**[]string**](string.md)| Status values that need to be considered for filter | 
+ **status** | [**[]string**](string.md) | Status values that need to be considered for filter | 
 
 ### Return type
 
@@ -127,19 +136,24 @@ Name | Type | Description  | Notes
 
 ## FindPetsByTags
 
-> []Pet FindPetsByTags(ctx, tags)
+> []Pet FindPetsByTags(ctx).Tags(tags).Execute()
 
 Finds Pets by tags
 
-Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFindPetsByTagsRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**tags** | [**[]string**](string.md)| Tags to filter by | 
+ **tags** | [**[]string**](string.md) | Tags to filter by | 
 
 ### Return type
 
@@ -161,19 +175,28 @@ Name | Type | Description  | Notes
 
 ## GetPetById
 
-> Pet GetPetById(ctx, petId)
+> Pet GetPetById(ctx, petId).Execute()
 
 Find pet by ID
 
-Returns a single pet
 
-### Required Parameters
+
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**petId** | **int64**| ID of pet to return | 
+**petId** | **int64** | ID of pet to return | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetPetByIdRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 
@@ -195,17 +218,22 @@ Name | Type | Description  | Notes
 
 ## UpdatePet
 
-> UpdatePet(ctx, body)
+> UpdatePet(ctx).Body(body).Execute()
 
 Update an existing pet
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiUpdatePetRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**body** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **body** | [**Pet**](Pet.md) | Pet object that needs to be added to the store | 
 
 ### Return type
 
@@ -227,29 +255,28 @@ Name | Type | Description  | Notes
 
 ## UpdatePetWithForm
 
-> UpdatePetWithForm(ctx, petId, optional)
+> UpdatePetWithForm(ctx, petId).Name(name).Status(status).Execute()
 
 Updates a pet in the store with form data
 
-### Required Parameters
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**petId** | **int64**| ID of pet that needs to be updated | 
- **optional** | ***UpdatePetWithFormOpts** | optional parameters | nil if no parameters
+**petId** | **int64** | ID of pet that needs to be updated | 
 
-### Optional Parameters
+### Other Parameters
 
-Optional parameters are passed through a pointer to a UpdatePetWithFormOpts struct
+Other parameters are passed through a pointer to a apiUpdatePetWithFormRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **name** | **optional.String**| Updated name of the pet | 
- **status** | **optional.String**| Updated status of the pet | 
+ **name** | **string** | Updated name of the pet | 
+ **status** | **string** | Updated status of the pet | 
 
 ### Return type
 
@@ -271,29 +298,28 @@ Name | Type | Description  | Notes
 
 ## UploadFile
 
-> ApiResponse UploadFile(ctx, petId, optional)
+> ApiResponse UploadFile(ctx, petId).AdditionalMetadata(additionalMetadata).File(file).Execute()
 
 uploads an image
 
-### Required Parameters
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**petId** | **int64**| ID of pet to update | 
- **optional** | ***UploadFileOpts** | optional parameters | nil if no parameters
+**petId** | **int64** | ID of pet to update | 
 
-### Optional Parameters
+### Other Parameters
 
-Optional parameters are passed through a pointer to a UploadFileOpts struct
+Other parameters are passed through a pointer to a apiUploadFileRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **additionalMetadata** | **optional.String**| Additional data to pass to server | 
- **file** | **optional.Interface of *os.File****optional.*os.File**| file to upload | 
+ **additionalMetadata** | **string** | Additional data to pass to server | 
+ **file** | ***os.File** | file to upload | 
 
 ### Return type
 
@@ -315,30 +341,28 @@ Name | Type | Description  | Notes
 
 ## UploadFileWithRequiredFile
 
-> ApiResponse UploadFileWithRequiredFile(ctx, petId, requiredFile, optional)
+> ApiResponse UploadFileWithRequiredFile(ctx, petId).RequiredFile(requiredFile).AdditionalMetadata(additionalMetadata).Execute()
 
 uploads an image (required)
 
-### Required Parameters
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**petId** | **int64**| ID of pet to update | 
-**requiredFile** | ***os.File*****os.File**| file to upload | 
- **optional** | ***UploadFileWithRequiredFileOpts** | optional parameters | nil if no parameters
+**petId** | **int64** | ID of pet to update | 
 
-### Optional Parameters
+### Other Parameters
 
-Optional parameters are passed through a pointer to a UploadFileWithRequiredFileOpts struct
+Other parameters are passed through a pointer to a apiUploadFileWithRequiredFileRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
-
- **additionalMetadata** | **optional.String**| Additional data to pass to server | 
+ **requiredFile** | ***os.File** | file to upload | 
+ **additionalMetadata** | **string** | Additional data to pass to server | 
 
 ### Return type
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/StoreApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/StoreApi.md
@@ -13,19 +13,28 @@ Method | HTTP request | Description
 
 ## DeleteOrder
 
-> DeleteOrder(ctx, orderId)
+> DeleteOrder(ctx, orderId).Execute()
 
 Delete purchase order by ID
 
-For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 
-### Required Parameters
+
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**orderId** | **string**| ID of the order that needs to be deleted | 
+**orderId** | **string** | ID of the order that needs to be deleted | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiDeleteOrderRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 
@@ -47,15 +56,20 @@ No authorization required
 
 ## GetInventory
 
-> map[string]int32 GetInventory(ctx, )
+> map[string]int32 GetInventory(ctx).Execute()
 
 Returns pet inventories by status
 
-Returns a map of status codes to quantities
 
-### Required Parameters
+
+### Path Parameters
 
 This endpoint does not need any parameter.
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetInventoryRequest struct via the builder pattern
+
 
 ### Return type
 
@@ -77,19 +91,28 @@ This endpoint does not need any parameter.
 
 ## GetOrderById
 
-> Order GetOrderById(ctx, orderId)
+> Order GetOrderById(ctx, orderId).Execute()
 
 Find purchase order by ID
 
-For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
 
-### Required Parameters
+
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**orderId** | **int64**| ID of pet that needs to be fetched | 
+**orderId** | **int64** | ID of pet that needs to be fetched | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetOrderByIdRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 
@@ -111,17 +134,22 @@ No authorization required
 
 ## PlaceOrder
 
-> Order PlaceOrder(ctx, body)
+> Order PlaceOrder(ctx).Body(body).Execute()
 
 Place an order for a pet
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiPlaceOrderRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**body** | [**Order**](Order.md)| order placed for purchasing the pet | 
+ **body** | [**Order**](Order.md) | order placed for purchasing the pet | 
 
 ### Return type
 

--- a/samples/client/petstore/go-experimental/go-petstore/docs/UserApi.md
+++ b/samples/client/petstore/go-experimental/go-petstore/docs/UserApi.md
@@ -17,19 +17,24 @@ Method | HTTP request | Description
 
 ## CreateUser
 
-> CreateUser(ctx, body)
+> CreateUser(ctx).Body(body).Execute()
 
 Create user
 
-This can only be done by the logged in user.
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCreateUserRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**body** | [**User**](User.md)| Created user object | 
+ **body** | [**User**](User.md) | Created user object | 
 
 ### Return type
 
@@ -51,17 +56,22 @@ No authorization required
 
 ## CreateUsersWithArrayInput
 
-> CreateUsersWithArrayInput(ctx, body)
+> CreateUsersWithArrayInput(ctx).Body(body).Execute()
 
 Creates list of users with given input array
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCreateUsersWithArrayInputRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**body** | [**[]User**](User.md)| List of user object | 
+ **body** | [**[]User**](User.md) | List of user object | 
 
 ### Return type
 
@@ -83,17 +93,22 @@ No authorization required
 
 ## CreateUsersWithListInput
 
-> CreateUsersWithListInput(ctx, body)
+> CreateUsersWithListInput(ctx).Body(body).Execute()
 
 Creates list of users with given input array
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCreateUsersWithListInputRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**body** | [**[]User**](User.md)| List of user object | 
+ **body** | [**[]User**](User.md) | List of user object | 
 
 ### Return type
 
@@ -115,19 +130,28 @@ No authorization required
 
 ## DeleteUser
 
-> DeleteUser(ctx, username)
+> DeleteUser(ctx, username).Execute()
 
 Delete user
 
-This can only be done by the logged in user.
 
-### Required Parameters
+
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**username** | **string**| The name that needs to be deleted | 
+**username** | **string** | The name that needs to be deleted | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiDeleteUserRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 
@@ -149,17 +173,26 @@ No authorization required
 
 ## GetUserByName
 
-> User GetUserByName(ctx, username)
+> User GetUserByName(ctx, username).Execute()
 
 Get user by user name
 
-### Required Parameters
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**username** | **string**| The name that needs to be fetched. Use user1 for testing. | 
+**username** | **string** | The name that needs to be fetched. Use user1 for testing. | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetUserByNameRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 
@@ -181,18 +214,23 @@ No authorization required
 
 ## LoginUser
 
-> string LoginUser(ctx, username, password)
+> string LoginUser(ctx).Username(username).Password(password).Execute()
 
 Logs user into the system
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiLoginUserRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**username** | **string**| The user name for login | 
-**password** | **string**| The password for login in clear text | 
+ **username** | **string** | The user name for login | 
+ **password** | **string** | The password for login in clear text | 
 
 ### Return type
 
@@ -214,13 +252,18 @@ No authorization required
 
 ## LogoutUser
 
-> LogoutUser(ctx, )
+> LogoutUser(ctx).Execute()
 
 Logs out current logged in user session
 
-### Required Parameters
+### Path Parameters
 
 This endpoint does not need any parameter.
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiLogoutUserRequest struct via the builder pattern
+
 
 ### Return type
 
@@ -242,20 +285,29 @@ No authorization required
 
 ## UpdateUser
 
-> UpdateUser(ctx, username, body)
+> UpdateUser(ctx, username).Body(body).Execute()
 
 Updated user
 
-This can only be done by the logged in user.
 
-### Required Parameters
+
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**username** | **string**| name that need to be deleted | 
-**body** | [**User**](User.md)| Updated user object | 
+**username** | **string** | name that need to be deleted | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiUpdateUserRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+ **body** | [**User**](User.md) | Updated user object | 
 
 ### Return type
 

--- a/samples/client/petstore/go-experimental/pet_api_test.go
+++ b/samples/client/petstore/go-experimental/pet_api_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/antihax/optional"
 	"github.com/stretchr/testify/assert"
 
 	sw "./go-petstore"
@@ -32,7 +31,7 @@ func TestAddPet(t *testing.T) {
 		PhotoUrls: []string{"http://1.com", "http://2.com"}, Status: sw.PtrString("pending"),
 		Tags: &[]sw.Tag{sw.Tag{Id: sw.PtrInt64(1), Name: sw.PtrString("tag2")}}})
 
-	r, err := client.PetApi.AddPet(context.Background(), newPet)
+	r, err := client.PetApi.AddPet(context.Background()).Body(newPet).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while adding pet: %v", err)
@@ -43,7 +42,7 @@ func TestAddPet(t *testing.T) {
 }
 
 func TestFindPetsByStatusWithMissingParam(t *testing.T) {
-	_, r, err := client.PetApi.FindPetsByStatus(context.Background(), nil)
+	_, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status(nil).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while testing TestFindPetsByStatusWithMissingParam: %v", err)
@@ -58,7 +57,7 @@ func TestGetPetById(t *testing.T) {
 }
 
 func TestGetPetByIdWithInvalidID(t *testing.T) {
-	resp, r, err := client.PetApi.GetPetById(context.Background(), 999999999)
+	resp, r, err := client.PetApi.GetPetById(context.Background(), 999999999).Execute()
 	if r != nil && r.StatusCode == 404 {
 		assertedError, ok := err.(sw.GenericOpenAPIError)
 		a := assert.New(t)
@@ -75,10 +74,7 @@ func TestGetPetByIdWithInvalidID(t *testing.T) {
 }
 
 func TestUpdatePetWithForm(t *testing.T) {
-	r, err := client.PetApi.UpdatePetWithForm(context.Background(), 12830, &sw.UpdatePetWithFormOpts{
-		Name:   optional.NewString("golang"),
-		Status: optional.NewString("available"),
-	})
+	r, err := client.PetApi.UpdatePetWithForm(context.Background(), 12830).Name("golang").Status("available").Execute()
 	if err != nil {
 		t.Fatalf("Error while updating pet by id: %v", err)
 		t.Log(r)
@@ -93,7 +89,7 @@ func TestUpdatePetWithForm(t *testing.T) {
 
 func TestFindPetsByTag(t *testing.T) {
 	var found = false
-	resp, r, err := client.PetApi.FindPetsByTags(context.Background(), []string{"tag2"})
+	resp, r, err := client.PetApi.FindPetsByTags(context.Background()).Tags([]string{"tag2"}).Execute()
 	if err != nil {
 		t.Fatalf("Error while getting pet by tag: %v", err)
 		t.Log(r)
@@ -122,7 +118,7 @@ func TestFindPetsByTag(t *testing.T) {
 }
 
 func TestFindPetsByStatus(t *testing.T) {
-	resp, r, err := client.PetApi.FindPetsByStatus(context.Background(), []string{"available"})
+	resp, r, err := client.PetApi.FindPetsByStatus(context.Background()).Status([]string{"available"}).Execute()
 	if err != nil {
 		t.Fatalf("Error while getting pet by id: %v", err)
 		t.Log(r)
@@ -145,10 +141,7 @@ func TestFindPetsByStatus(t *testing.T) {
 func TestUploadFile(t *testing.T) {
 	file, _ := os.Open("../python/testfiles/foo.png")
 
-	_, r, err := client.PetApi.UploadFile(context.Background(), 12830, &sw.UploadFileOpts{
-		AdditionalMetadata: optional.NewString("golang"),
-		File:               optional.NewInterface(file),
-	})
+	_, r, err := client.PetApi.UploadFile(context.Background(), 12830).AdditionalMetadata("golang").File(file).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
@@ -163,11 +156,7 @@ func TestUploadFileRequired(t *testing.T) {
 	return // remove when server supports this endpoint
 	file, _ := os.Open("../python/testfiles/foo.png")
 
-	_, r, err := client.PetApi.UploadFileWithRequiredFile(context.Background(), 12830,
-		file,
-		&sw.UploadFileWithRequiredFileOpts{
-			AdditionalMetadata: optional.NewString("golang"),
-		})
+	_, r, err := client.PetApi.UploadFileWithRequiredFile(context.Background(), 12830).RequiredFile(file).AdditionalMetadata("golang").Execute()
 
 	if err != nil {
 		t.Fatalf("Error while uploading file: %v", err)
@@ -179,7 +168,7 @@ func TestUploadFileRequired(t *testing.T) {
 }
 
 func TestDeletePet(t *testing.T) {
-	r, err := client.PetApi.DeletePet(context.Background(), 12830, nil)
+	r, err := client.PetApi.DeletePet(context.Background(), 12830).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
@@ -269,7 +258,7 @@ func waitOnFunctions(t *testing.T, errc chan error, n int) {
 }
 
 func deletePet(t *testing.T, id int64) {
-	r, err := client.PetApi.DeletePet(context.Background(), id, nil)
+	r, err := client.PetApi.DeletePet(context.Background(), id).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while deleting pet by id: %v", err)
@@ -281,7 +270,7 @@ func deletePet(t *testing.T, id int64) {
 
 func isPetCorrect(t *testing.T, id int64, name string, status string) {
 	assert := assert.New(t)
-	resp, r, err := client.PetApi.GetPetById(context.Background(), id)
+	resp, r, err := client.PetApi.GetPetById(context.Background(), id).Execute()
 	if err != nil {
 		t.Fatalf("Error while getting pet by id: %v", err)
 	} else {

--- a/samples/client/petstore/go-experimental/store_api_test.go
+++ b/samples/client/petstore/go-experimental/store_api_test.go
@@ -18,7 +18,7 @@ func TestPlaceOrder(t *testing.T) {
 		Status:   sw.PtrString("placed"),
 		Complete: sw.PtrBool(false)}
 
-	_, r, err := client.StoreApi.PlaceOrder(context.Background(), newOrder)
+	_, r, err := client.StoreApi.PlaceOrder(context.Background()).Body(newOrder).Execute()
 
 	if err != nil {
 		// Skip parsing time error due to error in Petstore Test Server

--- a/samples/client/petstore/go-experimental/user_api_test.go
+++ b/samples/client/petstore/go-experimental/user_api_test.go
@@ -20,7 +20,7 @@ func TestCreateUser(t *testing.T) {
 		Phone:      sw.PtrString("5101112222"),
 		UserStatus: sw.PtrInt32(1)}
 
-	apiResponse, err := client.UserApi.CreateUser(context.Background(), newUser)
+	apiResponse, err := client.UserApi.CreateUser(context.Background()).Body(newUser).Execute()
 
 	if err != nil {
 		t.Fatalf("Error while adding user: %v", err)
@@ -55,7 +55,7 @@ func TestCreateUsersWithArrayInput(t *testing.T) {
 		},
 	}
 
-	apiResponse, err := client.UserApi.CreateUsersWithArrayInput(context.Background(), newUsers)
+	apiResponse, err := client.UserApi.CreateUsersWithArrayInput(context.Background()).Body(newUsers).Execute()
 	if err != nil {
 		t.Fatalf("Error while adding users: %v", err)
 	}
@@ -64,13 +64,13 @@ func TestCreateUsersWithArrayInput(t *testing.T) {
 	}
 
 	//tear down
-	_, err1 := client.UserApi.DeleteUser(context.Background(), "gopher1")
+	_, err1 := client.UserApi.DeleteUser(context.Background(), "gopher1").Execute()
 	if err1 != nil {
 		t.Errorf("Error while deleting user")
 		t.Log(err1)
 	}
 
-	_, err2 := client.UserApi.DeleteUser(context.Background(), "gopher2")
+	_, err2 := client.UserApi.DeleteUser(context.Background(), "gopher2").Execute()
 	if err2 != nil {
 		t.Errorf("Error while deleting user")
 		t.Log(err2)
@@ -80,7 +80,7 @@ func TestCreateUsersWithArrayInput(t *testing.T) {
 func TestGetUserByName(t *testing.T) {
 	assert := assert.New(t)
 
-	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher")
+	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher").Execute()
 	if err != nil {
 		t.Fatalf("Error while getting user by id: %v", err)
 	} else {
@@ -95,7 +95,7 @@ func TestGetUserByName(t *testing.T) {
 }
 
 func TestGetUserByNameWithInvalidID(t *testing.T) {
-	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "999999999")
+	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "999999999").Execute()
 	if apiResponse != nil && apiResponse.StatusCode == 404 {
 		return // This is a pass condition. API will return with a 404 error.
 	} else if err != nil {
@@ -122,7 +122,7 @@ func TestUpdateUser(t *testing.T) {
 		Phone:      sw.PtrString("5101112222"),
 		UserStatus: sw.PtrInt32(1)}
 
-	apiResponse, err := client.UserApi.UpdateUser(context.Background(), "gopher", newUser)
+	apiResponse, err := client.UserApi.UpdateUser(context.Background(), "gopher").Body(newUser).Execute()
 	if err != nil {
 		t.Fatalf("Error while deleting user by id: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestUpdateUser(t *testing.T) {
 	}
 
 	//verify changings are correct
-	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher")
+	resp, apiResponse, err := client.UserApi.GetUserByName(context.Background(), "gopher").Execute()
 	if err != nil {
 		t.Fatalf("Error while getting user by id: %v", err)
 	} else {
@@ -142,7 +142,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestDeleteUser(t *testing.T) {
-	apiResponse, err := client.UserApi.DeleteUser(context.Background(), "gopher")
+	apiResponse, err := client.UserApi.DeleteUser(context.Background(), "gopher").Execute()
 
 	if err != nil {
 		t.Fatalf("Error while deleting user: %v", err)

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -25,15 +25,15 @@ var (
 type AnotherFakeApiService service
 
 type apiCall123TestSpecialTagsRequest struct {
-    ctx _context.Context
-    apiService *AnotherFakeApiService
-    client *Client
+	ctx _context.Context
+	apiService *AnotherFakeApiService
+	client *Client
 }
 
 
 func (r apiCall123TestSpecialTagsRequest) Client(client Client) apiCall123TestSpecialTagsRequest {
-    r.client = &client
-    return r
+	r.client = &client
+	return r
 }
 
 /*
@@ -43,10 +43,10 @@ To test special tags and operation ID starting with number
 @return apiCall123TestSpecialTagsRequest
 */
 func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context) apiCall123TestSpecialTagsRequest {
-    return apiCall123TestSpecialTagsRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiCall123TestSpecialTagsRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -63,25 +63,20 @@ func (r apiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response,
 		localVarReturnValue  Client
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "AnotherFakeApiService.Call123TestSpecialTags")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "AnotherFakeApiService.Call123TestSpecialTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/another-fake/dummy"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/another-fake/dummy"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.client == nil {
-        return localVarReturnValue, nil, reportError("client is required and must be specified")
-    }
+	if r.client == nil {
+		return localVarReturnValue, nil, reportError("client is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -101,7 +96,7 @@ func (r apiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response,
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.client
+	localVarPostBody = r.client
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_another_fake.go
@@ -24,14 +24,36 @@ var (
 // AnotherFakeApiService AnotherFakeApi service
 type AnotherFakeApiService service
 
+type apiCall123TestSpecialTagsRequest struct {
+    ctx _context.Context
+    apiService *AnotherFakeApiService
+    client *Client
+}
+
+
+func (r apiCall123TestSpecialTagsRequest) Client(client Client) apiCall123TestSpecialTagsRequest {
+    r.client = &client
+    return r
+}
+
 /*
 Call123TestSpecialTags To test special tags
 To test special tags and operation ID starting with number
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param client client model
-@return Client
+@return apiCall123TestSpecialTagsRequest
 */
-func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, client Client) (Client, *_nethttp.Response, error) {
+func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context) apiCall123TestSpecialTagsRequest {
+    return apiCall123TestSpecialTagsRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return Client
+*/
+func (r apiCall123TestSpecialTagsRequest) Execute() (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -41,6 +63,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, cli
 		localVarReturnValue  Client
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "AnotherFakeApiService.Call123TestSpecialTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -48,9 +71,17 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, cli
 
 	localVarPath := localBasePath + "/another-fake/dummy"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/another-fake/dummy"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.client == nil {
+        return localVarReturnValue, nil, reportError("client is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -70,13 +101,13 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, cli
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &client
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.client
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -94,7 +125,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, cli
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Client
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -104,7 +135,7 @@ func (a *AnotherFakeApiService) Call123TestSpecialTags(ctx _context.Context, cli
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
@@ -24,12 +24,29 @@ var (
 // DefaultApiService DefaultApi service
 type DefaultApiService service
 
+type apiFooGetRequest struct {
+    ctx _context.Context
+    apiService *DefaultApiService
+}
+
+
 /*
 FooGet Method for FooGet
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-@return InlineResponseDefault
+@return apiFooGetRequest
 */
-func (a *DefaultApiService) FooGet(ctx _context.Context) (InlineResponseDefault, *_nethttp.Response, error) {
+func (a *DefaultApiService) FooGet(ctx _context.Context) apiFooGetRequest {
+    return apiFooGetRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return InlineResponseDefault
+*/
+func (r apiFooGetRequest) Execute() (InlineResponseDefault, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -39,6 +56,7 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) (InlineResponseDefault,
 		localVarReturnValue  InlineResponseDefault
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "DefaultApiService.FooGet")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -46,6 +64,10 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) (InlineResponseDefault,
 
 	localVarPath := localBasePath + "/foo"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/foo"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -67,12 +89,12 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) (InlineResponseDefault,
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -89,7 +111,7 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) (InlineResponseDefault,
 			error: localVarHTTPResponse.Status,
 		}
 			var v InlineResponseDefault
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -98,7 +120,7 @@ func (a *DefaultApiService) FooGet(ctx _context.Context) (InlineResponseDefault,
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_default.go
@@ -25,8 +25,8 @@ var (
 type DefaultApiService service
 
 type apiFooGetRequest struct {
-    ctx _context.Context
-    apiService *DefaultApiService
+	ctx _context.Context
+	apiService *DefaultApiService
 }
 
 
@@ -36,10 +36,10 @@ FooGet Method for FooGet
 @return apiFooGetRequest
 */
 func (a *DefaultApiService) FooGet(ctx _context.Context) apiFooGetRequest {
-    return apiFooGetRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFooGetRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -56,18 +56,13 @@ func (r apiFooGetRequest) Execute() (InlineResponseDefault, *_nethttp.Response, 
 		localVarReturnValue  InlineResponseDefault
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "DefaultApiService.FooGet")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "DefaultApiService.FooGet")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/foo"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/foo"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -14,8 +14,8 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"github.com/antihax/optional"
 	"os"
+	"time"
 	"reflect"
 )
 
@@ -27,12 +27,29 @@ var (
 // FakeApiService FakeApi service
 type FakeApiService service
 
+type apiFakeHealthGetRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+}
+
+
 /*
 FakeHealthGet Health check endpoint
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-@return HealthCheckResult
+@return apiFakeHealthGetRequest
 */
-func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult, *_nethttp.Response, error) {
+func (a *FakeApiService) FakeHealthGet(ctx _context.Context) apiFakeHealthGetRequest {
+    return apiFakeHealthGetRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return HealthCheckResult
+*/
+func (r apiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -42,6 +59,7 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 		localVarReturnValue  HealthCheckResult
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeHealthGet")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -49,6 +67,10 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 
 	localVarPath := localBasePath + "/fake/health"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/health"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -70,12 +92,12 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -93,7 +115,7 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v HealthCheckResult
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -103,7 +125,7 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -114,21 +136,36 @@ func (a *FakeApiService) FakeHealthGet(ctx _context.Context) (HealthCheckResult,
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiFakeOuterBooleanSerializeRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    body *bool
+}
 
-// FakeOuterBooleanSerializeOpts Optional parameters for the method 'FakeOuterBooleanSerialize'
-type FakeOuterBooleanSerializeOpts struct {
-    Body optional.Bool
+
+func (r apiFakeOuterBooleanSerializeRequest) Body(body bool) apiFakeOuterBooleanSerializeRequest {
+    r.body = &body
+    return r
 }
 
 /*
 FakeOuterBooleanSerialize Method for FakeOuterBooleanSerialize
 Test serialization of outer boolean types
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *FakeOuterBooleanSerializeOpts - Optional Parameters:
- * @param "Body" (optional.Bool) -  Input boolean as post body
-@return bool
+@return apiFakeOuterBooleanSerializeRequest
 */
-func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVarOptionals *FakeOuterBooleanSerializeOpts) (bool, *_nethttp.Response, error) {
+func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context) apiFakeOuterBooleanSerializeRequest {
+    return apiFakeOuterBooleanSerializeRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return bool
+*/
+func (r apiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -138,6 +175,7 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		localVarReturnValue  bool
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterBooleanSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -145,10 +183,14 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 
 	localVarPath := localBasePath + "/fake/outer/boolean"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/boolean"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
 
@@ -167,16 +209,13 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
-		localVarPostBody = localVarOptionals.Body.Value()
-	}
-
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -194,7 +233,7 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v bool
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -204,7 +243,7 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -215,21 +254,36 @@ func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context, localVa
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiFakeOuterCompositeSerializeRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    outerComposite *OuterComposite
+}
 
-// FakeOuterCompositeSerializeOpts Optional parameters for the method 'FakeOuterCompositeSerialize'
-type FakeOuterCompositeSerializeOpts struct {
-    OuterComposite optional.Interface
+
+func (r apiFakeOuterCompositeSerializeRequest) OuterComposite(outerComposite OuterComposite) apiFakeOuterCompositeSerializeRequest {
+    r.outerComposite = &outerComposite
+    return r
 }
 
 /*
 FakeOuterCompositeSerialize Method for FakeOuterCompositeSerialize
 Test serialization of object with outer number type
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *FakeOuterCompositeSerializeOpts - Optional Parameters:
- * @param "OuterComposite" (optional.Interface of OuterComposite) -  Input composite as post body
-@return OuterComposite
+@return apiFakeOuterCompositeSerializeRequest
 */
-func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, localVarOptionals *FakeOuterCompositeSerializeOpts) (OuterComposite, *_nethttp.Response, error) {
+func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context) apiFakeOuterCompositeSerializeRequest {
+    return apiFakeOuterCompositeSerializeRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return OuterComposite
+*/
+func (r apiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -239,6 +293,7 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		localVarReturnValue  OuterComposite
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterCompositeSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -246,10 +301,14 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 
 	localVarPath := localBasePath + "/fake/outer/composite"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/composite"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
 
@@ -268,20 +327,13 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	if localVarOptionals != nil && localVarOptionals.OuterComposite.IsSet() {
-		localVarOptionalOuterComposite, localVarOptionalOuterCompositeok := localVarOptionals.OuterComposite.Value().(OuterComposite)
-		if !localVarOptionalOuterCompositeok {
-			return localVarReturnValue, nil, reportError("outerComposite should be OuterComposite")
-		}
-		localVarPostBody = &localVarOptionalOuterComposite
-	}
-
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.outerComposite
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -299,7 +351,7 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v OuterComposite
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -309,7 +361,7 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -320,21 +372,36 @@ func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context, local
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiFakeOuterNumberSerializeRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    body *float32
+}
 
-// FakeOuterNumberSerializeOpts Optional parameters for the method 'FakeOuterNumberSerialize'
-type FakeOuterNumberSerializeOpts struct {
-    Body optional.Float32
+
+func (r apiFakeOuterNumberSerializeRequest) Body(body float32) apiFakeOuterNumberSerializeRequest {
+    r.body = &body
+    return r
 }
 
 /*
 FakeOuterNumberSerialize Method for FakeOuterNumberSerialize
 Test serialization of outer number types
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *FakeOuterNumberSerializeOpts - Optional Parameters:
- * @param "Body" (optional.Float32) -  Input number as post body
-@return float32
+@return apiFakeOuterNumberSerializeRequest
 */
-func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVarOptionals *FakeOuterNumberSerializeOpts) (float32, *_nethttp.Response, error) {
+func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context) apiFakeOuterNumberSerializeRequest {
+    return apiFakeOuterNumberSerializeRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return float32
+*/
+func (r apiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -344,6 +411,7 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		localVarReturnValue  float32
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterNumberSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -351,10 +419,14 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 
 	localVarPath := localBasePath + "/fake/outer/number"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/number"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
 
@@ -373,16 +445,13 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
-		localVarPostBody = localVarOptionals.Body.Value()
-	}
-
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -400,7 +469,7 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v float32
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -410,7 +479,7 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -421,21 +490,36 @@ func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context, localVar
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiFakeOuterStringSerializeRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    body *string
+}
 
-// FakeOuterStringSerializeOpts Optional parameters for the method 'FakeOuterStringSerialize'
-type FakeOuterStringSerializeOpts struct {
-    Body optional.String
+
+func (r apiFakeOuterStringSerializeRequest) Body(body string) apiFakeOuterStringSerializeRequest {
+    r.body = &body
+    return r
 }
 
 /*
 FakeOuterStringSerialize Method for FakeOuterStringSerialize
 Test serialization of outer string types
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *FakeOuterStringSerializeOpts - Optional Parameters:
- * @param "Body" (optional.String) -  Input string as post body
-@return string
+@return apiFakeOuterStringSerializeRequest
 */
-func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVarOptionals *FakeOuterStringSerializeOpts) (string, *_nethttp.Response, error) {
+func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context) apiFakeOuterStringSerializeRequest {
+    return apiFakeOuterStringSerializeRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return string
+*/
+func (r apiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -445,6 +529,7 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		localVarReturnValue  string
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterStringSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -452,10 +537,14 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 
 	localVarPath := localBasePath + "/fake/outer/string"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/string"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
 
@@ -474,16 +563,13 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
-		localVarPostBody = localVarOptionals.Body.Value()
-	}
-
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.body
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -501,7 +587,7 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v string
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -511,7 +597,7 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -522,22 +608,46 @@ func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context, localVar
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiTestBodyWithFileSchemaRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    fileSchemaTestClass *FileSchemaTestClass
+}
+
+
+func (r apiTestBodyWithFileSchemaRequest) FileSchemaTestClass(fileSchemaTestClass FileSchemaTestClass) apiTestBodyWithFileSchemaRequest {
+    r.fileSchemaTestClass = &fileSchemaTestClass
+    return r
+}
 
 /*
 TestBodyWithFileSchema Method for TestBodyWithFileSchema
-For this test, the body for this request much reference a schema named &#x60;File&#x60;.
+For this test, the body for this request much reference a schema named `File`.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param fileSchemaTestClass
+@return apiTestBodyWithFileSchemaRequest
 */
-func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, fileSchemaTestClass FileSchemaTestClass) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context) apiTestBodyWithFileSchemaRequest {
+    return apiTestBodyWithFileSchemaRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithFileSchema")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -545,9 +655,17 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, fileSchema
 
 	localVarPath := localBasePath + "/fake/body-with-file-schema"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/body-with-file-schema"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.fileSchemaTestClass == nil {
+        return nil, reportError("fileSchemaTestClass is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -567,13 +685,13 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, fileSchema
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &fileSchemaTestClass
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.fileSchemaTestClass
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -594,22 +712,51 @@ func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context, fileSchema
 
 	return localVarHTTPResponse, nil
 }
+type apiTestBodyWithQueryParamsRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    query *string
+    user *User
+}
+
+
+func (r apiTestBodyWithQueryParamsRequest) Query(query string) apiTestBodyWithQueryParamsRequest {
+    r.query = &query
+    return r
+}
+
+func (r apiTestBodyWithQueryParamsRequest) User(user User) apiTestBodyWithQueryParamsRequest {
+    r.user = &user
+    return r
+}
 
 /*
 TestBodyWithQueryParams Method for TestBodyWithQueryParams
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param query
- * @param user
+@return apiTestBodyWithQueryParamsRequest
 */
-func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query string, user User) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context) apiTestBodyWithQueryParamsRequest {
+    return apiTestBodyWithQueryParamsRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithQueryParams")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -617,11 +764,23 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 
 	localVarPath := localBasePath + "/fake/body-with-query-params"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/body-with-query-params"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.query == nil {
+        return nil, reportError("query is required and must be specified")
+    }
+	
+    if r.user == nil {
+        return nil, reportError("user is required and must be specified")
+    }
 
-	localVarQueryParams.Add("query", parameterToString(query, ""))
+	localVarQueryParams.Add("query", parameterToString(*r.query, ""))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
 
@@ -640,13 +799,13 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &user
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.user
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -667,15 +826,36 @@ func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context, query str
 
 	return localVarHTTPResponse, nil
 }
+type apiTestClientModelRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    client *Client
+}
+
+
+func (r apiTestClientModelRequest) Client(client Client) apiTestClientModelRequest {
+    r.client = &client
+    return r
+}
 
 /*
 TestClientModel To test \"client\" model
-To test \&quot;client\&quot; model
+To test "client" model
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param client client model
-@return Client
+@return apiTestClientModelRequest
 */
-func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (Client, *_nethttp.Response, error) {
+func (a *FakeApiService) TestClientModel(ctx _context.Context) apiTestClientModelRequest {
+    return apiTestClientModelRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return Client
+*/
+func (r apiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -685,6 +865,7 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (C
 		localVarReturnValue  Client
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestClientModel")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -692,9 +873,17 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (C
 
 	localVarPath := localBasePath + "/fake"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.client == nil {
+        return localVarReturnValue, nil, reportError("client is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -714,13 +903,13 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (C
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &client
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.client
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -738,7 +927,7 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (C
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Client
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -748,7 +937,7 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (C
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -759,50 +948,128 @@ func (a *FakeApiService) TestClientModel(ctx _context.Context, client Client) (C
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiTestEndpointParametersRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    number *float32
+    double *float64
+    patternWithoutDelimiter *string
+    byte_ *string
+    integer *int32
+    int32_ *int32
+    int64_ *int64
+    float *float32
+    string_ *string
+    binary **os.File
+    date *string
+    dateTime *time.Time
+    password *string
+    callback *string
+}
 
-// TestEndpointParametersOpts Optional parameters for the method 'TestEndpointParameters'
-type TestEndpointParametersOpts struct {
-    Integer optional.Int32
-    Int32_ optional.Int32
-    Int64_ optional.Int64
-    Float optional.Float32
-    String_ optional.String
-    Binary optional.Interface
-    Date optional.String
-    DateTime optional.Time
-    Password optional.String
-    Callback optional.String
+
+func (r apiTestEndpointParametersRequest) Number(number float32) apiTestEndpointParametersRequest {
+    r.number = &number
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Double(double float64) apiTestEndpointParametersRequest {
+    r.double = &double
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithoutDelimiter string) apiTestEndpointParametersRequest {
+    r.patternWithoutDelimiter = &patternWithoutDelimiter
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Byte_(byte_ string) apiTestEndpointParametersRequest {
+    r.byte_ = &byte_
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Integer(integer int32) apiTestEndpointParametersRequest {
+    r.integer = &integer
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Int32_(int32_ int32) apiTestEndpointParametersRequest {
+    r.int32_ = &int32_
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Int64_(int64_ int64) apiTestEndpointParametersRequest {
+    r.int64_ = &int64_
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Float(float float32) apiTestEndpointParametersRequest {
+    r.float = &float
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) String_(string_ string) apiTestEndpointParametersRequest {
+    r.string_ = &string_
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Binary(binary *os.File) apiTestEndpointParametersRequest {
+    r.binary = &binary
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Date(date string) apiTestEndpointParametersRequest {
+    r.date = &date
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) DateTime(dateTime time.Time) apiTestEndpointParametersRequest {
+    r.dateTime = &dateTime
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Password(password string) apiTestEndpointParametersRequest {
+    r.password = &password
+    return r
+}
+
+func (r apiTestEndpointParametersRequest) Callback(callback string) apiTestEndpointParametersRequest {
+    r.callback = &callback
+    return r
 }
 
 /*
 TestEndpointParameters Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
-Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
+Fake endpoint for testing various parameters
+假端點
+偽のエンドポイント
+가짜 엔드 포인트
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param number None
- * @param double None
- * @param patternWithoutDelimiter None
- * @param byte_ None
- * @param optional nil or *TestEndpointParametersOpts - Optional Parameters:
- * @param "Integer" (optional.Int32) -  None
- * @param "Int32_" (optional.Int32) -  None
- * @param "Int64_" (optional.Int64) -  None
- * @param "Float" (optional.Float32) -  None
- * @param "String_" (optional.String) -  None
- * @param "Binary" (optional.Interface of *os.File) -  None
- * @param "Date" (optional.String) -  None
- * @param "DateTime" (optional.Time) -  None
- * @param "Password" (optional.String) -  None
- * @param "Callback" (optional.String) -  None
+@return apiTestEndpointParametersRequest
 */
-func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number float32, double float64, patternWithoutDelimiter string, byte_ string, localVarOptionals *TestEndpointParametersOpts) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestEndpointParameters(ctx _context.Context) apiTestEndpointParametersRequest {
+    return apiTestEndpointParametersRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEndpointParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -810,22 +1077,42 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 
 	localVarPath := localBasePath + "/fake"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if number < 32.1 {
+	
+    if r.number == nil {
+        return nil, reportError("number is required and must be specified")
+    }
+	if *r.number < 32.1 {
 		return nil, reportError("number must be greater than 32.1")
 	}
-	if number > 543.2 {
+	if *r.number > 543.2 {
 		return nil, reportError("number must be less than 543.2")
 	}
-	if double < 67.8 {
+	
+    if r.double == nil {
+        return nil, reportError("double is required and must be specified")
+    }
+	if *r.double < 67.8 {
 		return nil, reportError("double must be greater than 67.8")
 	}
-	if double > 123.4 {
+	if *r.double > 123.4 {
 		return nil, reportError("double must be less than 123.4")
 	}
-
+	
+    if r.patternWithoutDelimiter == nil {
+        return nil, reportError("patternWithoutDelimiter is required and must be specified")
+    }
+	
+    if r.byte_ == nil {
+        return nil, reportError("byte_ is required and must be specified")
+    }
+										
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
 
@@ -843,33 +1130,29 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.Integer.IsSet() {
-		localVarFormParams.Add("integer", parameterToString(localVarOptionals.Integer.Value(), ""))
+	if r.integer != nil {
+		localVarFormParams.Add("integer", parameterToString(*r.integer, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Int32_.IsSet() {
-		localVarFormParams.Add("int32", parameterToString(localVarOptionals.Int32_.Value(), ""))
+	if r.int32_ != nil {
+		localVarFormParams.Add("int32", parameterToString(*r.int32_, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Int64_.IsSet() {
-		localVarFormParams.Add("int64", parameterToString(localVarOptionals.Int64_.Value(), ""))
+	if r.int64_ != nil {
+		localVarFormParams.Add("int64", parameterToString(*r.int64_, ""))
 	}
-	localVarFormParams.Add("number", parameterToString(number, ""))
-	if localVarOptionals != nil && localVarOptionals.Float.IsSet() {
-		localVarFormParams.Add("float", parameterToString(localVarOptionals.Float.Value(), ""))
+	localVarFormParams.Add("number", parameterToString(*r.number, ""))
+	if r.float != nil {
+		localVarFormParams.Add("float", parameterToString(*r.float, ""))
 	}
-	localVarFormParams.Add("double", parameterToString(double, ""))
-	if localVarOptionals != nil && localVarOptionals.String_.IsSet() {
-		localVarFormParams.Add("string", parameterToString(localVarOptionals.String_.Value(), ""))
+	localVarFormParams.Add("double", parameterToString(*r.double, ""))
+	if r.string_ != nil {
+		localVarFormParams.Add("string", parameterToString(*r.string_, ""))
 	}
-	localVarFormParams.Add("pattern_without_delimiter", parameterToString(patternWithoutDelimiter, ""))
-	localVarFormParams.Add("byte", parameterToString(byte_, ""))
+	localVarFormParams.Add("pattern_without_delimiter", parameterToString(*r.patternWithoutDelimiter, ""))
+	localVarFormParams.Add("byte", parameterToString(*r.byte_, ""))
 	localVarFormFileName = "binary"
 	var localVarFile *os.File
-	if localVarOptionals != nil && localVarOptionals.Binary.IsSet() {
-		localVarFileOk := false
-		localVarFile, localVarFileOk = localVarOptionals.Binary.Value().(*os.File)
-		if !localVarFileOk {
-				return nil, reportError("binary should be *os.File")
-		}
+	if r.binary != nil {
+		localVarFile = *r.binary
 	}
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
@@ -877,24 +1160,24 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 		localVarFileName = localVarFile.Name()
 		localVarFile.Close()
 	}
-	if localVarOptionals != nil && localVarOptionals.Date.IsSet() {
-		localVarFormParams.Add("date", parameterToString(localVarOptionals.Date.Value(), ""))
+	if r.date != nil {
+		localVarFormParams.Add("date", parameterToString(*r.date, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.DateTime.IsSet() {
-		localVarFormParams.Add("dateTime", parameterToString(localVarOptionals.DateTime.Value(), ""))
+	if r.dateTime != nil {
+		localVarFormParams.Add("dateTime", parameterToString(*r.dateTime, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Password.IsSet() {
-		localVarFormParams.Add("password", parameterToString(localVarOptionals.Password.Value(), ""))
+	if r.password != nil {
+		localVarFormParams.Add("password", parameterToString(*r.password, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Callback.IsSet() {
-		localVarFormParams.Add("callback", parameterToString(localVarOptionals.Callback.Value(), ""))
+	if r.callback != nil {
+		localVarFormParams.Add("callback", parameterToString(*r.callback, ""))
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -915,42 +1198,88 @@ func (a *FakeApiService) TestEndpointParameters(ctx _context.Context, number flo
 
 	return localVarHTTPResponse, nil
 }
+type apiTestEnumParametersRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    enumHeaderStringArray *[]string
+    enumHeaderString *string
+    enumQueryStringArray *[]string
+    enumQueryString *string
+    enumQueryInteger *int32
+    enumQueryDouble *float64
+    enumFormStringArray *[]string
+    enumFormString *string
+}
 
-// TestEnumParametersOpts Optional parameters for the method 'TestEnumParameters'
-type TestEnumParametersOpts struct {
-    EnumHeaderStringArray optional.Interface
-    EnumHeaderString optional.String
-    EnumQueryStringArray optional.Interface
-    EnumQueryString optional.String
-    EnumQueryInteger optional.Int32
-    EnumQueryDouble optional.Float64
-    EnumFormStringArray optional.Interface
-    EnumFormString optional.String
+
+func (r apiTestEnumParametersRequest) EnumHeaderStringArray(enumHeaderStringArray []string) apiTestEnumParametersRequest {
+    r.enumHeaderStringArray = &enumHeaderStringArray
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumHeaderString(enumHeaderString string) apiTestEnumParametersRequest {
+    r.enumHeaderString = &enumHeaderString
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumQueryStringArray(enumQueryStringArray []string) apiTestEnumParametersRequest {
+    r.enumQueryStringArray = &enumQueryStringArray
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumQueryString(enumQueryString string) apiTestEnumParametersRequest {
+    r.enumQueryString = &enumQueryString
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumQueryInteger(enumQueryInteger int32) apiTestEnumParametersRequest {
+    r.enumQueryInteger = &enumQueryInteger
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumQueryDouble(enumQueryDouble float64) apiTestEnumParametersRequest {
+    r.enumQueryDouble = &enumQueryDouble
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumFormStringArray(enumFormStringArray []string) apiTestEnumParametersRequest {
+    r.enumFormStringArray = &enumFormStringArray
+    return r
+}
+
+func (r apiTestEnumParametersRequest) EnumFormString(enumFormString string) apiTestEnumParametersRequest {
+    r.enumFormString = &enumFormString
+    return r
 }
 
 /*
 TestEnumParameters To test enum parameters
 To test enum parameters
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param optional nil or *TestEnumParametersOpts - Optional Parameters:
- * @param "EnumHeaderStringArray" (optional.Interface of []string) -  Header parameter enum test (string array)
- * @param "EnumHeaderString" (optional.String) -  Header parameter enum test (string)
- * @param "EnumQueryStringArray" (optional.Interface of []string) -  Query parameter enum test (string array)
- * @param "EnumQueryString" (optional.String) -  Query parameter enum test (string)
- * @param "EnumQueryInteger" (optional.Int32) -  Query parameter enum test (double)
- * @param "EnumQueryDouble" (optional.Float64) -  Query parameter enum test (double)
- * @param "EnumFormStringArray" (optional.Interface of []string) -  Form parameter enum test (string array)
- * @param "EnumFormString" (optional.String) -  Form parameter enum test (string)
+@return apiTestEnumParametersRequest
 */
-func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOptionals *TestEnumParametersOpts) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestEnumParameters(ctx _context.Context) apiTestEnumParametersRequest {
+    return apiTestEnumParametersRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEnumParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -958,12 +1287,16 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 
 	localVarPath := localBasePath + "/fake"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
-	if localVarOptionals != nil && localVarOptionals.EnumQueryStringArray.IsSet() {
-		t:=localVarOptionals.EnumQueryStringArray.Value()
+								
+	if r.enumQueryStringArray != nil {
+		t := *r.enumQueryStringArray
 		if reflect.TypeOf(t).Kind() == reflect.Slice {
 			s := reflect.ValueOf(t)
 			for i := 0; i < s.Len(); i++ {
@@ -973,14 +1306,14 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 			localVarQueryParams.Add("enum_query_string_array", parameterToString(t, "multi"))
 		}
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumQueryString.IsSet() {
-		localVarQueryParams.Add("enum_query_string", parameterToString(localVarOptionals.EnumQueryString.Value(), ""))
+	if r.enumQueryString != nil {
+		localVarQueryParams.Add("enum_query_string", parameterToString(*r.enumQueryString, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumQueryInteger.IsSet() {
-		localVarQueryParams.Add("enum_query_integer", parameterToString(localVarOptionals.EnumQueryInteger.Value(), ""))
+	if r.enumQueryInteger != nil {
+		localVarQueryParams.Add("enum_query_integer", parameterToString(*r.enumQueryInteger, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumQueryDouble.IsSet() {
-		localVarQueryParams.Add("enum_query_double", parameterToString(localVarOptionals.EnumQueryDouble.Value(), ""))
+	if r.enumQueryDouble != nil {
+		localVarQueryParams.Add("enum_query_double", parameterToString(*r.enumQueryDouble, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -999,24 +1332,24 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumHeaderStringArray.IsSet() {
-		localVarHeaderParams["enum_header_string_array"] = parameterToString(localVarOptionals.EnumHeaderStringArray.Value(), "csv")
+	if r.enumHeaderStringArray != nil {
+		localVarHeaderParams["enum_header_string_array"] = parameterToString(*r.enumHeaderStringArray, "csv")
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumHeaderString.IsSet() {
-		localVarHeaderParams["enum_header_string"] = parameterToString(localVarOptionals.EnumHeaderString.Value(), "")
+	if r.enumHeaderString != nil {
+		localVarHeaderParams["enum_header_string"] = parameterToString(*r.enumHeaderString, "")
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumFormStringArray.IsSet() {
-		localVarFormParams.Add("enum_form_string_array", parameterToString(localVarOptionals.EnumFormStringArray.Value(), "csv"))
+	if r.enumFormStringArray != nil {
+		localVarFormParams.Add("enum_form_string_array", parameterToString(*r.enumFormStringArray, "csv"))
 	}
-	if localVarOptionals != nil && localVarOptionals.EnumFormString.IsSet() {
-		localVarFormParams.Add("enum_form_string", parameterToString(localVarOptionals.EnumFormString.Value(), ""))
+	if r.enumFormString != nil {
+		localVarFormParams.Add("enum_form_string", parameterToString(*r.enumFormString, ""))
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -1037,35 +1370,76 @@ func (a *FakeApiService) TestEnumParameters(ctx _context.Context, localVarOption
 
 	return localVarHTTPResponse, nil
 }
+type apiTestGroupParametersRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    requiredStringGroup *int32
+    requiredBooleanGroup *bool
+    requiredInt64Group *int64
+    stringGroup *int32
+    booleanGroup *bool
+    int64Group *int64
+}
 
-// TestGroupParametersOpts Optional parameters for the method 'TestGroupParameters'
-type TestGroupParametersOpts struct {
-    StringGroup optional.Int32
-    BooleanGroup optional.Bool
-    Int64Group optional.Int64
+
+func (r apiTestGroupParametersRequest) RequiredStringGroup(requiredStringGroup int32) apiTestGroupParametersRequest {
+    r.requiredStringGroup = &requiredStringGroup
+    return r
+}
+
+func (r apiTestGroupParametersRequest) RequiredBooleanGroup(requiredBooleanGroup bool) apiTestGroupParametersRequest {
+    r.requiredBooleanGroup = &requiredBooleanGroup
+    return r
+}
+
+func (r apiTestGroupParametersRequest) RequiredInt64Group(requiredInt64Group int64) apiTestGroupParametersRequest {
+    r.requiredInt64Group = &requiredInt64Group
+    return r
+}
+
+func (r apiTestGroupParametersRequest) StringGroup(stringGroup int32) apiTestGroupParametersRequest {
+    r.stringGroup = &stringGroup
+    return r
+}
+
+func (r apiTestGroupParametersRequest) BooleanGroup(booleanGroup bool) apiTestGroupParametersRequest {
+    r.booleanGroup = &booleanGroup
+    return r
+}
+
+func (r apiTestGroupParametersRequest) Int64Group(int64Group int64) apiTestGroupParametersRequest {
+    r.int64Group = &int64Group
+    return r
 }
 
 /*
 TestGroupParameters Fake endpoint to test group parameters (optional)
 Fake endpoint to test group parameters (optional)
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param requiredStringGroup Required String in group parameters
- * @param requiredBooleanGroup Required Boolean in group parameters
- * @param requiredInt64Group Required Integer in group parameters
- * @param optional nil or *TestGroupParametersOpts - Optional Parameters:
- * @param "StringGroup" (optional.Int32) -  String in group parameters
- * @param "BooleanGroup" (optional.Bool) -  Boolean in group parameters
- * @param "Int64Group" (optional.Int64) -  Integer in group parameters
+@return apiTestGroupParametersRequest
 */
-func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStringGroup int32, requiredBooleanGroup bool, requiredInt64Group int64, localVarOptionals *TestGroupParametersOpts) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestGroupParameters(ctx _context.Context) apiTestGroupParametersRequest {
+    return apiTestGroupParametersRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestGroupParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -1073,17 +1447,33 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 
 	localVarPath := localBasePath + "/fake"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
-	localVarQueryParams.Add("required_string_group", parameterToString(requiredStringGroup, ""))
-	localVarQueryParams.Add("required_int64_group", parameterToString(requiredInt64Group, ""))
-	if localVarOptionals != nil && localVarOptionals.StringGroup.IsSet() {
-		localVarQueryParams.Add("string_group", parameterToString(localVarOptionals.StringGroup.Value(), ""))
+	
+    if r.requiredStringGroup == nil {
+        return nil, reportError("requiredStringGroup is required and must be specified")
+    }
+	
+    if r.requiredBooleanGroup == nil {
+        return nil, reportError("requiredBooleanGroup is required and must be specified")
+    }
+	
+    if r.requiredInt64Group == nil {
+        return nil, reportError("requiredInt64Group is required and must be specified")
+    }
+			
+	localVarQueryParams.Add("required_string_group", parameterToString(*r.requiredStringGroup, ""))
+	localVarQueryParams.Add("required_int64_group", parameterToString(*r.requiredInt64Group, ""))
+	if r.stringGroup != nil {
+		localVarQueryParams.Add("string_group", parameterToString(*r.stringGroup, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Int64Group.IsSet() {
-		localVarQueryParams.Add("int64_group", parameterToString(localVarOptionals.Int64Group.Value(), ""))
+	if r.int64Group != nil {
+		localVarQueryParams.Add("int64_group", parameterToString(*r.int64Group, ""))
 	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -1102,16 +1492,16 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	localVarHeaderParams["required_boolean_group"] = parameterToString(requiredBooleanGroup, "")
-	if localVarOptionals != nil && localVarOptionals.BooleanGroup.IsSet() {
-		localVarHeaderParams["boolean_group"] = parameterToString(localVarOptionals.BooleanGroup.Value(), "")
+	localVarHeaderParams["required_boolean_group"] = parameterToString(*r.requiredBooleanGroup, "")
+	if r.booleanGroup != nil {
+		localVarHeaderParams["boolean_group"] = parameterToString(*r.booleanGroup, "")
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -1132,21 +1522,45 @@ func (a *FakeApiService) TestGroupParameters(ctx _context.Context, requiredStrin
 
 	return localVarHTTPResponse, nil
 }
+type apiTestInlineAdditionalPropertiesRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    requestBody *map[string]string
+}
+
+
+func (r apiTestInlineAdditionalPropertiesRequest) RequestBody(requestBody map[string]string) apiTestInlineAdditionalPropertiesRequest {
+    r.requestBody = &requestBody
+    return r
+}
 
 /*
 TestInlineAdditionalProperties test inline additionalProperties
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param requestBody request body
+@return apiTestInlineAdditionalPropertiesRequest
 */
-func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, requestBody map[string]string) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context) apiTestInlineAdditionalPropertiesRequest {
+    return apiTestInlineAdditionalPropertiesRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestInlineAdditionalProperties")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -1154,9 +1568,17 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, re
 
 	localVarPath := localBasePath + "/fake/inline-additionalProperties"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/inline-additionalProperties"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.requestBody == nil {
+        return nil, reportError("requestBody is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -1176,13 +1598,13 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, re
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &requestBody
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.requestBody
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -1203,22 +1625,51 @@ func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context, re
 
 	return localVarHTTPResponse, nil
 }
+type apiTestJsonFormDataRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    param *string
+    param2 *string
+}
+
+
+func (r apiTestJsonFormDataRequest) Param(param string) apiTestJsonFormDataRequest {
+    r.param = &param
+    return r
+}
+
+func (r apiTestJsonFormDataRequest) Param2(param2 string) apiTestJsonFormDataRequest {
+    r.param2 = &param2
+    return r
+}
 
 /*
 TestJsonFormData test json serialization of form data
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param param field1
- * @param param2 field2
+@return apiTestJsonFormDataRequest
 */
-func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, param2 string) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestJsonFormData(ctx _context.Context) apiTestJsonFormDataRequest {
+    return apiTestJsonFormDataRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestJsonFormData")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -1226,9 +1677,21 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 
 	localVarPath := localBasePath + "/fake/jsonFormData"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/jsonFormData"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.param == nil {
+        return nil, reportError("param is required and must be specified")
+    }
+	
+    if r.param2 == nil {
+        return nil, reportError("param2 is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -1247,14 +1710,14 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	localVarFormParams.Add("param", parameterToString(param, ""))
-	localVarFormParams.Add("param2", parameterToString(param2, ""))
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarFormParams.Add("param", parameterToString(*r.param, ""))
+	localVarFormParams.Add("param2", parameterToString(*r.param2, ""))
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -1275,26 +1738,70 @@ func (a *FakeApiService) TestJsonFormData(ctx _context.Context, param string, pa
 
 	return localVarHTTPResponse, nil
 }
+type apiTestQueryParameterCollectionFormatRequest struct {
+    ctx _context.Context
+    apiService *FakeApiService
+    pipe *[]string
+    ioutil *[]string
+    http *[]string
+    url *[]string
+    context *[]string
+}
+
+
+func (r apiTestQueryParameterCollectionFormatRequest) Pipe(pipe []string) apiTestQueryParameterCollectionFormatRequest {
+    r.pipe = &pipe
+    return r
+}
+
+func (r apiTestQueryParameterCollectionFormatRequest) Ioutil(ioutil []string) apiTestQueryParameterCollectionFormatRequest {
+    r.ioutil = &ioutil
+    return r
+}
+
+func (r apiTestQueryParameterCollectionFormatRequest) Http(http []string) apiTestQueryParameterCollectionFormatRequest {
+    r.http = &http
+    return r
+}
+
+func (r apiTestQueryParameterCollectionFormatRequest) Url(url []string) apiTestQueryParameterCollectionFormatRequest {
+    r.url = &url
+    return r
+}
+
+func (r apiTestQueryParameterCollectionFormatRequest) Context(context []string) apiTestQueryParameterCollectionFormatRequest {
+    r.context = &context
+    return r
+}
 
 /*
 TestQueryParameterCollectionFormat Method for TestQueryParameterCollectionFormat
 To test the collection format in query parameters
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param pipe
- * @param ioutil
- * @param http
- * @param url
- * @param context
+@return apiTestQueryParameterCollectionFormatRequest
 */
-func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context, pipe []string, ioutil []string, http []string, url []string, context []string) (*_nethttp.Response, error) {
+func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context) apiTestQueryParameterCollectionFormatRequest {
+    return apiTestQueryParameterCollectionFormatRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestQueryParameterCollectionFormat")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -1302,11 +1809,35 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 
 	localVarPath := localBasePath + "/fake/test-query-paramters"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/test-query-paramters"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.pipe == nil {
+        return nil, reportError("pipe is required and must be specified")
+    }
+	
+    if r.ioutil == nil {
+        return nil, reportError("ioutil is required and must be specified")
+    }
+	
+    if r.http == nil {
+        return nil, reportError("http is required and must be specified")
+    }
+	
+    if r.url == nil {
+        return nil, reportError("url is required and must be specified")
+    }
+	
+    if r.context == nil {
+        return nil, reportError("context is required and must be specified")
+    }
 
-	t:=pipe
+	t := *r.pipe
 	if reflect.TypeOf(t).Kind() == reflect.Slice {
 		s := reflect.ValueOf(t)
 		for i := 0; i < s.Len(); i++ {
@@ -1315,10 +1846,10 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 	} else {
 		localVarQueryParams.Add("pipe", parameterToString(t, "multi"))
 	}
-	localVarQueryParams.Add("ioutil", parameterToString(ioutil, "csv"))
-	localVarQueryParams.Add("http", parameterToString(http, "space"))
-	localVarQueryParams.Add("url", parameterToString(url, "csv"))
-	t:=context
+	localVarQueryParams.Add("ioutil", parameterToString(*r.ioutil, "csv"))
+	localVarQueryParams.Add("http", parameterToString(*r.http, "space"))
+	localVarQueryParams.Add("url", parameterToString(*r.url, "csv"))
+	t := *r.context
 	if reflect.TypeOf(t).Kind() == reflect.Slice {
 		s := reflect.ValueOf(t)
 		for i := 0; i < s.Len(); i++ {
@@ -1344,12 +1875,12 @@ func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake.go
@@ -28,8 +28,8 @@ var (
 type FakeApiService service
 
 type apiFakeHealthGetRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
+	ctx _context.Context
+	apiService *FakeApiService
 }
 
 
@@ -39,10 +39,10 @@ FakeHealthGet Health check endpoint
 @return apiFakeHealthGetRequest
 */
 func (a *FakeApiService) FakeHealthGet(ctx _context.Context) apiFakeHealthGetRequest {
-    return apiFakeHealthGetRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFakeHealthGetRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -59,18 +59,13 @@ func (r apiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Respons
 		localVarReturnValue  HealthCheckResult
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeHealthGet")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeHealthGet")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/health"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/health"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -137,15 +132,15 @@ func (r apiFakeHealthGetRequest) Execute() (HealthCheckResult, *_nethttp.Respons
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiFakeOuterBooleanSerializeRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    body *bool
+	ctx _context.Context
+	apiService *FakeApiService
+	body *bool
 }
 
 
 func (r apiFakeOuterBooleanSerializeRequest) Body(body bool) apiFakeOuterBooleanSerializeRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -155,10 +150,10 @@ Test serialization of outer boolean types
 @return apiFakeOuterBooleanSerializeRequest
 */
 func (a *FakeApiService) FakeOuterBooleanSerialize(ctx _context.Context) apiFakeOuterBooleanSerializeRequest {
-    return apiFakeOuterBooleanSerializeRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFakeOuterBooleanSerializeRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -175,18 +170,13 @@ func (r apiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response
 		localVarReturnValue  bool
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterBooleanSerialize")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterBooleanSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/boolean"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/boolean"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -209,7 +199,7 @@ func (r apiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -255,15 +245,15 @@ func (r apiFakeOuterBooleanSerializeRequest) Execute() (bool, *_nethttp.Response
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiFakeOuterCompositeSerializeRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    outerComposite *OuterComposite
+	ctx _context.Context
+	apiService *FakeApiService
+	outerComposite *OuterComposite
 }
 
 
 func (r apiFakeOuterCompositeSerializeRequest) OuterComposite(outerComposite OuterComposite) apiFakeOuterCompositeSerializeRequest {
-    r.outerComposite = &outerComposite
-    return r
+	r.outerComposite = &outerComposite
+	return r
 }
 
 /*
@@ -273,10 +263,10 @@ Test serialization of object with outer number type
 @return apiFakeOuterCompositeSerializeRequest
 */
 func (a *FakeApiService) FakeOuterCompositeSerialize(ctx _context.Context) apiFakeOuterCompositeSerializeRequest {
-    return apiFakeOuterCompositeSerializeRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFakeOuterCompositeSerializeRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -293,18 +283,13 @@ func (r apiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_neth
 		localVarReturnValue  OuterComposite
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterCompositeSerialize")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterCompositeSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/composite"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/composite"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -327,7 +312,7 @@ func (r apiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_neth
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.outerComposite
+	localVarPostBody = r.outerComposite
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -373,15 +358,15 @@ func (r apiFakeOuterCompositeSerializeRequest) Execute() (OuterComposite, *_neth
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiFakeOuterNumberSerializeRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    body *float32
+	ctx _context.Context
+	apiService *FakeApiService
+	body *float32
 }
 
 
 func (r apiFakeOuterNumberSerializeRequest) Body(body float32) apiFakeOuterNumberSerializeRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -391,10 +376,10 @@ Test serialization of outer number types
 @return apiFakeOuterNumberSerializeRequest
 */
 func (a *FakeApiService) FakeOuterNumberSerialize(ctx _context.Context) apiFakeOuterNumberSerializeRequest {
-    return apiFakeOuterNumberSerializeRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFakeOuterNumberSerializeRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -411,18 +396,13 @@ func (r apiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Respon
 		localVarReturnValue  float32
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterNumberSerialize")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterNumberSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/number"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/number"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -445,7 +425,7 @@ func (r apiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Respon
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -491,15 +471,15 @@ func (r apiFakeOuterNumberSerializeRequest) Execute() (float32, *_nethttp.Respon
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiFakeOuterStringSerializeRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    body *string
+	ctx _context.Context
+	apiService *FakeApiService
+	body *string
 }
 
 
 func (r apiFakeOuterStringSerializeRequest) Body(body string) apiFakeOuterStringSerializeRequest {
-    r.body = &body
-    return r
+	r.body = &body
+	return r
 }
 
 /*
@@ -509,10 +489,10 @@ Test serialization of outer string types
 @return apiFakeOuterStringSerializeRequest
 */
 func (a *FakeApiService) FakeOuterStringSerialize(ctx _context.Context) apiFakeOuterStringSerializeRequest {
-    return apiFakeOuterStringSerializeRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFakeOuterStringSerializeRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -529,18 +509,13 @@ func (r apiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Respons
 		localVarReturnValue  string
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.FakeOuterStringSerialize")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.FakeOuterStringSerialize")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/outer/string"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/outer/string"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -563,7 +538,7 @@ func (r apiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Respons
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.body
+	localVarPostBody = r.body
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -609,15 +584,15 @@ func (r apiFakeOuterStringSerializeRequest) Execute() (string, *_nethttp.Respons
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiTestBodyWithFileSchemaRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    fileSchemaTestClass *FileSchemaTestClass
+	ctx _context.Context
+	apiService *FakeApiService
+	fileSchemaTestClass *FileSchemaTestClass
 }
 
 
 func (r apiTestBodyWithFileSchemaRequest) FileSchemaTestClass(fileSchemaTestClass FileSchemaTestClass) apiTestBodyWithFileSchemaRequest {
-    r.fileSchemaTestClass = &fileSchemaTestClass
-    return r
+	r.fileSchemaTestClass = &fileSchemaTestClass
+	return r
 }
 
 /*
@@ -627,10 +602,10 @@ For this test, the body for this request much reference a schema named `File`.
 @return apiTestBodyWithFileSchemaRequest
 */
 func (a *FakeApiService) TestBodyWithFileSchema(ctx _context.Context) apiTestBodyWithFileSchemaRequest {
-    return apiTestBodyWithFileSchemaRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestBodyWithFileSchemaRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -647,25 +622,20 @@ func (r apiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) 
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithFileSchema")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithFileSchema")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-file-schema"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/body-with-file-schema"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.fileSchemaTestClass == nil {
-        return nil, reportError("fileSchemaTestClass is required and must be specified")
-    }
+	if r.fileSchemaTestClass == nil {
+		return nil, reportError("fileSchemaTestClass is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -685,7 +655,7 @@ func (r apiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) 
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.fileSchemaTestClass
+	localVarPostBody = r.fileSchemaTestClass
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -713,21 +683,21 @@ func (r apiTestBodyWithFileSchemaRequest) Execute() (*_nethttp.Response, error) 
 	return localVarHTTPResponse, nil
 }
 type apiTestBodyWithQueryParamsRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    query *string
-    user *User
+	ctx _context.Context
+	apiService *FakeApiService
+	query *string
+	user *User
 }
 
 
 func (r apiTestBodyWithQueryParamsRequest) Query(query string) apiTestBodyWithQueryParamsRequest {
-    r.query = &query
-    return r
+	r.query = &query
+	return r
 }
 
 func (r apiTestBodyWithQueryParamsRequest) User(user User) apiTestBodyWithQueryParamsRequest {
-    r.user = &user
-    return r
+	r.user = &user
+	return r
 }
 
 /*
@@ -736,10 +706,10 @@ TestBodyWithQueryParams Method for TestBodyWithQueryParams
 @return apiTestBodyWithQueryParamsRequest
 */
 func (a *FakeApiService) TestBodyWithQueryParams(ctx _context.Context) apiTestBodyWithQueryParamsRequest {
-    return apiTestBodyWithQueryParamsRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestBodyWithQueryParamsRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -756,29 +726,24 @@ func (r apiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error)
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestBodyWithQueryParams")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestBodyWithQueryParams")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/body-with-query-params"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/body-with-query-params"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.query == nil {
-        return nil, reportError("query is required and must be specified")
-    }
+	if r.query == nil {
+		return nil, reportError("query is required and must be specified")
+	}
 	
-    if r.user == nil {
-        return nil, reportError("user is required and must be specified")
-    }
+	if r.user == nil {
+		return nil, reportError("user is required and must be specified")
+	}
 
 	localVarQueryParams.Add("query", parameterToString(*r.query, ""))
 	// to determine the Content-Type header
@@ -799,7 +764,7 @@ func (r apiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error)
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.user
+	localVarPostBody = r.user
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -827,15 +792,15 @@ func (r apiTestBodyWithQueryParamsRequest) Execute() (*_nethttp.Response, error)
 	return localVarHTTPResponse, nil
 }
 type apiTestClientModelRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    client *Client
+	ctx _context.Context
+	apiService *FakeApiService
+	client *Client
 }
 
 
 func (r apiTestClientModelRequest) Client(client Client) apiTestClientModelRequest {
-    r.client = &client
-    return r
+	r.client = &client
+	return r
 }
 
 /*
@@ -845,10 +810,10 @@ To test "client" model
 @return apiTestClientModelRequest
 */
 func (a *FakeApiService) TestClientModel(ctx _context.Context) apiTestClientModelRequest {
-    return apiTestClientModelRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestClientModelRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -865,25 +830,20 @@ func (r apiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error)
 		localVarReturnValue  Client
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestClientModel")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestClientModel")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.client == nil {
-        return localVarReturnValue, nil, reportError("client is required and must be specified")
-    }
+	if r.client == nil {
+		return localVarReturnValue, nil, reportError("client is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -903,7 +863,7 @@ func (r apiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error)
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.client
+	localVarPostBody = r.client
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
@@ -949,93 +909,93 @@ func (r apiTestClientModelRequest) Execute() (Client, *_nethttp.Response, error)
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiTestEndpointParametersRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    number *float32
-    double *float64
-    patternWithoutDelimiter *string
-    byte_ *string
-    integer *int32
-    int32_ *int32
-    int64_ *int64
-    float *float32
-    string_ *string
-    binary **os.File
-    date *string
-    dateTime *time.Time
-    password *string
-    callback *string
+	ctx _context.Context
+	apiService *FakeApiService
+	number *float32
+	double *float64
+	patternWithoutDelimiter *string
+	byte_ *string
+	integer *int32
+	int32_ *int32
+	int64_ *int64
+	float *float32
+	string_ *string
+	binary **os.File
+	date *string
+	dateTime *time.Time
+	password *string
+	callback *string
 }
 
 
 func (r apiTestEndpointParametersRequest) Number(number float32) apiTestEndpointParametersRequest {
-    r.number = &number
-    return r
+	r.number = &number
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Double(double float64) apiTestEndpointParametersRequest {
-    r.double = &double
-    return r
+	r.double = &double
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) PatternWithoutDelimiter(patternWithoutDelimiter string) apiTestEndpointParametersRequest {
-    r.patternWithoutDelimiter = &patternWithoutDelimiter
-    return r
+	r.patternWithoutDelimiter = &patternWithoutDelimiter
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Byte_(byte_ string) apiTestEndpointParametersRequest {
-    r.byte_ = &byte_
-    return r
+	r.byte_ = &byte_
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Integer(integer int32) apiTestEndpointParametersRequest {
-    r.integer = &integer
-    return r
+	r.integer = &integer
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Int32_(int32_ int32) apiTestEndpointParametersRequest {
-    r.int32_ = &int32_
-    return r
+	r.int32_ = &int32_
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Int64_(int64_ int64) apiTestEndpointParametersRequest {
-    r.int64_ = &int64_
-    return r
+	r.int64_ = &int64_
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Float(float float32) apiTestEndpointParametersRequest {
-    r.float = &float
-    return r
+	r.float = &float
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) String_(string_ string) apiTestEndpointParametersRequest {
-    r.string_ = &string_
-    return r
+	r.string_ = &string_
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Binary(binary *os.File) apiTestEndpointParametersRequest {
-    r.binary = &binary
-    return r
+	r.binary = &binary
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Date(date string) apiTestEndpointParametersRequest {
-    r.date = &date
-    return r
+	r.date = &date
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) DateTime(dateTime time.Time) apiTestEndpointParametersRequest {
-    r.dateTime = &dateTime
-    return r
+	r.dateTime = &dateTime
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Password(password string) apiTestEndpointParametersRequest {
-    r.password = &password
-    return r
+	r.password = &password
+	return r
 }
 
 func (r apiTestEndpointParametersRequest) Callback(callback string) apiTestEndpointParametersRequest {
-    r.callback = &callback
-    return r
+	r.callback = &callback
+	return r
 }
 
 /*
@@ -1049,10 +1009,10 @@ Fake endpoint for testing various parameters
 @return apiTestEndpointParametersRequest
 */
 func (a *FakeApiService) TestEndpointParameters(ctx _context.Context) apiTestEndpointParametersRequest {
-    return apiTestEndpointParametersRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestEndpointParametersRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1069,25 +1029,20 @@ func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) 
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEndpointParameters")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEndpointParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.number == nil {
-        return nil, reportError("number is required and must be specified")
-    }
+	if r.number == nil {
+		return nil, reportError("number is required and must be specified")
+	}
 	if *r.number < 32.1 {
 		return nil, reportError("number must be greater than 32.1")
 	}
@@ -1095,9 +1050,9 @@ func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) 
 		return nil, reportError("number must be less than 543.2")
 	}
 	
-    if r.double == nil {
-        return nil, reportError("double is required and must be specified")
-    }
+	if r.double == nil {
+		return nil, reportError("double is required and must be specified")
+	}
 	if *r.double < 67.8 {
 		return nil, reportError("double must be greater than 67.8")
 	}
@@ -1105,13 +1060,13 @@ func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) 
 		return nil, reportError("double must be less than 123.4")
 	}
 	
-    if r.patternWithoutDelimiter == nil {
-        return nil, reportError("patternWithoutDelimiter is required and must be specified")
-    }
+	if r.patternWithoutDelimiter == nil {
+		return nil, reportError("patternWithoutDelimiter is required and must be specified")
+	}
 	
-    if r.byte_ == nil {
-        return nil, reportError("byte_ is required and must be specified")
-    }
+	if r.byte_ == nil {
+		return nil, reportError("byte_ is required and must be specified")
+	}
 										
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -1199,57 +1154,57 @@ func (r apiTestEndpointParametersRequest) Execute() (*_nethttp.Response, error) 
 	return localVarHTTPResponse, nil
 }
 type apiTestEnumParametersRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    enumHeaderStringArray *[]string
-    enumHeaderString *string
-    enumQueryStringArray *[]string
-    enumQueryString *string
-    enumQueryInteger *int32
-    enumQueryDouble *float64
-    enumFormStringArray *[]string
-    enumFormString *string
+	ctx _context.Context
+	apiService *FakeApiService
+	enumHeaderStringArray *[]string
+	enumHeaderString *string
+	enumQueryStringArray *[]string
+	enumQueryString *string
+	enumQueryInteger *int32
+	enumQueryDouble *float64
+	enumFormStringArray *[]string
+	enumFormString *string
 }
 
 
 func (r apiTestEnumParametersRequest) EnumHeaderStringArray(enumHeaderStringArray []string) apiTestEnumParametersRequest {
-    r.enumHeaderStringArray = &enumHeaderStringArray
-    return r
+	r.enumHeaderStringArray = &enumHeaderStringArray
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumHeaderString(enumHeaderString string) apiTestEnumParametersRequest {
-    r.enumHeaderString = &enumHeaderString
-    return r
+	r.enumHeaderString = &enumHeaderString
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumQueryStringArray(enumQueryStringArray []string) apiTestEnumParametersRequest {
-    r.enumQueryStringArray = &enumQueryStringArray
-    return r
+	r.enumQueryStringArray = &enumQueryStringArray
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumQueryString(enumQueryString string) apiTestEnumParametersRequest {
-    r.enumQueryString = &enumQueryString
-    return r
+	r.enumQueryString = &enumQueryString
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumQueryInteger(enumQueryInteger int32) apiTestEnumParametersRequest {
-    r.enumQueryInteger = &enumQueryInteger
-    return r
+	r.enumQueryInteger = &enumQueryInteger
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumQueryDouble(enumQueryDouble float64) apiTestEnumParametersRequest {
-    r.enumQueryDouble = &enumQueryDouble
-    return r
+	r.enumQueryDouble = &enumQueryDouble
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumFormStringArray(enumFormStringArray []string) apiTestEnumParametersRequest {
-    r.enumFormStringArray = &enumFormStringArray
-    return r
+	r.enumFormStringArray = &enumFormStringArray
+	return r
 }
 
 func (r apiTestEnumParametersRequest) EnumFormString(enumFormString string) apiTestEnumParametersRequest {
-    r.enumFormString = &enumFormString
-    return r
+	r.enumFormString = &enumFormString
+	return r
 }
 
 /*
@@ -1259,10 +1214,10 @@ To test enum parameters
 @return apiTestEnumParametersRequest
 */
 func (a *FakeApiService) TestEnumParameters(ctx _context.Context) apiTestEnumParametersRequest {
-    return apiTestEnumParametersRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestEnumParametersRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1279,18 +1234,13 @@ func (r apiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestEnumParameters")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestEnumParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -1371,45 +1321,45 @@ func (r apiTestEnumParametersRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiTestGroupParametersRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    requiredStringGroup *int32
-    requiredBooleanGroup *bool
-    requiredInt64Group *int64
-    stringGroup *int32
-    booleanGroup *bool
-    int64Group *int64
+	ctx _context.Context
+	apiService *FakeApiService
+	requiredStringGroup *int32
+	requiredBooleanGroup *bool
+	requiredInt64Group *int64
+	stringGroup *int32
+	booleanGroup *bool
+	int64Group *int64
 }
 
 
 func (r apiTestGroupParametersRequest) RequiredStringGroup(requiredStringGroup int32) apiTestGroupParametersRequest {
-    r.requiredStringGroup = &requiredStringGroup
-    return r
+	r.requiredStringGroup = &requiredStringGroup
+	return r
 }
 
 func (r apiTestGroupParametersRequest) RequiredBooleanGroup(requiredBooleanGroup bool) apiTestGroupParametersRequest {
-    r.requiredBooleanGroup = &requiredBooleanGroup
-    return r
+	r.requiredBooleanGroup = &requiredBooleanGroup
+	return r
 }
 
 func (r apiTestGroupParametersRequest) RequiredInt64Group(requiredInt64Group int64) apiTestGroupParametersRequest {
-    r.requiredInt64Group = &requiredInt64Group
-    return r
+	r.requiredInt64Group = &requiredInt64Group
+	return r
 }
 
 func (r apiTestGroupParametersRequest) StringGroup(stringGroup int32) apiTestGroupParametersRequest {
-    r.stringGroup = &stringGroup
-    return r
+	r.stringGroup = &stringGroup
+	return r
 }
 
 func (r apiTestGroupParametersRequest) BooleanGroup(booleanGroup bool) apiTestGroupParametersRequest {
-    r.booleanGroup = &booleanGroup
-    return r
+	r.booleanGroup = &booleanGroup
+	return r
 }
 
 func (r apiTestGroupParametersRequest) Int64Group(int64Group int64) apiTestGroupParametersRequest {
-    r.int64Group = &int64Group
-    return r
+	r.int64Group = &int64Group
+	return r
 }
 
 /*
@@ -1419,10 +1369,10 @@ Fake endpoint to test group parameters (optional)
 @return apiTestGroupParametersRequest
 */
 func (a *FakeApiService) TestGroupParameters(ctx _context.Context) apiTestGroupParametersRequest {
-    return apiTestGroupParametersRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestGroupParametersRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1439,33 +1389,28 @@ func (r apiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestGroupParameters")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestGroupParameters")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.requiredStringGroup == nil {
-        return nil, reportError("requiredStringGroup is required and must be specified")
-    }
+	if r.requiredStringGroup == nil {
+		return nil, reportError("requiredStringGroup is required and must be specified")
+	}
 	
-    if r.requiredBooleanGroup == nil {
-        return nil, reportError("requiredBooleanGroup is required and must be specified")
-    }
+	if r.requiredBooleanGroup == nil {
+		return nil, reportError("requiredBooleanGroup is required and must be specified")
+	}
 	
-    if r.requiredInt64Group == nil {
-        return nil, reportError("requiredInt64Group is required and must be specified")
-    }
+	if r.requiredInt64Group == nil {
+		return nil, reportError("requiredInt64Group is required and must be specified")
+	}
 			
 	localVarQueryParams.Add("required_string_group", parameterToString(*r.requiredStringGroup, ""))
 	localVarQueryParams.Add("required_int64_group", parameterToString(*r.requiredInt64Group, ""))
@@ -1523,15 +1468,15 @@ func (r apiTestGroupParametersRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiTestInlineAdditionalPropertiesRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    requestBody *map[string]string
+	ctx _context.Context
+	apiService *FakeApiService
+	requestBody *map[string]string
 }
 
 
 func (r apiTestInlineAdditionalPropertiesRequest) RequestBody(requestBody map[string]string) apiTestInlineAdditionalPropertiesRequest {
-    r.requestBody = &requestBody
-    return r
+	r.requestBody = &requestBody
+	return r
 }
 
 /*
@@ -1540,10 +1485,10 @@ TestInlineAdditionalProperties test inline additionalProperties
 @return apiTestInlineAdditionalPropertiesRequest
 */
 func (a *FakeApiService) TestInlineAdditionalProperties(ctx _context.Context) apiTestInlineAdditionalPropertiesRequest {
-    return apiTestInlineAdditionalPropertiesRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestInlineAdditionalPropertiesRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1560,25 +1505,20 @@ func (r apiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response,
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestInlineAdditionalProperties")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestInlineAdditionalProperties")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/inline-additionalProperties"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/inline-additionalProperties"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.requestBody == nil {
-        return nil, reportError("requestBody is required and must be specified")
-    }
+	if r.requestBody == nil {
+		return nil, reportError("requestBody is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -1598,7 +1538,7 @@ func (r apiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response,
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.requestBody
+	localVarPostBody = r.requestBody
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -1626,21 +1566,21 @@ func (r apiTestInlineAdditionalPropertiesRequest) Execute() (*_nethttp.Response,
 	return localVarHTTPResponse, nil
 }
 type apiTestJsonFormDataRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    param *string
-    param2 *string
+	ctx _context.Context
+	apiService *FakeApiService
+	param *string
+	param2 *string
 }
 
 
 func (r apiTestJsonFormDataRequest) Param(param string) apiTestJsonFormDataRequest {
-    r.param = &param
-    return r
+	r.param = &param
+	return r
 }
 
 func (r apiTestJsonFormDataRequest) Param2(param2 string) apiTestJsonFormDataRequest {
-    r.param2 = &param2
-    return r
+	r.param2 = &param2
+	return r
 }
 
 /*
@@ -1649,10 +1589,10 @@ TestJsonFormData test json serialization of form data
 @return apiTestJsonFormDataRequest
 */
 func (a *FakeApiService) TestJsonFormData(ctx _context.Context) apiTestJsonFormDataRequest {
-    return apiTestJsonFormDataRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestJsonFormDataRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1669,29 +1609,24 @@ func (r apiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestJsonFormData")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestJsonFormData")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/jsonFormData"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/jsonFormData"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.param == nil {
-        return nil, reportError("param is required and must be specified")
-    }
+	if r.param == nil {
+		return nil, reportError("param is required and must be specified")
+	}
 	
-    if r.param2 == nil {
-        return nil, reportError("param2 is required and must be specified")
-    }
+	if r.param2 == nil {
+		return nil, reportError("param2 is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
@@ -1739,39 +1674,39 @@ func (r apiTestJsonFormDataRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiTestQueryParameterCollectionFormatRequest struct {
-    ctx _context.Context
-    apiService *FakeApiService
-    pipe *[]string
-    ioutil *[]string
-    http *[]string
-    url *[]string
-    context *[]string
+	ctx _context.Context
+	apiService *FakeApiService
+	pipe *[]string
+	ioutil *[]string
+	http *[]string
+	url *[]string
+	context *[]string
 }
 
 
 func (r apiTestQueryParameterCollectionFormatRequest) Pipe(pipe []string) apiTestQueryParameterCollectionFormatRequest {
-    r.pipe = &pipe
-    return r
+	r.pipe = &pipe
+	return r
 }
 
 func (r apiTestQueryParameterCollectionFormatRequest) Ioutil(ioutil []string) apiTestQueryParameterCollectionFormatRequest {
-    r.ioutil = &ioutil
-    return r
+	r.ioutil = &ioutil
+	return r
 }
 
 func (r apiTestQueryParameterCollectionFormatRequest) Http(http []string) apiTestQueryParameterCollectionFormatRequest {
-    r.http = &http
-    return r
+	r.http = &http
+	return r
 }
 
 func (r apiTestQueryParameterCollectionFormatRequest) Url(url []string) apiTestQueryParameterCollectionFormatRequest {
-    r.url = &url
-    return r
+	r.url = &url
+	return r
 }
 
 func (r apiTestQueryParameterCollectionFormatRequest) Context(context []string) apiTestQueryParameterCollectionFormatRequest {
-    r.context = &context
-    return r
+	r.context = &context
+	return r
 }
 
 /*
@@ -1781,10 +1716,10 @@ To test the collection format in query parameters
 @return apiTestQueryParameterCollectionFormatRequest
 */
 func (a *FakeApiService) TestQueryParameterCollectionFormat(ctx _context.Context) apiTestQueryParameterCollectionFormatRequest {
-    return apiTestQueryParameterCollectionFormatRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestQueryParameterCollectionFormatRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -1801,41 +1736,36 @@ func (r apiTestQueryParameterCollectionFormatRequest) Execute() (*_nethttp.Respo
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeApiService.TestQueryParameterCollectionFormat")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeApiService.TestQueryParameterCollectionFormat")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/test-query-paramters"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/test-query-paramters"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.pipe == nil {
-        return nil, reportError("pipe is required and must be specified")
-    }
+	if r.pipe == nil {
+		return nil, reportError("pipe is required and must be specified")
+	}
 	
-    if r.ioutil == nil {
-        return nil, reportError("ioutil is required and must be specified")
-    }
+	if r.ioutil == nil {
+		return nil, reportError("ioutil is required and must be specified")
+	}
 	
-    if r.http == nil {
-        return nil, reportError("http is required and must be specified")
-    }
+	if r.http == nil {
+		return nil, reportError("http is required and must be specified")
+	}
 	
-    if r.url == nil {
-        return nil, reportError("url is required and must be specified")
-    }
+	if r.url == nil {
+		return nil, reportError("url is required and must be specified")
+	}
 	
-    if r.context == nil {
-        return nil, reportError("context is required and must be specified")
-    }
+	if r.context == nil {
+		return nil, reportError("context is required and must be specified")
+	}
 
 	t := *r.pipe
 	if reflect.TypeOf(t).Kind() == reflect.Slice {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -24,14 +24,36 @@ var (
 // FakeClassnameTags123ApiService FakeClassnameTags123Api service
 type FakeClassnameTags123ApiService service
 
+type apiTestClassnameRequest struct {
+    ctx _context.Context
+    apiService *FakeClassnameTags123ApiService
+    client *Client
+}
+
+
+func (r apiTestClassnameRequest) Client(client Client) apiTestClassnameRequest {
+    r.client = &client
+    return r
+}
+
 /*
 TestClassname To test class name in snake case
 To test class name in snake case
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param client client model
-@return Client
+@return apiTestClassnameRequest
 */
-func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, client Client) (Client, *_nethttp.Response, error) {
+func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context) apiTestClassnameRequest {
+    return apiTestClassnameRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return Client
+*/
+func (r apiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -41,6 +63,7 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, cli
 		localVarReturnValue  Client
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeClassnameTags123ApiService.TestClassname")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -48,9 +71,17 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, cli
 
 	localVarPath := localBasePath + "/fake_classname_test"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake_classname_test"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.client == nil {
+        return localVarReturnValue, nil, reportError("client is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -70,10 +101,10 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, cli
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &client
-	if ctx != nil {
+	localVarPostBody = *r.client
+	if r.ctx != nil {
 		// API Key Authentication
-		if auth, ok := ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
 			if auth, ok := auth["api_key_query"]; ok {
 				var key string
 				if auth.Prefix != "" {
@@ -85,12 +116,12 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, cli
 			}
 		}
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -108,7 +139,7 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, cli
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Client
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -118,7 +149,7 @@ func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context, cli
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_fake_classname_tags123.go
@@ -25,15 +25,15 @@ var (
 type FakeClassnameTags123ApiService service
 
 type apiTestClassnameRequest struct {
-    ctx _context.Context
-    apiService *FakeClassnameTags123ApiService
-    client *Client
+	ctx _context.Context
+	apiService *FakeClassnameTags123ApiService
+	client *Client
 }
 
 
 func (r apiTestClassnameRequest) Client(client Client) apiTestClassnameRequest {
-    r.client = &client
-    return r
+	r.client = &client
+	return r
 }
 
 /*
@@ -43,10 +43,10 @@ To test class name in snake case
 @return apiTestClassnameRequest
 */
 func (a *FakeClassnameTags123ApiService) TestClassname(ctx _context.Context) apiTestClassnameRequest {
-    return apiTestClassnameRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiTestClassnameRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -63,25 +63,20 @@ func (r apiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 		localVarReturnValue  Client
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "FakeClassnameTags123ApiService.TestClassname")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "FakeClassnameTags123ApiService.TestClassname")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake_classname_test"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake_classname_test"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.client == nil {
-        return localVarReturnValue, nil, reportError("client is required and must be specified")
-    }
+	if r.client == nil {
+		return localVarReturnValue, nil, reportError("client is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -101,7 +96,7 @@ func (r apiTestClassnameRequest) Execute() (Client, *_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.client
+	localVarPostBody = r.client
 	if r.ctx != nil {
 		// API Key Authentication
 		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -27,15 +27,15 @@ var (
 type PetApiService service
 
 type apiAddPetRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    pet *Pet
+	ctx _context.Context
+	apiService *PetApiService
+	pet *Pet
 }
 
 
 func (r apiAddPetRequest) Pet(pet Pet) apiAddPetRequest {
-    r.pet = &pet
-    return r
+	r.pet = &pet
+	return r
 }
 
 /*
@@ -44,10 +44,10 @@ AddPet Add a new pet to the store
 @return apiAddPetRequest
 */
 func (a *PetApiService) AddPet(ctx _context.Context) apiAddPetRequest {
-    return apiAddPetRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiAddPetRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -64,25 +64,20 @@ func (r apiAddPetRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.AddPet")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.AddPet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.pet == nil {
-        return nil, reportError("pet is required and must be specified")
-    }
+	if r.pet == nil {
+		return nil, reportError("pet is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json", "application/xml"}
@@ -102,7 +97,7 @@ func (r apiAddPetRequest) Execute() (*_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.pet
+	localVarPostBody = r.pet
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -130,16 +125,16 @@ func (r apiAddPetRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiDeletePetRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    petId int64
-    apiKey *string
+	ctx _context.Context
+	apiService *PetApiService
+	petId int64
+	apiKey *string
 }
 
 
 func (r apiDeletePetRequest) ApiKey(apiKey string) apiDeletePetRequest {
-    r.apiKey = &apiKey
-    return r
+	r.apiKey = &apiKey
+	return r
 }
 
 /*
@@ -149,11 +144,11 @@ DeletePet Deletes a pet
 @return apiDeletePetRequest
 */
 func (a *PetApiService) DeletePet(ctx _context.Context, petId int64) apiDeletePetRequest {
-    return apiDeletePetRequest{
-        apiService: a,
-        ctx: ctx,
-        petId: petId,
-    }
+	return apiDeletePetRequest{
+		apiService: a,
+		ctx: ctx,
+		petId: petId,
+	}
 }
 
 /*
@@ -170,19 +165,13 @@ func (r apiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.DeletePet")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.DeletePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -236,15 +225,15 @@ func (r apiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiFindPetsByStatusRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    status *[]string
+	ctx _context.Context
+	apiService *PetApiService
+	status *[]string
 }
 
 
 func (r apiFindPetsByStatusRequest) Status(status []string) apiFindPetsByStatusRequest {
-    r.status = &status
-    return r
+	r.status = &status
+	return r
 }
 
 /*
@@ -254,10 +243,10 @@ Multiple status values can be provided with comma separated strings
 @return apiFindPetsByStatusRequest
 */
 func (a *PetApiService) FindPetsByStatus(ctx _context.Context) apiFindPetsByStatusRequest {
-    return apiFindPetsByStatusRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFindPetsByStatusRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -274,25 +263,20 @@ func (r apiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error)
 		localVarReturnValue  []Pet
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByStatus")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByStatus")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByStatus"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/findByStatus"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.status == nil {
-        return localVarReturnValue, nil, reportError("status is required and must be specified")
-    }
+	if r.status == nil {
+		return localVarReturnValue, nil, reportError("status is required and must be specified")
+	}
 
 	localVarQueryParams.Add("status", parameterToString(*r.status, "csv"))
 	// to determine the Content-Type header
@@ -358,15 +342,15 @@ func (r apiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error)
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiFindPetsByTagsRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    tags *[]string
+	ctx _context.Context
+	apiService *PetApiService
+	tags *[]string
 }
 
 
 func (r apiFindPetsByTagsRequest) Tags(tags []string) apiFindPetsByTagsRequest {
-    r.tags = &tags
-    return r
+	r.tags = &tags
+	return r
 }
 
 /*
@@ -376,10 +360,10 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 @return apiFindPetsByTagsRequest
 */
 func (a *PetApiService) FindPetsByTags(ctx _context.Context) apiFindPetsByTagsRequest {
-    return apiFindPetsByTagsRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiFindPetsByTagsRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -396,25 +380,20 @@ func (r apiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 		localVarReturnValue  []Pet
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByTags")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.FindPetsByTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/findByTags"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/findByTags"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.tags == nil {
-        return localVarReturnValue, nil, reportError("tags is required and must be specified")
-    }
+	if r.tags == nil {
+		return localVarReturnValue, nil, reportError("tags is required and must be specified")
+	}
 
 	localVarQueryParams.Add("tags", parameterToString(*r.tags, "csv"))
 	// to determine the Content-Type header
@@ -480,9 +459,9 @@ func (r apiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiGetPetByIdRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    petId int64
+	ctx _context.Context
+	apiService *PetApiService
+	petId int64
 }
 
 
@@ -494,11 +473,11 @@ Returns a single pet
 @return apiGetPetByIdRequest
 */
 func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) apiGetPetByIdRequest {
-    return apiGetPetByIdRequest{
-        apiService: a,
-        ctx: ctx,
-        petId: petId,
-    }
+	return apiGetPetByIdRequest{
+		apiService: a,
+		ctx: ctx,
+		petId: petId,
+	}
 }
 
 /*
@@ -515,19 +494,13 @@ func (r apiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 		localVarReturnValue  Pet
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.GetPetById")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.GetPetById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -611,15 +584,15 @@ func (r apiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiUpdatePetRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    pet *Pet
+	ctx _context.Context
+	apiService *PetApiService
+	pet *Pet
 }
 
 
 func (r apiUpdatePetRequest) Pet(pet Pet) apiUpdatePetRequest {
-    r.pet = &pet
-    return r
+	r.pet = &pet
+	return r
 }
 
 /*
@@ -628,10 +601,10 @@ UpdatePet Update an existing pet
 @return apiUpdatePetRequest
 */
 func (a *PetApiService) UpdatePet(ctx _context.Context) apiUpdatePetRequest {
-    return apiUpdatePetRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiUpdatePetRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -648,25 +621,20 @@ func (r apiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePet")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.pet == nil {
-        return nil, reportError("pet is required and must be specified")
-    }
+	if r.pet == nil {
+		return nil, reportError("pet is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json", "application/xml"}
@@ -686,7 +654,7 @@ func (r apiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.pet
+	localVarPostBody = r.pet
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -714,22 +682,22 @@ func (r apiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiUpdatePetWithFormRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    petId int64
-    name *string
-    status *string
+	ctx _context.Context
+	apiService *PetApiService
+	petId int64
+	name *string
+	status *string
 }
 
 
 func (r apiUpdatePetWithFormRequest) Name(name string) apiUpdatePetWithFormRequest {
-    r.name = &name
-    return r
+	r.name = &name
+	return r
 }
 
 func (r apiUpdatePetWithFormRequest) Status(status string) apiUpdatePetWithFormRequest {
-    r.status = &status
-    return r
+	r.status = &status
+	return r
 }
 
 /*
@@ -739,11 +707,11 @@ UpdatePetWithForm Updates a pet in the store with form data
 @return apiUpdatePetWithFormRequest
 */
 func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64) apiUpdatePetWithFormRequest {
-    return apiUpdatePetWithFormRequest{
-        apiService: a,
-        ctx: ctx,
-        petId: petId,
-    }
+	return apiUpdatePetWithFormRequest{
+		apiService: a,
+		ctx: ctx,
+		petId: petId,
+	}
 }
 
 /*
@@ -760,19 +728,13 @@ func (r apiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePetWithForm")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UpdatePetWithForm")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -829,22 +791,22 @@ func (r apiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiUploadFileRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    petId int64
-    additionalMetadata *string
-    file **os.File
+	ctx _context.Context
+	apiService *PetApiService
+	petId int64
+	additionalMetadata *string
+	file **os.File
 }
 
 
 func (r apiUploadFileRequest) AdditionalMetadata(additionalMetadata string) apiUploadFileRequest {
-    r.additionalMetadata = &additionalMetadata
-    return r
+	r.additionalMetadata = &additionalMetadata
+	return r
 }
 
 func (r apiUploadFileRequest) File(file *os.File) apiUploadFileRequest {
-    r.file = &file
-    return r
+	r.file = &file
+	return r
 }
 
 /*
@@ -854,11 +816,11 @@ UploadFile uploads an image
 @return apiUploadFileRequest
 */
 func (a *PetApiService) UploadFile(ctx _context.Context, petId int64) apiUploadFileRequest {
-    return apiUploadFileRequest{
-        apiService: a,
-        ctx: ctx,
-        petId: petId,
-    }
+	return apiUploadFileRequest{
+		apiService: a,
+		ctx: ctx,
+		petId: petId,
+	}
 }
 
 /*
@@ -875,19 +837,13 @@ func (r apiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error)
 		localVarReturnValue  ApiResponse
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFile")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}/uploadImage"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -970,22 +926,22 @@ func (r apiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error)
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiUploadFileWithRequiredFileRequest struct {
-    ctx _context.Context
-    apiService *PetApiService
-    petId int64
-    requiredFile **os.File
-    additionalMetadata *string
+	ctx _context.Context
+	apiService *PetApiService
+	petId int64
+	requiredFile **os.File
+	additionalMetadata *string
 }
 
 
 func (r apiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) apiUploadFileWithRequiredFileRequest {
-    r.requiredFile = &requiredFile
-    return r
+	r.requiredFile = &requiredFile
+	return r
 }
 
 func (r apiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetadata string) apiUploadFileWithRequiredFileRequest {
-    r.additionalMetadata = &additionalMetadata
-    return r
+	r.additionalMetadata = &additionalMetadata
+	return r
 }
 
 /*
@@ -995,11 +951,11 @@ UploadFileWithRequiredFile uploads an image (required)
 @return apiUploadFileWithRequiredFileRequest
 */
 func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId int64) apiUploadFileWithRequiredFileRequest {
-    return apiUploadFileWithRequiredFileRequest{
-        apiService: a,
-        ctx: ctx,
-        petId: petId,
-    }
+	return apiUploadFileWithRequiredFileRequest{
+		apiService: a,
+		ctx: ctx,
+		petId: petId,
+	}
 }
 
 /*
@@ -1016,28 +972,22 @@ func (r apiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.
 		localVarReturnValue  ApiResponse
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFileWithRequiredFile")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "PetApiService.UploadFileWithRequiredFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
-	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/fake/{petId}/uploadImageWithRequiredFile"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
 	
-    if r.requiredFile == nil {
-        return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
-    }
+	if r.requiredFile == nil {
+		return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
+	}
 	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"multipart/form-data"}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_pet.go
@@ -15,7 +15,6 @@ import (
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
-	"github.com/antihax/optional"
 	"os"
 )
 
@@ -27,20 +26,45 @@ var (
 // PetApiService PetApi service
 type PetApiService service
 
+type apiAddPetRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    pet *Pet
+}
+
+
+func (r apiAddPetRequest) Pet(pet Pet) apiAddPetRequest {
+    r.pet = &pet
+    return r
+}
+
 /*
 AddPet Add a new pet to the store
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param pet Pet object that needs to be added to the store
+@return apiAddPetRequest
 */
-func (a *PetApiService) AddPet(ctx _context.Context, pet Pet) (*_nethttp.Response, error) {
+func (a *PetApiService) AddPet(ctx _context.Context) apiAddPetRequest {
+    return apiAddPetRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiAddPetRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.AddPet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -48,9 +72,17 @@ func (a *PetApiService) AddPet(ctx _context.Context, pet Pet) (*_nethttp.Respons
 
 	localVarPath := localBasePath + "/pet"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.pet == nil {
+        return nil, reportError("pet is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json", "application/xml"}
@@ -70,13 +102,13 @@ func (a *PetApiService) AddPet(ctx _context.Context, pet Pet) (*_nethttp.Respons
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &pet
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.pet
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -97,28 +129,48 @@ func (a *PetApiService) AddPet(ctx _context.Context, pet Pet) (*_nethttp.Respons
 
 	return localVarHTTPResponse, nil
 }
+type apiDeletePetRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    petId int64
+    apiKey *string
+}
 
-// DeletePetOpts Optional parameters for the method 'DeletePet'
-type DeletePetOpts struct {
-    ApiKey optional.String
+
+func (r apiDeletePetRequest) ApiKey(apiKey string) apiDeletePetRequest {
+    r.apiKey = &apiKey
+    return r
 }
 
 /*
 DeletePet Deletes a pet
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param petId Pet id to delete
- * @param optional nil or *DeletePetOpts - Optional Parameters:
- * @param "ApiKey" (optional.String) - 
+@return apiDeletePetRequest
 */
-func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOptionals *DeletePetOpts) (*_nethttp.Response, error) {
+func (a *PetApiService) DeletePet(ctx _context.Context, petId int64) apiDeletePetRequest {
+    return apiDeletePetRequest{
+        apiService: a,
+        ctx: ctx,
+        petId: petId,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiDeletePetRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.DeletePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -126,11 +178,17 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 
 	localVarPath := localBasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -148,15 +206,15 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.ApiKey.IsSet() {
-		localVarHeaderParams["api_key"] = parameterToString(localVarOptionals.ApiKey.Value(), "")
+	if r.apiKey != nil {
+		localVarHeaderParams["api_key"] = parameterToString(*r.apiKey, "")
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -177,15 +235,36 @@ func (a *PetApiService) DeletePet(ctx _context.Context, petId int64, localVarOpt
 
 	return localVarHTTPResponse, nil
 }
+type apiFindPetsByStatusRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    status *[]string
+}
+
+
+func (r apiFindPetsByStatusRequest) Status(status []string) apiFindPetsByStatusRequest {
+    r.status = &status
+    return r
+}
 
 /*
 FindPetsByStatus Finds Pets by status
 Multiple status values can be provided with comma separated strings
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param status Status values that need to be considered for filter
-@return []Pet
+@return apiFindPetsByStatusRequest
 */
-func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) ([]Pet, *_nethttp.Response, error) {
+func (a *PetApiService) FindPetsByStatus(ctx _context.Context) apiFindPetsByStatusRequest {
+    return apiFindPetsByStatusRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return []Pet
+*/
+func (r apiFindPetsByStatusRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -195,6 +274,7 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 		localVarReturnValue  []Pet
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByStatus")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -202,11 +282,19 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 
 	localVarPath := localBasePath + "/pet/findByStatus"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/findByStatus"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.status == nil {
+        return localVarReturnValue, nil, reportError("status is required and must be specified")
+    }
 
-	localVarQueryParams.Add("status", parameterToString(status, "csv"))
+	localVarQueryParams.Add("status", parameterToString(*r.status, "csv"))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -224,12 +312,12 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -247,7 +335,7 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v []Pet
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -258,7 +346,7 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -269,15 +357,36 @@ func (a *PetApiService) FindPetsByStatus(ctx _context.Context, status []string) 
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiFindPetsByTagsRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    tags *[]string
+}
+
+
+func (r apiFindPetsByTagsRequest) Tags(tags []string) apiFindPetsByTagsRequest {
+    r.tags = &tags
+    return r
+}
 
 /*
 FindPetsByTags Finds Pets by tags
 Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param tags Tags to filter by
-@return []Pet
+@return apiFindPetsByTagsRequest
 */
-func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]Pet, *_nethttp.Response, error) {
+func (a *PetApiService) FindPetsByTags(ctx _context.Context) apiFindPetsByTagsRequest {
+    return apiFindPetsByTagsRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return []Pet
+*/
+func (r apiFindPetsByTagsRequest) Execute() ([]Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -287,6 +396,7 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 		localVarReturnValue  []Pet
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.FindPetsByTags")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -294,11 +404,19 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 
 	localVarPath := localBasePath + "/pet/findByTags"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/findByTags"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.tags == nil {
+        return localVarReturnValue, nil, reportError("tags is required and must be specified")
+    }
 
-	localVarQueryParams.Add("tags", parameterToString(tags, "csv"))
+	localVarQueryParams.Add("tags", parameterToString(*r.tags, "csv"))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -316,12 +434,12 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -339,7 +457,7 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v []Pet
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -350,7 +468,7 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -361,15 +479,33 @@ func (a *PetApiService) FindPetsByTags(ctx _context.Context, tags []string) ([]P
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiGetPetByIdRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    petId int64
+}
+
 
 /*
 GetPetById Find pet by ID
 Returns a single pet
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param petId ID of pet to return
-@return Pet
+@return apiGetPetByIdRequest
 */
-func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_nethttp.Response, error) {
+func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) apiGetPetByIdRequest {
+    return apiGetPetByIdRequest{
+        apiService: a,
+        ctx: ctx,
+        petId: petId,
+    }
+}
+
+/*
+Execute executes the request
+ @return Pet
+*/
+func (r apiGetPetByIdRequest) Execute() (Pet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -379,6 +515,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 		localVarReturnValue  Pet
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.GetPetById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -386,10 +523,16 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 
 	localVarPath := localBasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -408,9 +551,9 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if ctx != nil {
+	if r.ctx != nil {
 		// API Key Authentication
-		if auth, ok := ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
 			if auth, ok := auth["api_key"]; ok {
 				var key string
 				if auth.Prefix != "" {
@@ -422,12 +565,12 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 			}
 		}
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -445,7 +588,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Pet
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -456,7 +599,7 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -467,21 +610,45 @@ func (a *PetApiService) GetPetById(ctx _context.Context, petId int64) (Pet, *_ne
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiUpdatePetRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    pet *Pet
+}
+
+
+func (r apiUpdatePetRequest) Pet(pet Pet) apiUpdatePetRequest {
+    r.pet = &pet
+    return r
+}
 
 /*
 UpdatePet Update an existing pet
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param pet Pet object that needs to be added to the store
+@return apiUpdatePetRequest
 */
-func (a *PetApiService) UpdatePet(ctx _context.Context, pet Pet) (*_nethttp.Response, error) {
+func (a *PetApiService) UpdatePet(ctx _context.Context) apiUpdatePetRequest {
+    return apiUpdatePetRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiUpdatePetRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePet")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -489,9 +656,17 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, pet Pet) (*_nethttp.Resp
 
 	localVarPath := localBasePath + "/pet"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.pet == nil {
+        return nil, reportError("pet is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json", "application/xml"}
@@ -511,13 +686,13 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, pet Pet) (*_nethttp.Resp
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &pet
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.pet
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -538,30 +713,54 @@ func (a *PetApiService) UpdatePet(ctx _context.Context, pet Pet) (*_nethttp.Resp
 
 	return localVarHTTPResponse, nil
 }
+type apiUpdatePetWithFormRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    petId int64
+    name *string
+    status *string
+}
 
-// UpdatePetWithFormOpts Optional parameters for the method 'UpdatePetWithForm'
-type UpdatePetWithFormOpts struct {
-    Name optional.String
-    Status optional.String
+
+func (r apiUpdatePetWithFormRequest) Name(name string) apiUpdatePetWithFormRequest {
+    r.name = &name
+    return r
+}
+
+func (r apiUpdatePetWithFormRequest) Status(status string) apiUpdatePetWithFormRequest {
+    r.status = &status
+    return r
 }
 
 /*
 UpdatePetWithForm Updates a pet in the store with form data
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param petId ID of pet that needs to be updated
- * @param optional nil or *UpdatePetWithFormOpts - Optional Parameters:
- * @param "Name" (optional.String) -  Updated name of the pet
- * @param "Status" (optional.String) -  Updated status of the pet
+@return apiUpdatePetWithFormRequest
 */
-func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, localVarOptionals *UpdatePetWithFormOpts) (*_nethttp.Response, error) {
+func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64) apiUpdatePetWithFormRequest {
+    return apiUpdatePetWithFormRequest{
+        apiService: a,
+        ctx: ctx,
+        petId: petId,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiUpdatePetWithFormRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UpdatePetWithForm")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -569,11 +768,17 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 
 	localVarPath := localBasePath + "/pet/{petId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
+		
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/x-www-form-urlencoded"}
 
@@ -591,18 +796,18 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.Name.IsSet() {
-		localVarFormParams.Add("name", parameterToString(localVarOptionals.Name.Value(), ""))
+	if r.name != nil {
+		localVarFormParams.Add("name", parameterToString(*r.name, ""))
 	}
-	if localVarOptionals != nil && localVarOptionals.Status.IsSet() {
-		localVarFormParams.Add("status", parameterToString(localVarOptionals.Status.Value(), ""))
+	if r.status != nil {
+		localVarFormParams.Add("status", parameterToString(*r.status, ""))
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -623,23 +828,44 @@ func (a *PetApiService) UpdatePetWithForm(ctx _context.Context, petId int64, loc
 
 	return localVarHTTPResponse, nil
 }
+type apiUploadFileRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    petId int64
+    additionalMetadata *string
+    file **os.File
+}
 
-// UploadFileOpts Optional parameters for the method 'UploadFile'
-type UploadFileOpts struct {
-    AdditionalMetadata optional.String
-    File optional.Interface
+
+func (r apiUploadFileRequest) AdditionalMetadata(additionalMetadata string) apiUploadFileRequest {
+    r.additionalMetadata = &additionalMetadata
+    return r
+}
+
+func (r apiUploadFileRequest) File(file *os.File) apiUploadFileRequest {
+    r.file = &file
+    return r
 }
 
 /*
 UploadFile uploads an image
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param petId ID of pet to update
- * @param optional nil or *UploadFileOpts - Optional Parameters:
- * @param "AdditionalMetadata" (optional.String) -  Additional data to pass to server
- * @param "File" (optional.Interface of *os.File) -  file to upload
-@return ApiResponse
+@return apiUploadFileRequest
 */
-func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOptionals *UploadFileOpts) (ApiResponse, *_nethttp.Response, error) {
+func (a *PetApiService) UploadFile(ctx _context.Context, petId int64) apiUploadFileRequest {
+    return apiUploadFileRequest{
+        apiService: a,
+        ctx: ctx,
+        petId: petId,
+    }
+}
+
+/*
+Execute executes the request
+ @return ApiResponse
+*/
+func (r apiUploadFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -649,6 +875,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		localVarReturnValue  ApiResponse
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -656,11 +883,17 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 
 	localVarPath := localBasePath + "/pet/{petId}/uploadImage"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/pet/{petId}/uploadImage"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
+		
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"multipart/form-data"}
 
@@ -678,17 +911,13 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.AdditionalMetadata.IsSet() {
-		localVarFormParams.Add("additionalMetadata", parameterToString(localVarOptionals.AdditionalMetadata.Value(), ""))
+	if r.additionalMetadata != nil {
+		localVarFormParams.Add("additionalMetadata", parameterToString(*r.additionalMetadata, ""))
 	}
 	localVarFormFileName = "file"
 	var localVarFile *os.File
-	if localVarOptionals != nil && localVarOptionals.File.IsSet() {
-		localVarFileOk := false
-		localVarFile, localVarFileOk = localVarOptionals.File.Value().(*os.File)
-		if !localVarFileOk {
-				return localVarReturnValue, nil, reportError("file should be *os.File")
-		}
+	if r.file != nil {
+		localVarFile = *r.file
 	}
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
@@ -696,12 +925,12 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		localVarFileName = localVarFile.Name()
 		localVarFile.Close()
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -719,7 +948,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v ApiResponse
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -729,7 +958,7 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -740,22 +969,44 @@ func (a *PetApiService) UploadFile(ctx _context.Context, petId int64, localVarOp
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiUploadFileWithRequiredFileRequest struct {
+    ctx _context.Context
+    apiService *PetApiService
+    petId int64
+    requiredFile **os.File
+    additionalMetadata *string
+}
 
-// UploadFileWithRequiredFileOpts Optional parameters for the method 'UploadFileWithRequiredFile'
-type UploadFileWithRequiredFileOpts struct {
-    AdditionalMetadata optional.String
+
+func (r apiUploadFileWithRequiredFileRequest) RequiredFile(requiredFile *os.File) apiUploadFileWithRequiredFileRequest {
+    r.requiredFile = &requiredFile
+    return r
+}
+
+func (r apiUploadFileWithRequiredFileRequest) AdditionalMetadata(additionalMetadata string) apiUploadFileWithRequiredFileRequest {
+    r.additionalMetadata = &additionalMetadata
+    return r
 }
 
 /*
 UploadFileWithRequiredFile uploads an image (required)
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param petId ID of pet to update
- * @param requiredFile file to upload
- * @param optional nil or *UploadFileWithRequiredFileOpts - Optional Parameters:
- * @param "AdditionalMetadata" (optional.String) -  Additional data to pass to server
-@return ApiResponse
+@return apiUploadFileWithRequiredFileRequest
 */
-func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId int64, requiredFile *os.File, localVarOptionals *UploadFileWithRequiredFileOpts) (ApiResponse, *_nethttp.Response, error) {
+func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId int64) apiUploadFileWithRequiredFileRequest {
+    return apiUploadFileWithRequiredFileRequest{
+        apiService: a,
+        ctx: ctx,
+        petId: petId,
+    }
+}
+
+/*
+Execute executes the request
+ @return ApiResponse
+*/
+func (r apiUploadFileWithRequiredFileRequest) Execute() (ApiResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -765,6 +1016,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 		localVarReturnValue  ApiResponse
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "PetApiService.UploadFileWithRequiredFile")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -772,11 +1024,21 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 
 	localVarPath := localBasePath + "/fake/{petId}/uploadImageWithRequiredFile"
 	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(petId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/fake/{petId}/uploadImageWithRequiredFile"
+	localVarPath = strings.Replace(localVarPath, "{"+"petId"+"}", _neturl.QueryEscape(parameterToString(r.petId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-
+	
+	
+    if r.requiredFile == nil {
+        return localVarReturnValue, nil, reportError("requiredFile is required and must be specified")
+    }
+	
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"multipart/form-data"}
 
@@ -794,23 +1056,23 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if localVarOptionals != nil && localVarOptionals.AdditionalMetadata.IsSet() {
-		localVarFormParams.Add("additionalMetadata", parameterToString(localVarOptionals.AdditionalMetadata.Value(), ""))
+	if r.additionalMetadata != nil {
+		localVarFormParams.Add("additionalMetadata", parameterToString(*r.additionalMetadata, ""))
 	}
 	localVarFormFileName = "requiredFile"
-	localVarFile := requiredFile
+	localVarFile := *r.requiredFile
 	if localVarFile != nil {
 		fbs, _ := _ioutil.ReadAll(localVarFile)
 		localVarFileBytes = fbs
 		localVarFileName = localVarFile.Name()
 		localVarFile.Close()
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -828,7 +1090,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v ApiResponse
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -838,7 +1100,7 @@ func (a *PetApiService) UploadFileWithRequiredFile(ctx _context.Context, petId i
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
@@ -26,9 +26,9 @@ var (
 type StoreApiService service
 
 type apiDeleteOrderRequest struct {
-    ctx _context.Context
-    apiService *StoreApiService
-    orderId string
+	ctx _context.Context
+	apiService *StoreApiService
+	orderId string
 }
 
 
@@ -40,11 +40,11 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 @return apiDeleteOrderRequest
 */
 func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) apiDeleteOrderRequest {
-    return apiDeleteOrderRequest{
-        apiService: a,
-        ctx: ctx,
-        orderId: orderId,
-    }
+	return apiDeleteOrderRequest{
+		apiService: a,
+		ctx: ctx,
+		orderId: orderId,
+	}
 }
 
 /*
@@ -61,19 +61,13 @@ func (r apiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.DeleteOrder")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.DeleteOrder")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/store/order/{order_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(r.orderId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -124,8 +118,8 @@ func (r apiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiGetInventoryRequest struct {
-    ctx _context.Context
-    apiService *StoreApiService
+	ctx _context.Context
+	apiService *StoreApiService
 }
 
 
@@ -136,10 +130,10 @@ Returns a map of status codes to quantities
 @return apiGetInventoryRequest
 */
 func (a *StoreApiService) GetInventory(ctx _context.Context) apiGetInventoryRequest {
-    return apiGetInventoryRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiGetInventoryRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -156,18 +150,13 @@ func (r apiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response,
 		localVarReturnValue  map[string]int32
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetInventory")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetInventory")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/inventory"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/store/inventory"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -248,9 +237,9 @@ func (r apiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response,
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiGetOrderByIdRequest struct {
-    ctx _context.Context
-    apiService *StoreApiService
-    orderId int64
+	ctx _context.Context
+	apiService *StoreApiService
+	orderId int64
 }
 
 
@@ -262,11 +251,11 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 @return apiGetOrderByIdRequest
 */
 func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) apiGetOrderByIdRequest {
-    return apiGetOrderByIdRequest{
-        apiService: a,
-        ctx: ctx,
-        orderId: orderId,
-    }
+	return apiGetOrderByIdRequest{
+		apiService: a,
+		ctx: ctx,
+		orderId: orderId,
+	}
 }
 
 /*
@@ -283,28 +272,22 @@ func (r apiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 		localVarReturnValue  Order
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetOrderById")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.GetOrderById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
-	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/store/order/{order_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(r.orderId, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-	if *r.orderId < 1 {
+	if r.orderId < 1 {
 		return localVarReturnValue, nil, reportError("orderId must be greater than 1")
 	}
-	if *r.orderId > 5 {
+	if r.orderId > 5 {
 		return localVarReturnValue, nil, reportError("orderId must be less than 5")
 	}
 
@@ -371,15 +354,15 @@ func (r apiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiPlaceOrderRequest struct {
-    ctx _context.Context
-    apiService *StoreApiService
-    order *Order
+	ctx _context.Context
+	apiService *StoreApiService
+	order *Order
 }
 
 
 func (r apiPlaceOrderRequest) Order(order Order) apiPlaceOrderRequest {
-    r.order = &order
-    return r
+	r.order = &order
+	return r
 }
 
 /*
@@ -388,10 +371,10 @@ PlaceOrder Place an order for a pet
 @return apiPlaceOrderRequest
 */
 func (a *StoreApiService) PlaceOrder(ctx _context.Context) apiPlaceOrderRequest {
-    return apiPlaceOrderRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiPlaceOrderRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -408,25 +391,20 @@ func (r apiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 		localVarReturnValue  Order
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.PlaceOrder")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "StoreApiService.PlaceOrder")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/store/order"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/store/order"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.order == nil {
-        return localVarReturnValue, nil, reportError("order is required and must be specified")
-    }
+	if r.order == nil {
+		return localVarReturnValue, nil, reportError("order is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -446,7 +424,7 @@ func (r apiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.order
+	localVarPostBody = r.order
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_store.go
@@ -25,21 +25,43 @@ var (
 // StoreApiService StoreApi service
 type StoreApiService service
 
+type apiDeleteOrderRequest struct {
+    ctx _context.Context
+    apiService *StoreApiService
+    orderId string
+}
+
+
 /*
 DeleteOrder Delete purchase order by ID
-For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
+For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param orderId ID of the order that needs to be deleted
+@return apiDeleteOrderRequest
 */
-func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_nethttp.Response, error) {
+func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) apiDeleteOrderRequest {
+    return apiDeleteOrderRequest{
+        apiService: a,
+        ctx: ctx,
+        orderId: orderId,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiDeleteOrderRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.DeleteOrder")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -47,10 +69,16 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/store/order/{order_id}"
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(r.orderId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -69,12 +97,12 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -95,14 +123,30 @@ func (a *StoreApiService) DeleteOrder(ctx _context.Context, orderId string) (*_n
 
 	return localVarHTTPResponse, nil
 }
+type apiGetInventoryRequest struct {
+    ctx _context.Context
+    apiService *StoreApiService
+}
+
 
 /*
 GetInventory Returns pet inventories by status
 Returns a map of status codes to quantities
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-@return map[string]int32
+@return apiGetInventoryRequest
 */
-func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, *_nethttp.Response, error) {
+func (a *StoreApiService) GetInventory(ctx _context.Context) apiGetInventoryRequest {
+    return apiGetInventoryRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return map[string]int32
+*/
+func (r apiGetInventoryRequest) Execute() (map[string]int32, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -112,6 +156,7 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 		localVarReturnValue  map[string]int32
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetInventory")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -119,6 +164,10 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 
 	localVarPath := localBasePath + "/store/inventory"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/store/inventory"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -140,9 +189,9 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	if ctx != nil {
+	if r.ctx != nil {
 		// API Key Authentication
-		if auth, ok := ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
 			if auth, ok := auth["api_key"]; ok {
 				var key string
 				if auth.Prefix != "" {
@@ -154,12 +203,12 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 			}
 		}
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -177,7 +226,7 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v map[string]int32
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -187,7 +236,7 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -198,15 +247,33 @@ func (a *StoreApiService) GetInventory(ctx _context.Context) (map[string]int32, 
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiGetOrderByIdRequest struct {
+    ctx _context.Context
+    apiService *StoreApiService
+    orderId int64
+}
+
 
 /*
 GetOrderById Find purchase order by ID
-For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generated exceptions
+For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param orderId ID of pet that needs to be fetched
-@return Order
+@return apiGetOrderByIdRequest
 */
-func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Order, *_nethttp.Response, error) {
+func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) apiGetOrderByIdRequest {
+    return apiGetOrderByIdRequest{
+        apiService: a,
+        ctx: ctx,
+        orderId: orderId,
+    }
+}
+
+/*
+Execute executes the request
+ @return Order
+*/
+func (r apiGetOrderByIdRequest) Execute() (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -216,6 +283,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 		localVarReturnValue  Order
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.GetOrderById")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -223,14 +291,20 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 
 	localVarPath := localBasePath + "/store/order/{order_id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(orderId, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/store/order/{order_id}"
+	localVarPath = strings.Replace(localVarPath, "{"+"order_id"+"}", _neturl.QueryEscape(parameterToString(r.orderId, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	if orderId < 1 {
+	
+	if *r.orderId < 1 {
 		return localVarReturnValue, nil, reportError("orderId must be greater than 1")
 	}
-	if orderId > 5 {
+	if *r.orderId > 5 {
 		return localVarReturnValue, nil, reportError("orderId must be less than 5")
 	}
 
@@ -251,12 +325,12 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -274,7 +348,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Order
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -285,7 +359,7 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -296,14 +370,35 @@ func (a *StoreApiService) GetOrderById(ctx _context.Context, orderId int64) (Ord
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiPlaceOrderRequest struct {
+    ctx _context.Context
+    apiService *StoreApiService
+    order *Order
+}
+
+
+func (r apiPlaceOrderRequest) Order(order Order) apiPlaceOrderRequest {
+    r.order = &order
+    return r
+}
 
 /*
 PlaceOrder Place an order for a pet
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param order order placed for purchasing the pet
-@return Order
+@return apiPlaceOrderRequest
 */
-func (a *StoreApiService) PlaceOrder(ctx _context.Context, order Order) (Order, *_nethttp.Response, error) {
+func (a *StoreApiService) PlaceOrder(ctx _context.Context) apiPlaceOrderRequest {
+    return apiPlaceOrderRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return Order
+*/
+func (r apiPlaceOrderRequest) Execute() (Order, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -313,6 +408,7 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, order Order) (Order, 
 		localVarReturnValue  Order
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "StoreApiService.PlaceOrder")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -320,9 +416,17 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, order Order) (Order, 
 
 	localVarPath := localBasePath + "/store/order"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/store/order"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.order == nil {
+        return localVarReturnValue, nil, reportError("order is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -342,13 +446,13 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, order Order) (Order, 
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &order
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.order
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -366,7 +470,7 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, order Order) (Order, 
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v Order
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -377,7 +481,7 @@ func (a *StoreApiService) PlaceOrder(ctx _context.Context, order Order) (Order, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
@@ -25,21 +25,46 @@ var (
 // UserApiService UserApi service
 type UserApiService service
 
+type apiCreateUserRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    user *User
+}
+
+
+func (r apiCreateUserRequest) User(user User) apiCreateUserRequest {
+    r.user = &user
+    return r
+}
+
 /*
 CreateUser Create user
 This can only be done by the logged in user.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param user Created user object
+@return apiCreateUserRequest
 */
-func (a *UserApiService) CreateUser(ctx _context.Context, user User) (*_nethttp.Response, error) {
+func (a *UserApiService) CreateUser(ctx _context.Context) apiCreateUserRequest {
+    return apiCreateUserRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -47,9 +72,17 @@ func (a *UserApiService) CreateUser(ctx _context.Context, user User) (*_nethttp.
 
 	localVarPath := localBasePath + "/user"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.user == nil {
+        return nil, reportError("user is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -69,13 +102,13 @@ func (a *UserApiService) CreateUser(ctx _context.Context, user User) (*_nethttp.
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &user
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.user
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -96,21 +129,45 @@ func (a *UserApiService) CreateUser(ctx _context.Context, user User) (*_nethttp.
 
 	return localVarHTTPResponse, nil
 }
+type apiCreateUsersWithArrayInputRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    user *[]User
+}
+
+
+func (r apiCreateUsersWithArrayInputRequest) User(user []User) apiCreateUsersWithArrayInputRequest {
+    r.user = &user
+    return r
+}
 
 /*
 CreateUsersWithArrayInput Creates list of users with given input array
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param user List of user object
+@return apiCreateUsersWithArrayInputRequest
 */
-func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, user []User) (*_nethttp.Response, error) {
+func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context) apiCreateUsersWithArrayInputRequest {
+    return apiCreateUsersWithArrayInputRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithArrayInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -118,9 +175,17 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, user []
 
 	localVarPath := localBasePath + "/user/createWithArray"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/createWithArray"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.user == nil {
+        return nil, reportError("user is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -140,13 +205,13 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, user []
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &user
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.user
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -167,21 +232,45 @@ func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context, user []
 
 	return localVarHTTPResponse, nil
 }
+type apiCreateUsersWithListInputRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    user *[]User
+}
+
+
+func (r apiCreateUsersWithListInputRequest) User(user []User) apiCreateUsersWithListInputRequest {
+    r.user = &user
+    return r
+}
 
 /*
 CreateUsersWithListInput Creates list of users with given input array
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param user List of user object
+@return apiCreateUsersWithListInputRequest
 */
-func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, user []User) (*_nethttp.Response, error) {
+func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context) apiCreateUsersWithListInputRequest {
+    return apiCreateUsersWithListInputRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithListInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -189,9 +278,17 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, user []U
 
 	localVarPath := localBasePath + "/user/createWithList"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/createWithList"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.user == nil {
+        return nil, reportError("user is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -211,13 +308,13 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, user []U
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &user
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.user
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -238,22 +335,43 @@ func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context, user []U
 
 	return localVarHTTPResponse, nil
 }
+type apiDeleteUserRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    username string
+}
+
 
 /*
 DeleteUser Delete user
 This can only be done by the logged in user.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param username The name that needs to be deleted
+@return apiDeleteUserRequest
 */
-func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_nethttp.Response, error) {
+func (a *UserApiService) DeleteUser(ctx _context.Context, username string) apiDeleteUserRequest {
+    return apiDeleteUserRequest{
+        apiService: a,
+        ctx: ctx,
+        username: username,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.DeleteUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -261,10 +379,16 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 
 	localVarPath := localBasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -283,12 +407,12 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -309,14 +433,32 @@ func (a *UserApiService) DeleteUser(ctx _context.Context, username string) (*_ne
 
 	return localVarHTTPResponse, nil
 }
+type apiGetUserByNameRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    username string
+}
+
 
 /*
 GetUserByName Get user by user name
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param username The name that needs to be fetched. Use user1 for testing.
-@return User
+@return apiGetUserByNameRequest
 */
-func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (User, *_nethttp.Response, error) {
+func (a *UserApiService) GetUserByName(ctx _context.Context, username string) apiGetUserByNameRequest {
+    return apiGetUserByNameRequest{
+        apiService: a,
+        ctx: ctx,
+        username: username,
+    }
+}
+
+/*
+Execute executes the request
+ @return User
+*/
+func (r apiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -326,6 +468,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 		localVarReturnValue  User
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.GetUserByName")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -333,10 +476,16 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 
 	localVarPath := localBasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
@@ -355,12 +504,12 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -378,7 +527,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v User
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -389,7 +538,7 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -400,15 +549,41 @@ func (a *UserApiService) GetUserByName(ctx _context.Context, username string) (U
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiLoginUserRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    username *string
+    password *string
+}
+
+
+func (r apiLoginUserRequest) Username(username string) apiLoginUserRequest {
+    r.username = &username
+    return r
+}
+
+func (r apiLoginUserRequest) Password(password string) apiLoginUserRequest {
+    r.password = &password
+    return r
+}
 
 /*
 LoginUser Logs user into the system
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param username The user name for login
- * @param password The password for login in clear text
-@return string
+@return apiLoginUserRequest
 */
-func (a *UserApiService) LoginUser(ctx _context.Context, username string, password string) (string, *_nethttp.Response, error) {
+func (a *UserApiService) LoginUser(ctx _context.Context) apiLoginUserRequest {
+    return apiLoginUserRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+ @return string
+*/
+func (r apiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -418,6 +593,7 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 		localVarReturnValue  string
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LoginUser")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
@@ -425,12 +601,24 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 
 	localVarPath := localBasePath + "/user/login"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/login"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+    if r.username == nil {
+        return localVarReturnValue, nil, reportError("username is required and must be specified")
+    }
+	
+    if r.password == nil {
+        return localVarReturnValue, nil, reportError("password is required and must be specified")
+    }
 
-	localVarQueryParams.Add("username", parameterToString(username, ""))
-	localVarQueryParams.Add("password", parameterToString(password, ""))
+	localVarQueryParams.Add("username", parameterToString(*r.username, ""))
+	localVarQueryParams.Add("password", parameterToString(*r.password, ""))
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 
@@ -448,12 +636,12 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
@@ -471,7 +659,7 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 		}
 		if localVarHTTPResponse.StatusCode == 200 {
 			var v string
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			err = r.apiService.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHTTPResponse, newErr
@@ -482,7 +670,7 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	err = r.apiService.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -493,20 +681,39 @@ func (a *UserApiService) LoginUser(ctx _context.Context, username string, passwo
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+type apiLogoutUserRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+}
+
 
 /*
 LogoutUser Logs out current logged in user session
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+@return apiLogoutUserRequest
 */
-func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, error) {
+func (a *UserApiService) LogoutUser(ctx _context.Context) apiLogoutUserRequest {
+    return apiLogoutUserRequest{
+        apiService: a,
+        ctx: ctx,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LogoutUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -514,6 +721,10 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 
 	localVarPath := localBasePath + "/user/logout"
 
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/logout"
+>>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -535,12 +746,12 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 	if localVarHTTPHeaderAccept != "" {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}
@@ -561,23 +772,49 @@ func (a *UserApiService) LogoutUser(ctx _context.Context) (*_nethttp.Response, e
 
 	return localVarHTTPResponse, nil
 }
+type apiUpdateUserRequest struct {
+    ctx _context.Context
+    apiService *UserApiService
+    username string
+    user *User
+}
+
+
+func (r apiUpdateUserRequest) User(user User) apiUpdateUserRequest {
+    r.user = &user
+    return r
+}
 
 /*
 UpdateUser Updated user
 This can only be done by the logged in user.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param username name that need to be deleted
- * @param user Updated user object
+@return apiUpdateUserRequest
 */
-func (a *UserApiService) UpdateUser(ctx _context.Context, username string, user User) (*_nethttp.Response, error) {
+func (a *UserApiService) UpdateUser(ctx _context.Context, username string) apiUpdateUserRequest {
+    return apiUpdateUserRequest{
+        apiService: a,
+        ctx: ctx,
+        username: username,
+    }
+}
+
+/*
+Execute executes the request
+
+*/
+func (r apiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
+		
 	)
 
+<<<<<<< HEAD
 	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.UpdateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
@@ -585,10 +822,20 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, user 
 
 	localVarPath := localBasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
+=======
+	// create path and map variables
+	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
+	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
+>>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
+	
+	
+    if r.user == nil {
+        return nil, reportError("user is required and must be specified")
+    }
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -608,13 +855,13 @@ func (a *UserApiService) UpdateUser(ctx _context.Context, username string, user 
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = &user
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	localVarPostBody = *r.user
+	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := a.client.callAPI(r)
+	localVarHTTPResponse, err := r.apiService.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/api_user.go
@@ -26,15 +26,15 @@ var (
 type UserApiService service
 
 type apiCreateUserRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    user *User
+	ctx _context.Context
+	apiService *UserApiService
+	user *User
 }
 
 
 func (r apiCreateUserRequest) User(user User) apiCreateUserRequest {
-    r.user = &user
-    return r
+	r.user = &user
+	return r
 }
 
 /*
@@ -44,10 +44,10 @@ This can only be done by the logged in user.
 @return apiCreateUserRequest
 */
 func (a *UserApiService) CreateUser(ctx _context.Context) apiCreateUserRequest {
-    return apiCreateUserRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiCreateUserRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -64,25 +64,20 @@ func (r apiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUser")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.user == nil {
-        return nil, reportError("user is required and must be specified")
-    }
+	if r.user == nil {
+		return nil, reportError("user is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -102,7 +97,7 @@ func (r apiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.user
+	localVarPostBody = r.user
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -130,15 +125,15 @@ func (r apiCreateUserRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiCreateUsersWithArrayInputRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    user *[]User
+	ctx _context.Context
+	apiService *UserApiService
+	user *[]User
 }
 
 
 func (r apiCreateUsersWithArrayInputRequest) User(user []User) apiCreateUsersWithArrayInputRequest {
-    r.user = &user
-    return r
+	r.user = &user
+	return r
 }
 
 /*
@@ -147,10 +142,10 @@ CreateUsersWithArrayInput Creates list of users with given input array
 @return apiCreateUsersWithArrayInputRequest
 */
 func (a *UserApiService) CreateUsersWithArrayInput(ctx _context.Context) apiCreateUsersWithArrayInputRequest {
-    return apiCreateUsersWithArrayInputRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiCreateUsersWithArrayInputRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -167,25 +162,20 @@ func (r apiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, erro
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithArrayInput")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithArrayInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithArray"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/createWithArray"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.user == nil {
-        return nil, reportError("user is required and must be specified")
-    }
+	if r.user == nil {
+		return nil, reportError("user is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -205,7 +195,7 @@ func (r apiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, erro
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.user
+	localVarPostBody = r.user
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -233,15 +223,15 @@ func (r apiCreateUsersWithArrayInputRequest) Execute() (*_nethttp.Response, erro
 	return localVarHTTPResponse, nil
 }
 type apiCreateUsersWithListInputRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    user *[]User
+	ctx _context.Context
+	apiService *UserApiService
+	user *[]User
 }
 
 
 func (r apiCreateUsersWithListInputRequest) User(user []User) apiCreateUsersWithListInputRequest {
-    r.user = &user
-    return r
+	r.user = &user
+	return r
 }
 
 /*
@@ -250,10 +240,10 @@ CreateUsersWithListInput Creates list of users with given input array
 @return apiCreateUsersWithListInputRequest
 */
 func (a *UserApiService) CreateUsersWithListInput(ctx _context.Context) apiCreateUsersWithListInputRequest {
-    return apiCreateUsersWithListInputRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiCreateUsersWithListInputRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -270,25 +260,20 @@ func (r apiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.CreateUsersWithListInput")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.CreateUsersWithListInput")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/createWithList"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/createWithList"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.user == nil {
-        return nil, reportError("user is required and must be specified")
-    }
+	if r.user == nil {
+		return nil, reportError("user is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -308,7 +293,7 @@ func (r apiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.user
+	localVarPostBody = r.user
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err
@@ -336,9 +321,9 @@ func (r apiCreateUsersWithListInputRequest) Execute() (*_nethttp.Response, error
 	return localVarHTTPResponse, nil
 }
 type apiDeleteUserRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    username string
+	ctx _context.Context
+	apiService *UserApiService
+	username string
 }
 
 
@@ -350,11 +335,11 @@ This can only be done by the logged in user.
 @return apiDeleteUserRequest
 */
 func (a *UserApiService) DeleteUser(ctx _context.Context, username string) apiDeleteUserRequest {
-    return apiDeleteUserRequest{
-        apiService: a,
-        ctx: ctx,
-        username: username,
-    }
+	return apiDeleteUserRequest{
+		apiService: a,
+		ctx: ctx,
+		username: username,
+	}
 }
 
 /*
@@ -371,19 +356,13 @@ func (r apiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.DeleteUser")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.DeleteUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -434,9 +413,9 @@ func (r apiDeleteUserRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiGetUserByNameRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    username string
+	ctx _context.Context
+	apiService *UserApiService
+	username string
 }
 
 
@@ -447,11 +426,11 @@ GetUserByName Get user by user name
 @return apiGetUserByNameRequest
 */
 func (a *UserApiService) GetUserByName(ctx _context.Context, username string) apiGetUserByNameRequest {
-    return apiGetUserByNameRequest{
-        apiService: a,
-        ctx: ctx,
-        username: username,
-    }
+	return apiGetUserByNameRequest{
+		apiService: a,
+		ctx: ctx,
+		username: username,
+	}
 }
 
 /*
@@ -468,19 +447,13 @@ func (r apiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 		localVarReturnValue  User
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.GetUserByName")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.GetUserByName")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
@@ -550,21 +523,21 @@ func (r apiGetUserByNameRequest) Execute() (User, *_nethttp.Response, error) {
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiLoginUserRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    username *string
-    password *string
+	ctx _context.Context
+	apiService *UserApiService
+	username *string
+	password *string
 }
 
 
 func (r apiLoginUserRequest) Username(username string) apiLoginUserRequest {
-    r.username = &username
-    return r
+	r.username = &username
+	return r
 }
 
 func (r apiLoginUserRequest) Password(password string) apiLoginUserRequest {
-    r.password = &password
-    return r
+	r.password = &password
+	return r
 }
 
 /*
@@ -573,10 +546,10 @@ LoginUser Logs user into the system
 @return apiLoginUserRequest
 */
 func (a *UserApiService) LoginUser(ctx _context.Context) apiLoginUserRequest {
-    return apiLoginUserRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiLoginUserRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -593,29 +566,24 @@ func (r apiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 		localVarReturnValue  string
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LoginUser")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LoginUser")
 	if err != nil {
 		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/login"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/login"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
-    if r.username == nil {
-        return localVarReturnValue, nil, reportError("username is required and must be specified")
-    }
+	if r.username == nil {
+		return localVarReturnValue, nil, reportError("username is required and must be specified")
+	}
 	
-    if r.password == nil {
-        return localVarReturnValue, nil, reportError("password is required and must be specified")
-    }
+	if r.password == nil {
+		return localVarReturnValue, nil, reportError("password is required and must be specified")
+	}
 
 	localVarQueryParams.Add("username", parameterToString(*r.username, ""))
 	localVarQueryParams.Add("password", parameterToString(*r.password, ""))
@@ -682,8 +650,8 @@ func (r apiLoginUserRequest) Execute() (string, *_nethttp.Response, error) {
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 type apiLogoutUserRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
+	ctx _context.Context
+	apiService *UserApiService
 }
 
 
@@ -693,10 +661,10 @@ LogoutUser Logs out current logged in user session
 @return apiLogoutUserRequest
 */
 func (a *UserApiService) LogoutUser(ctx _context.Context) apiLogoutUserRequest {
-    return apiLogoutUserRequest{
-        apiService: a,
-        ctx: ctx,
-    }
+	return apiLogoutUserRequest{
+		apiService: a,
+		ctx: ctx,
+	}
 }
 
 /*
@@ -713,18 +681,13 @@ func (r apiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.LogoutUser")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.LogoutUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/logout"
 
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/logout"
->>>>>>> [go-experimental] Use builder pattern for requests
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
@@ -773,16 +736,16 @@ func (r apiLogoutUserRequest) Execute() (*_nethttp.Response, error) {
 	return localVarHTTPResponse, nil
 }
 type apiUpdateUserRequest struct {
-    ctx _context.Context
-    apiService *UserApiService
-    username string
-    user *User
+	ctx _context.Context
+	apiService *UserApiService
+	username string
+	user *User
 }
 
 
 func (r apiUpdateUserRequest) User(user User) apiUpdateUserRequest {
-    r.user = &user
-    return r
+	r.user = &user
+	return r
 }
 
 /*
@@ -793,11 +756,11 @@ This can only be done by the logged in user.
 @return apiUpdateUserRequest
 */
 func (a *UserApiService) UpdateUser(ctx _context.Context, username string) apiUpdateUserRequest {
-    return apiUpdateUserRequest{
-        apiService: a,
-        ctx: ctx,
-        username: username,
-    }
+	return apiUpdateUserRequest{
+		apiService: a,
+		ctx: ctx,
+		username: username,
+	}
 }
 
 /*
@@ -814,28 +777,22 @@ func (r apiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 		
 	)
 
-<<<<<<< HEAD
-	localBasePath, err := a.client.cfg.ServerURLWithContext(ctx, "UserApiService.UpdateUser")
+	localBasePath, err := r.apiService.client.cfg.ServerURLWithContext(r.ctx, "UserApiService.UpdateUser")
 	if err != nil {
 		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/user/{username}"
-	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(username, "")) , -1)
-=======
-	// create path and map variables
-	localVarPath := r.apiService.client.cfg.BasePath + "/user/{username}"
 	localVarPath = strings.Replace(localVarPath, "{"+"username"+"}", _neturl.QueryEscape(parameterToString(r.username, "")) , -1)
->>>>>>> [go-experimental] Use builder pattern for requests
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	
 	
-    if r.user == nil {
-        return nil, reportError("user is required and must be specified")
-    }
+	if r.user == nil {
+		return nil, reportError("user is required and must be specified")
+	}
 
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{"application/json"}
@@ -855,7 +812,7 @@ func (r apiUpdateUserRequest) Execute() (*_nethttp.Response, error) {
 		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
 	// body params
-	localVarPostBody = *r.user
+	localVarPostBody = r.user
 	req, err := r.apiService.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/AnotherFakeApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/AnotherFakeApi.md
@@ -10,19 +10,24 @@ Method | HTTP request | Description
 
 ## Call123TestSpecialTags
 
-> Client Call123TestSpecialTags(ctx, client)
+> Client Call123TestSpecialTags(ctx).Client(client).Execute()
 
 To test special tags
 
-To test special tags and operation ID starting with number
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCall123TestSpecialTagsRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**client** | [**Client**](Client.md)| client model | 
+ **client** | [**Client**](Client.md) | client model | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/DefaultApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/DefaultApi.md
@@ -10,13 +10,18 @@ Method | HTTP request | Description
 
 ## FooGet
 
-> InlineResponseDefault FooGet(ctx, )
+> InlineResponseDefault FooGet(ctx).Execute()
 
 
 
-### Required Parameters
+### Path Parameters
 
 This endpoint does not need any parameter.
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFooGetRequest struct via the builder pattern
+
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FakeApi.md
@@ -23,13 +23,18 @@ Method | HTTP request | Description
 
 ## FakeHealthGet
 
-> HealthCheckResult FakeHealthGet(ctx, )
+> HealthCheckResult FakeHealthGet(ctx).Execute()
 
 Health check endpoint
 
-### Required Parameters
+### Path Parameters
 
 This endpoint does not need any parameter.
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFakeHealthGetRequest struct via the builder pattern
+
 
 ### Return type
 
@@ -51,28 +56,24 @@ No authorization required
 
 ## FakeOuterBooleanSerialize
 
-> bool FakeOuterBooleanSerialize(ctx, optional)
+> bool FakeOuterBooleanSerialize(ctx).Body(body).Execute()
 
 
 
-Test serialization of outer boolean types
-
-### Required Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
- **optional** | ***FakeOuterBooleanSerializeOpts** | optional parameters | nil if no parameters
+### Path Parameters
 
-### Optional Parameters
 
-Optional parameters are passed through a pointer to a FakeOuterBooleanSerializeOpts struct
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFakeOuterBooleanSerializeRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | **optional.Bool**| Input boolean as post body | 
+ **body** | **bool** | Input boolean as post body | 
 
 ### Return type
 
@@ -94,28 +95,24 @@ No authorization required
 
 ## FakeOuterCompositeSerialize
 
-> OuterComposite FakeOuterCompositeSerialize(ctx, optional)
+> OuterComposite FakeOuterCompositeSerialize(ctx).OuterComposite(outerComposite).Execute()
 
 
 
-Test serialization of object with outer number type
-
-### Required Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
- **optional** | ***FakeOuterCompositeSerializeOpts** | optional parameters | nil if no parameters
+### Path Parameters
 
-### Optional Parameters
 
-Optional parameters are passed through a pointer to a FakeOuterCompositeSerializeOpts struct
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFakeOuterCompositeSerializeRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **outerComposite** | [**optional.Interface of OuterComposite**](OuterComposite.md)| Input composite as post body | 
+ **outerComposite** | [**OuterComposite**](OuterComposite.md) | Input composite as post body | 
 
 ### Return type
 
@@ -137,28 +134,24 @@ No authorization required
 
 ## FakeOuterNumberSerialize
 
-> float32 FakeOuterNumberSerialize(ctx, optional)
+> float32 FakeOuterNumberSerialize(ctx).Body(body).Execute()
 
 
 
-Test serialization of outer number types
-
-### Required Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
- **optional** | ***FakeOuterNumberSerializeOpts** | optional parameters | nil if no parameters
+### Path Parameters
 
-### Optional Parameters
 
-Optional parameters are passed through a pointer to a FakeOuterNumberSerializeOpts struct
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFakeOuterNumberSerializeRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | **optional.Float32**| Input number as post body | 
+ **body** | **float32** | Input number as post body | 
 
 ### Return type
 
@@ -180,28 +173,24 @@ No authorization required
 
 ## FakeOuterStringSerialize
 
-> string FakeOuterStringSerialize(ctx, optional)
+> string FakeOuterStringSerialize(ctx).Body(body).Execute()
 
 
 
-Test serialization of outer string types
-
-### Required Parameters
 
 
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
- **optional** | ***FakeOuterStringSerializeOpts** | optional parameters | nil if no parameters
+### Path Parameters
 
-### Optional Parameters
 
-Optional parameters are passed through a pointer to a FakeOuterStringSerializeOpts struct
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFakeOuterStringSerializeRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **body** | **optional.String**| Input string as post body | 
+ **body** | **string** | Input string as post body | 
 
 ### Return type
 
@@ -223,19 +212,24 @@ No authorization required
 
 ## TestBodyWithFileSchema
 
-> TestBodyWithFileSchema(ctx, fileSchemaTestClass)
+> TestBodyWithFileSchema(ctx).FileSchemaTestClass(fileSchemaTestClass).Execute()
 
 
 
-For this test, the body for this request much reference a schema named `File`.
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestBodyWithFileSchemaRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**fileSchemaTestClass** | [**FileSchemaTestClass**](FileSchemaTestClass.md)|  | 
+ **fileSchemaTestClass** | [**FileSchemaTestClass**](FileSchemaTestClass.md) |  | 
 
 ### Return type
 
@@ -257,18 +251,23 @@ No authorization required
 
 ## TestBodyWithQueryParams
 
-> TestBodyWithQueryParams(ctx, query, user)
+> TestBodyWithQueryParams(ctx).Query(query).User(user).Execute()
 
 
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestBodyWithQueryParamsRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**query** | **string**|  | 
-**user** | [**User**](User.md)|  | 
+ **query** | **string** |  | 
+ **user** | [**User**](User.md) |  | 
 
 ### Return type
 
@@ -290,19 +289,24 @@ No authorization required
 
 ## TestClientModel
 
-> Client TestClientModel(ctx, client)
+> Client TestClientModel(ctx).Client(client).Execute()
 
 To test \"client\" model
 
-To test \"client\" model
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestClientModelRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**client** | [**Client**](Client.md)| client model | 
+ **client** | [**Client**](Client.md) | client model | 
 
 ### Return type
 
@@ -324,45 +328,37 @@ No authorization required
 
 ## TestEndpointParameters
 
-> TestEndpointParameters(ctx, number, double, patternWithoutDelimiter, byte_, optional)
+> TestEndpointParameters(ctx).Number(number).Double(double).PatternWithoutDelimiter(patternWithoutDelimiter).Byte_(byte_).Integer(integer).Int32_(int32_).Int64_(int64_).Float(float).String_(string_).Binary(binary).Date(date).DateTime(dateTime).Password(password).Callback(callback).Execute()
 
 Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
-Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestEndpointParametersRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**number** | **float32**| None | 
-**double** | **float64**| None | 
-**patternWithoutDelimiter** | **string**| None | 
-**byte_** | **string**| None | 
- **optional** | ***TestEndpointParametersOpts** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a pointer to a TestEndpointParametersOpts struct
-
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-
-
-
-
- **integer** | **optional.Int32**| None | 
- **int32_** | **optional.Int32**| None | 
- **int64_** | **optional.Int64**| None | 
- **float** | **optional.Float32**| None | 
- **string_** | **optional.String**| None | 
- **binary** | **optional.Interface of *os.File****optional.*os.File**| None | 
- **date** | **optional.String**| None | 
- **dateTime** | **optional.Time**| None | 
- **password** | **optional.String**| None | 
- **callback** | **optional.String**| None | 
+ **number** | **float32** | None | 
+ **double** | **float64** | None | 
+ **patternWithoutDelimiter** | **string** | None | 
+ **byte_** | **string** | None | 
+ **integer** | **int32** | None | 
+ **int32_** | **int32** | None | 
+ **int64_** | **int64** | None | 
+ **float** | **float32** | None | 
+ **string_** | **string** | None | 
+ **binary** | ***os.File** | None | 
+ **date** | **string** | None | 
+ **dateTime** | **time.Time** | None | 
+ **password** | **string** | None | 
+ **callback** | **string** | None | 
 
 ### Return type
 
@@ -384,35 +380,31 @@ Name | Type | Description  | Notes
 
 ## TestEnumParameters
 
-> TestEnumParameters(ctx, optional)
+> TestEnumParameters(ctx).EnumHeaderStringArray(enumHeaderStringArray).EnumHeaderString(enumHeaderString).EnumQueryStringArray(enumQueryStringArray).EnumQueryString(enumQueryString).EnumQueryInteger(enumQueryInteger).EnumQueryDouble(enumQueryDouble).EnumFormStringArray(enumFormStringArray).EnumFormString(enumFormString).Execute()
 
 To test enum parameters
 
-To test enum parameters
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestEnumParametersRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
- **optional** | ***TestEnumParametersOpts** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a pointer to a TestEnumParametersOpts struct
-
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **enumHeaderStringArray** | [**optional.Interface of []string**](string.md)| Header parameter enum test (string array) | 
- **enumHeaderString** | **optional.String**| Header parameter enum test (string) | [default to -efg]
- **enumQueryStringArray** | [**optional.Interface of []string**](string.md)| Query parameter enum test (string array) | 
- **enumQueryString** | **optional.String**| Query parameter enum test (string) | [default to -efg]
- **enumQueryInteger** | **optional.Int32**| Query parameter enum test (double) | 
- **enumQueryDouble** | **optional.Float64**| Query parameter enum test (double) | 
- **enumFormStringArray** | [**optional.Interface of []string**](string.md)| Form parameter enum test (string array) | [default to $]
- **enumFormString** | **optional.String**| Form parameter enum test (string) | [default to -efg]
+ **enumHeaderStringArray** | [**[]string**](string.md) | Header parameter enum test (string array) | 
+ **enumHeaderString** | **string** | Header parameter enum test (string) | [default to -efg]
+ **enumQueryStringArray** | [**[]string**](string.md) | Query parameter enum test (string array) | 
+ **enumQueryString** | **string** | Query parameter enum test (string) | [default to -efg]
+ **enumQueryInteger** | **int32** | Query parameter enum test (double) | 
+ **enumQueryDouble** | **float64** | Query parameter enum test (double) | 
+ **enumFormStringArray** | [**[]string**](string.md) | Form parameter enum test (string array) | [default to $]
+ **enumFormString** | **string** | Form parameter enum test (string) | [default to -efg]
 
 ### Return type
 
@@ -434,36 +426,29 @@ No authorization required
 
 ## TestGroupParameters
 
-> TestGroupParameters(ctx, requiredStringGroup, requiredBooleanGroup, requiredInt64Group, optional)
+> TestGroupParameters(ctx).RequiredStringGroup(requiredStringGroup).RequiredBooleanGroup(requiredBooleanGroup).RequiredInt64Group(requiredInt64Group).StringGroup(stringGroup).BooleanGroup(booleanGroup).Int64Group(int64Group).Execute()
 
 Fake endpoint to test group parameters (optional)
 
-Fake endpoint to test group parameters (optional)
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestGroupParametersRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**requiredStringGroup** | **int32**| Required String in group parameters | 
-**requiredBooleanGroup** | **bool**| Required Boolean in group parameters | 
-**requiredInt64Group** | **int64**| Required Integer in group parameters | 
- **optional** | ***TestGroupParametersOpts** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a pointer to a TestGroupParametersOpts struct
-
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-
-
-
- **stringGroup** | **optional.Int32**| String in group parameters | 
- **booleanGroup** | **optional.Bool**| Boolean in group parameters | 
- **int64Group** | **optional.Int64**| Integer in group parameters | 
+ **requiredStringGroup** | **int32** | Required String in group parameters | 
+ **requiredBooleanGroup** | **bool** | Required Boolean in group parameters | 
+ **requiredInt64Group** | **int64** | Required Integer in group parameters | 
+ **stringGroup** | **int32** | String in group parameters | 
+ **booleanGroup** | **bool** | Boolean in group parameters | 
+ **int64Group** | **int64** | Integer in group parameters | 
 
 ### Return type
 
@@ -485,17 +470,22 @@ Name | Type | Description  | Notes
 
 ## TestInlineAdditionalProperties
 
-> TestInlineAdditionalProperties(ctx, requestBody)
+> TestInlineAdditionalProperties(ctx).RequestBody(requestBody).Execute()
 
 test inline additionalProperties
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestInlineAdditionalPropertiesRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**requestBody** | [**map[string]string**](string.md)| request body | 
+ **requestBody** | [**map[string]string**](string.md) | request body | 
 
 ### Return type
 
@@ -517,18 +507,23 @@ No authorization required
 
 ## TestJsonFormData
 
-> TestJsonFormData(ctx, param, param2)
+> TestJsonFormData(ctx).Param(param).Param2(param2).Execute()
 
 test json serialization of form data
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestJsonFormDataRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**param** | **string**| field1 | 
-**param2** | **string**| field2 | 
+ **param** | **string** | field1 | 
+ **param2** | **string** | field2 | 
 
 ### Return type
 
@@ -550,23 +545,28 @@ No authorization required
 
 ## TestQueryParameterCollectionFormat
 
-> TestQueryParameterCollectionFormat(ctx, pipe, ioutil, http, url, context)
+> TestQueryParameterCollectionFormat(ctx).Pipe(pipe).Ioutil(ioutil).Http(http).Url(url).Context(context).Execute()
 
 
 
-To test the collection format in query parameters
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestQueryParameterCollectionFormatRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**pipe** | [**[]string**](string.md)|  | 
-**ioutil** | [**[]string**](string.md)|  | 
-**http** | [**[]string**](string.md)|  | 
-**url** | [**[]string**](string.md)|  | 
-**context** | [**[]string**](string.md)|  | 
+ **pipe** | [**[]string**](string.md) |  | 
+ **ioutil** | [**[]string**](string.md) |  | 
+ **http** | [**[]string**](string.md) |  | 
+ **url** | [**[]string**](string.md) |  | 
+ **context** | [**[]string**](string.md) |  | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FakeClassnameTags123Api.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/FakeClassnameTags123Api.md
@@ -10,19 +10,24 @@ Method | HTTP request | Description
 
 ## TestClassname
 
-> Client TestClassname(ctx, client)
+> Client TestClassname(ctx).Client(client).Execute()
 
 To test class name in snake case
 
-To test class name in snake case
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestClassnameRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**client** | [**Client**](Client.md)| client model | 
+ **client** | [**Client**](Client.md) | client model | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/PetApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/PetApi.md
@@ -18,17 +18,22 @@ Method | HTTP request | Description
 
 ## AddPet
 
-> AddPet(ctx, pet)
+> AddPet(ctx).Pet(pet).Execute()
 
 Add a new pet to the store
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiAddPetRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **pet** | [**Pet**](Pet.md) | Pet object that needs to be added to the store | 
 
 ### Return type
 
@@ -50,28 +55,27 @@ Name | Type | Description  | Notes
 
 ## DeletePet
 
-> DeletePet(ctx, petId, optional)
+> DeletePet(ctx, petId).ApiKey(apiKey).Execute()
 
 Deletes a pet
 
-### Required Parameters
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**petId** | **int64**| Pet id to delete | 
- **optional** | ***DeletePetOpts** | optional parameters | nil if no parameters
+**petId** | **int64** | Pet id to delete | 
 
-### Optional Parameters
+### Other Parameters
 
-Optional parameters are passed through a pointer to a DeletePetOpts struct
+Other parameters are passed through a pointer to a apiDeletePetRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **apiKey** | **optional.String**|  | 
+ **apiKey** | **string** |  | 
 
 ### Return type
 
@@ -93,19 +97,24 @@ Name | Type | Description  | Notes
 
 ## FindPetsByStatus
 
-> []Pet FindPetsByStatus(ctx, status)
+> []Pet FindPetsByStatus(ctx).Status(status).Execute()
 
 Finds Pets by status
 
-Multiple status values can be provided with comma separated strings
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFindPetsByStatusRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**status** | [**[]string**](string.md)| Status values that need to be considered for filter | 
+ **status** | [**[]string**](string.md) | Status values that need to be considered for filter | 
 
 ### Return type
 
@@ -127,19 +136,24 @@ Name | Type | Description  | Notes
 
 ## FindPetsByTags
 
-> []Pet FindPetsByTags(ctx, tags)
+> []Pet FindPetsByTags(ctx).Tags(tags).Execute()
 
 Finds Pets by tags
 
-Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFindPetsByTagsRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**tags** | [**[]string**](string.md)| Tags to filter by | 
+ **tags** | [**[]string**](string.md) | Tags to filter by | 
 
 ### Return type
 
@@ -161,19 +175,28 @@ Name | Type | Description  | Notes
 
 ## GetPetById
 
-> Pet GetPetById(ctx, petId)
+> Pet GetPetById(ctx, petId).Execute()
 
 Find pet by ID
 
-Returns a single pet
 
-### Required Parameters
+
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**petId** | **int64**| ID of pet to return | 
+**petId** | **int64** | ID of pet to return | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetPetByIdRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 
@@ -195,17 +218,22 @@ Name | Type | Description  | Notes
 
 ## UpdatePet
 
-> UpdatePet(ctx, pet)
+> UpdatePet(ctx).Pet(pet).Execute()
 
 Update an existing pet
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiUpdatePetRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**pet** | [**Pet**](Pet.md)| Pet object that needs to be added to the store | 
+ **pet** | [**Pet**](Pet.md) | Pet object that needs to be added to the store | 
 
 ### Return type
 
@@ -227,29 +255,28 @@ Name | Type | Description  | Notes
 
 ## UpdatePetWithForm
 
-> UpdatePetWithForm(ctx, petId, optional)
+> UpdatePetWithForm(ctx, petId).Name(name).Status(status).Execute()
 
 Updates a pet in the store with form data
 
-### Required Parameters
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**petId** | **int64**| ID of pet that needs to be updated | 
- **optional** | ***UpdatePetWithFormOpts** | optional parameters | nil if no parameters
+**petId** | **int64** | ID of pet that needs to be updated | 
 
-### Optional Parameters
+### Other Parameters
 
-Optional parameters are passed through a pointer to a UpdatePetWithFormOpts struct
+Other parameters are passed through a pointer to a apiUpdatePetWithFormRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **name** | **optional.String**| Updated name of the pet | 
- **status** | **optional.String**| Updated status of the pet | 
+ **name** | **string** | Updated name of the pet | 
+ **status** | **string** | Updated status of the pet | 
 
 ### Return type
 
@@ -271,29 +298,28 @@ Name | Type | Description  | Notes
 
 ## UploadFile
 
-> ApiResponse UploadFile(ctx, petId, optional)
+> ApiResponse UploadFile(ctx, petId).AdditionalMetadata(additionalMetadata).File(file).Execute()
 
 uploads an image
 
-### Required Parameters
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**petId** | **int64**| ID of pet to update | 
- **optional** | ***UploadFileOpts** | optional parameters | nil if no parameters
+**petId** | **int64** | ID of pet to update | 
 
-### Optional Parameters
+### Other Parameters
 
-Optional parameters are passed through a pointer to a UploadFileOpts struct
+Other parameters are passed through a pointer to a apiUploadFileRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
- **additionalMetadata** | **optional.String**| Additional data to pass to server | 
- **file** | **optional.Interface of *os.File****optional.*os.File**| file to upload | 
+ **additionalMetadata** | **string** | Additional data to pass to server | 
+ **file** | ***os.File** | file to upload | 
 
 ### Return type
 
@@ -315,30 +341,28 @@ Name | Type | Description  | Notes
 
 ## UploadFileWithRequiredFile
 
-> ApiResponse UploadFileWithRequiredFile(ctx, petId, requiredFile, optional)
+> ApiResponse UploadFileWithRequiredFile(ctx, petId).RequiredFile(requiredFile).AdditionalMetadata(additionalMetadata).Execute()
 
 uploads an image (required)
 
-### Required Parameters
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**petId** | **int64**| ID of pet to update | 
-**requiredFile** | ***os.File*****os.File**| file to upload | 
- **optional** | ***UploadFileWithRequiredFileOpts** | optional parameters | nil if no parameters
+**petId** | **int64** | ID of pet to update | 
 
-### Optional Parameters
+### Other Parameters
 
-Optional parameters are passed through a pointer to a UploadFileWithRequiredFileOpts struct
+Other parameters are passed through a pointer to a apiUploadFileWithRequiredFileRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
-
- **additionalMetadata** | **optional.String**| Additional data to pass to server | 
+ **requiredFile** | ***os.File** | file to upload | 
+ **additionalMetadata** | **string** | Additional data to pass to server | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/StoreApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/StoreApi.md
@@ -13,19 +13,28 @@ Method | HTTP request | Description
 
 ## DeleteOrder
 
-> DeleteOrder(ctx, orderId)
+> DeleteOrder(ctx, orderId).Execute()
 
 Delete purchase order by ID
 
-For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
 
-### Required Parameters
+
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**orderId** | **string**| ID of the order that needs to be deleted | 
+**orderId** | **string** | ID of the order that needs to be deleted | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiDeleteOrderRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 
@@ -47,15 +56,20 @@ No authorization required
 
 ## GetInventory
 
-> map[string]int32 GetInventory(ctx, )
+> map[string]int32 GetInventory(ctx).Execute()
 
 Returns pet inventories by status
 
-Returns a map of status codes to quantities
 
-### Required Parameters
+
+### Path Parameters
 
 This endpoint does not need any parameter.
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetInventoryRequest struct via the builder pattern
+
 
 ### Return type
 
@@ -77,19 +91,28 @@ This endpoint does not need any parameter.
 
 ## GetOrderById
 
-> Order GetOrderById(ctx, orderId)
+> Order GetOrderById(ctx, orderId).Execute()
 
 Find purchase order by ID
 
-For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
 
-### Required Parameters
+
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**orderId** | **int64**| ID of pet that needs to be fetched | 
+**orderId** | **int64** | ID of pet that needs to be fetched | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetOrderByIdRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 
@@ -111,17 +134,22 @@ No authorization required
 
 ## PlaceOrder
 
-> Order PlaceOrder(ctx, order)
+> Order PlaceOrder(ctx).Order(order).Execute()
 
 Place an order for a pet
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiPlaceOrderRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**order** | [**Order**](Order.md)| order placed for purchasing the pet | 
+ **order** | [**Order**](Order.md) | order placed for purchasing the pet | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/UserApi.md
+++ b/samples/openapi3/client/petstore/go-experimental/go-petstore/docs/UserApi.md
@@ -17,19 +17,24 @@ Method | HTTP request | Description
 
 ## CreateUser
 
-> CreateUser(ctx, user)
+> CreateUser(ctx).User(user).Execute()
 
 Create user
 
-This can only be done by the logged in user.
 
-### Required Parameters
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCreateUserRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**user** | [**User**](User.md)| Created user object | 
+ **user** | [**User**](User.md) | Created user object | 
 
 ### Return type
 
@@ -51,17 +56,22 @@ No authorization required
 
 ## CreateUsersWithArrayInput
 
-> CreateUsersWithArrayInput(ctx, user)
+> CreateUsersWithArrayInput(ctx).User(user).Execute()
 
 Creates list of users with given input array
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCreateUsersWithArrayInputRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**user** | [**[]User**](User.md)| List of user object | 
+ **user** | [**[]User**](User.md) | List of user object | 
 
 ### Return type
 
@@ -83,17 +93,22 @@ No authorization required
 
 ## CreateUsersWithListInput
 
-> CreateUsersWithListInput(ctx, user)
+> CreateUsersWithListInput(ctx).User(user).Execute()
 
 Creates list of users with given input array
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiCreateUsersWithListInputRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**user** | [**[]User**](User.md)| List of user object | 
+ **user** | [**[]User**](User.md) | List of user object | 
 
 ### Return type
 
@@ -115,19 +130,28 @@ No authorization required
 
 ## DeleteUser
 
-> DeleteUser(ctx, username)
+> DeleteUser(ctx, username).Execute()
 
 Delete user
 
-This can only be done by the logged in user.
 
-### Required Parameters
+
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**username** | **string**| The name that needs to be deleted | 
+**username** | **string** | The name that needs to be deleted | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiDeleteUserRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 
@@ -149,17 +173,26 @@ No authorization required
 
 ## GetUserByName
 
-> User GetUserByName(ctx, username)
+> User GetUserByName(ctx, username).Execute()
 
 Get user by user name
 
-### Required Parameters
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**username** | **string**| The name that needs to be fetched. Use user1 for testing. | 
+**username** | **string** | The name that needs to be fetched. Use user1 for testing. | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiGetUserByNameRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
 
 ### Return type
 
@@ -181,18 +214,23 @@ No authorization required
 
 ## LoginUser
 
-> string LoginUser(ctx, username, password)
+> string LoginUser(ctx).Username(username).Password(password).Execute()
 
 Logs user into the system
 
-### Required Parameters
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiLoginUserRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**username** | **string**| The user name for login | 
-**password** | **string**| The password for login in clear text | 
+ **username** | **string** | The user name for login | 
+ **password** | **string** | The password for login in clear text | 
 
 ### Return type
 
@@ -214,13 +252,18 @@ No authorization required
 
 ## LogoutUser
 
-> LogoutUser(ctx, )
+> LogoutUser(ctx).Execute()
 
 Logs out current logged in user session
 
-### Required Parameters
+### Path Parameters
 
 This endpoint does not need any parameter.
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiLogoutUserRequest struct via the builder pattern
+
 
 ### Return type
 
@@ -242,20 +285,29 @@ No authorization required
 
 ## UpdateUser
 
-> UpdateUser(ctx, username, user)
+> UpdateUser(ctx, username).User(user).Execute()
 
 Updated user
 
-This can only be done by the logged in user.
 
-### Required Parameters
+
+### Path Parameters
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**username** | **string**| name that need to be deleted | 
-**user** | [**User**](User.md)| Updated user object | 
+**username** | **string** | name that need to be deleted | 
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiUpdateUserRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+ **user** | [**User**](User.md) | Updated user object | 
 
 ### Return type
 


### PR DESCRIPTION
Implement builder pattern to construct requests and pass all parameters. Similar construct as #4666 

The motivation for this is to keep a client that will stay backward compatible in case some required parameters become optional which is not a breaking change in itself, but with the current implementation, it would change the method signature, thus introducing a breaking change in the client upon new generation.

Only path parameters are always required and any change would break the API itself, which is why I left them in the function signature. 
cf https://swagger.io/specification/#parameterObject:
> Determines whether this parameter is mandatory. If the parameter location is "path", this property is REQUIRED and its value MUST be true. 

Additionally, this removes the use of the `antihax/optional` module for query parameters, as we don't need the explicit null functionality here. 
cf https://github.com/OpenAPITools/openapi-generator/issues/522#issuecomment-523896869

Any feedback/suggestion would be much appreciated.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @antihax (2017/11) @bvwells (2017/12) @grokify (2018/07) @kemokemo (2018/09) @bkabrda (2019/07)