### PR TITLE
typescript-angular: optimize tree-shaking by disabling providers array when for providedIn: root is set

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.module.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.module.mustache
@@ -13,9 +13,9 @@ import { {{classname}} } from './{{importPath}}';
   imports:      [],
   declarations: [],
   exports:      [],
-  providers: [
+  providers: [{{^providedInRoot}}
     {{#apiInfo}}{{#apis}}{{classname}}{{#hasMore}},
-    {{/hasMore}}{{/apis}}{{/apiInfo}} ]
+    {{/hasMore}}{{/apis}}{{/apiInfo}} {{/providedInRoot}}]
 })
 export class {{apiModuleClassName}} {
     public static forRoot(configurationFactory: () => Configuration): ModuleWithProviders {

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/default/api.module.ts
@@ -11,10 +11,7 @@ import { UserService } from './api/user.service';
   imports:      [],
   declarations: [],
   exports:      [],
-  providers: [
-    PetService,
-    StoreService,
-    UserService ]
+  providers: []
 })
 export class ApiModule {
     public static forRoot(configurationFactory: () => Configuration): ModuleWithProviders {

--- a/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v6-provided-in-root/builds/with-npm/api.module.ts
@@ -11,10 +11,7 @@ import { UserService } from './api/user.service';
   imports:      [],
   declarations: [],
   exports:      [],
-  providers: [
-    PetService,
-    StoreService,
-    UserService ]
+  providers: []
 })
 export class ApiModule {
     public static forRoot(configurationFactory: () => Configuration): ModuleWithProviders {

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/default/api.module.ts
@@ -11,10 +11,7 @@ import { UserService } from './api/user.service';
   imports:      [],
   declarations: [],
   exports:      [],
-  providers: [
-    PetService,
-    StoreService,
-    UserService ]
+  providers: []
 })
 export class ApiModule {
     public static forRoot(configurationFactory: () => Configuration): ModuleWithProviders {

--- a/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v7-provided-in-root/builds/with-npm/api.module.ts
@@ -11,10 +11,7 @@ import { UserService } from './api/user.service';
   imports:      [],
   declarations: [],
   exports:      [],
-  providers: [
-    PetService,
-    StoreService,
-    UserService ]
+  providers: []
 })
 export class ApiModule {
     public static forRoot(configurationFactory: () => Configuration): ModuleWithProviders {

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/single-request-parameter/api.module.ts
@@ -11,10 +11,7 @@ import { UserService } from './api/user.service';
   imports:      [],
   declarations: [],
   exports:      [],
-  providers: [
-    PetService,
-    StoreService,
-    UserService ]
+  providers: []
 })
 export class ApiModule {
     public static forRoot(configurationFactory: () => Configuration): ModuleWithProviders {

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-npm/api.module.ts
@@ -11,10 +11,7 @@ import { UserService } from './api/user.service';
   imports:      [],
   declarations: [],
   exports:      [],
-  providers: [
-    PetService,
-    StoreService,
-    UserService ]
+  providers: []
 })
 export class ApiModule {
     public static forRoot(configurationFactory: () => Configuration): ModuleWithProviders {

--- a/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api.module.ts
+++ b/samples/client/petstore/typescript-angular-v8-provided-in-root/builds/with-prefixed-module-name/api.module.ts
@@ -11,10 +11,7 @@ import { UserService } from './api/user.service';
   imports:      [],
   declarations: [],
   exports:      [],
-  providers: [
-    PetService,
-    StoreService,
-    UserService ]
+  providers: []
 })
 export class PetStoreApiModule {
     public static forRoot(configurationFactory: () => Configuration): ModuleWithProviders {


### PR DESCRIPTION
Relates to https://github.com/OpenAPITools/openapi-generator/pull/120

This PR removes services from the `providers` array in `@NgModule`s when `providedInRoot` mode is on.

Listing the providers in the `providers` array is not required if using `providedIn: 'root'` syntax. By excluding the providers from this array, the ones that are not used can be tree shaken out and excluded from the final build.

More info here:

https://angular.io/guide/providers#providedin-and-ngmodules

Without this change, all services are bundled in a final production bundle, regardless of if they are injected or not.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

cc @topce  @akehir 