### PR TITLE
[typescript-axios][client] Unnecessary imports occurs when using nested model in allOf

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAxiosClientCodegen.java
@@ -145,6 +145,22 @@ public class TypeScriptAxiosClientCodegen extends AbstractTypeScriptClientCodege
     }
 
     @Override
+    public Map<String, Object> postProcessAllModels(Map<String, Object> objs) {
+        Map<String, Object> result = super.postProcessAllModels(objs);
+        for (Map.Entry<String, Object> entry : result.entrySet()) {
+            Map<String, Object> inner = (Map<String, Object>) entry.getValue();
+            List<Map<String, Object>> models = (List<Map<String, Object>>) inner.get("models");
+            for (Map<String, Object> model : models) {
+                CodegenModel codegenModel = (CodegenModel) model.get("model");
+                model.put("hasAllOf", codegenModel.allOf.size() > 0);
+                model.put("hasOneOf", codegenModel.oneOf.size() > 0);
+            }
+        }
+        return result;
+    }
+
+
+    @Override
     protected void addAdditionPropertiesToCodeGenModel(CodegenModel codegenModel, Schema schema) {
         codegenModel.additionalPropertiesType = getTypeDeclaration(ModelUtils.getAdditionalProperties(schema));
         addImport(codegenModel, codegenModel.additionalPropertiesType);

--- a/modules/openapi-generator/src/main/resources/typescript-axios/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/model.mustache
@@ -1,8 +1,10 @@
 // tslint:disable
 {{>licenseInfo}}
-{{#withSeparateModelsAndApi}}{{#imports}}
-import { {{class}} } from './{{filename}}';{{/imports}}{{/withSeparateModelsAndApi}}
+{{#withSeparateModelsAndApi}}{{#hasAllOf}}{{#allOf}}
+import { {{class}} } from './{{filename}}';{{/allOf}}{{/hasAllOf}}{{#hasOneOf}}{{#oneOf}}
+import { {{class}} } from './{{filename}}';{{/oneOf}}{{/hasOneOf}}{{^hasAllOf}}{{^hasOneOf}}{{#imports}}
+import { {{class}} } from './{{filename}}';{{/imports}}{{/hasOneOf}}{{/hasAllOf}}{{/withSeparateModelsAndApi}}
 {{#models}}{{#model}}
-{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{#allOf}}{{#-first}}{{>modelAllOf}}{{/-first}}{{/allOf}}{{^isEnum}}{{^oneOf}}{{^allOf}}{{>modelGeneric}}{{/allOf}}{{/oneOf}}{{/isEnum}}
 {{/model}}{{/models}}
 

--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelAllOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelAllOf.mustache
@@ -1,0 +1,6 @@
+/**
+ * @type {{classname}}{{#description}}
+ * {{{description}}}{{/description}}
+ * @export
+ */
+export type {{classname}} = {{#allOf}}{{{.}}}{{^-last}} & {{/-last}}{{/allOf}};


### PR DESCRIPTION
fixes #4804

Hello.
When using typescript-axios, a warning occurred in unused import.
I tried to fix it, so please take a look if you like.

Before
```js
import { Box } from './box';
import { BoxInBox } from './box-in-box';
import { Response } from './response';

/**
 * 
 * @export
 * @interface BoxesResponse
 */
export interface BoxesResponse {
    /**
     * 
     * @type {string}
     * @memberof BoxesResponse
     */
    status: BoxesResponseStatusEnum;
    /**
     * 
     * @type {number}
     * @memberof BoxesResponse
     */
    id?: number;
    /**
     * 
     * @type {string}
     * @memberof BoxesResponse
     */
    name?: string;
    /**
     * 
     * @type {BoxInBox}
     * @memberof BoxesResponse
     */
    box?: BoxInBox;
}

/**
    * @export
    * @enum {string}
    */
export enum BoxesResponseStatusEnum {
    Success = 'success',
    Error = 'error'
}
```

After
```
import { Box } from './box';
import { Response } from './response';

/**
 * 
 * @export
 * @interface BoxesResponse
 */
export type BoxesResponse = Response & Box;
```

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @nicokoenig (2018/09) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11)
