### PR TITLE
[java] Jersey2 and resttemplate do not correctly send defaultCookies

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -715,6 +715,13 @@ public class ApiClient {
       }
     }
 
+    for (Entry<String, String> entry : defaultCookieMap.entrySet()) {
+      String value = entry.getValue();
+      if (value != null) {
+        invocationBuilder = invocationBuilder.cookie(entry.getKey(), value);
+      }
+    }
+
     for (Entry<String, String> entry : defaultHeaderMap.entrySet()) {
       String key = entry.getKey();
       if (!headerParams.containsKey(key)) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -663,7 +663,7 @@ public class ApiClient {
      * Build cookie header. Keeps a single value per cookie (as per <a href="https://tools.ietf.org/html/rfc6265#section-5.3">
      * RFC6265 section 5.3</a>).
      *
-     * @param cookies merged map of all cookies
+     * @param cookies map all cookies
      * @return header string for cookies.
      */
     private String buildCookieHeader(MultiValueMap<String, String> cookies) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -659,14 +659,20 @@ public class ApiClient {
         }
     }
 
+    /**
+     * Build cookie header. Keeps a single value per cookie (as per <a href="https://tools.ietf.org/html/rfc6265#section-5.3">
+     * RFC6265 section 5.3</a>).
+     *
+     * @param cookies merged map of all cookies
+     * @return header string for cookies.
+     */
     private String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
-            for (String value : entry.getValue()) {
-                cookieValue.append(String.format("%s%s=%s", delimiter, entry.getKey(), entry.getValue()));
-                delimiter = "; ";
-            }
+            final String value = entry.getValue().get(entry.getValue().size() - 1);
+            cookieValue.append(String.format("%s%s=%s", delimiter, entry.getKey(), value));
+            delimiter = "; ";
         }
         return cookieValue.toString();
     }

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/org/openapitools/client/ApiClient.java
@@ -699,6 +699,13 @@ public class ApiClient {
       }
     }
 
+    for (Entry<String, String> entry : defaultCookieMap.entrySet()) {
+      String value = entry.getValue();
+      if (value != null) {
+        invocationBuilder = invocationBuilder.cookie(entry.getKey(), value);
+      }
+    }
+
     for (Entry<String, String> entry : defaultHeaderMap.entrySet()) {
       String key = entry.getKey();
       if (!headerParams.containsKey(key)) {

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -699,6 +699,13 @@ public class ApiClient {
       }
     }
 
+    for (Entry<String, String> entry : defaultCookieMap.entrySet()) {
+      String value = entry.getValue();
+      if (value != null) {
+        invocationBuilder = invocationBuilder.cookie(entry.getKey(), value);
+      }
+    }
+
     for (Entry<String, String> entry : defaultHeaderMap.entrySet()) {
       String key = entry.getKey();
       if (!headerParams.containsKey(key)) {

--- a/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/org/openapitools/client/ApiClient.java
@@ -699,6 +699,13 @@ public class ApiClient {
       }
     }
 
+    for (Entry<String, String> entry : defaultCookieMap.entrySet()) {
+      String value = entry.getValue();
+      if (value != null) {
+        invocationBuilder = invocationBuilder.cookie(entry.getKey(), value);
+      }
+    }
+
     for (Entry<String, String> entry : defaultHeaderMap.entrySet()) {
       String key = entry.getKey();
       if (!headerParams.containsKey(key)) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -647,14 +647,20 @@ public class ApiClient {
         }
     }
 
+    /**
+     * Build cookie header. Keeps a single value per cookie (as per <a href="https://tools.ietf.org/html/rfc6265#section-5.3">
+     * RFC6265 section 5.3</a>).
+     *
+     * @param cookies merged map of all cookies
+     * @return header string for cookies.
+     */
     private String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
-            for (String value : entry.getValue()) {
-                cookieValue.append(String.format("%s%s=%s", delimiter, entry.getKey(), entry.getValue()));
-                delimiter = "; ";
-            }
+            final String value = entry.getValue().get(entry.getValue().size() - 1);
+            cookieValue.append(String.format("%s%s=%s", delimiter, entry.getKey(), value));
+            delimiter = "; ";
         }
         return cookieValue.toString();
     }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -651,7 +651,7 @@ public class ApiClient {
      * Build cookie header. Keeps a single value per cookie (as per <a href="https://tools.ietf.org/html/rfc6265#section-5.3">
      * RFC6265 section 5.3</a>).
      *
-     * @param cookies merged map of all cookies
+     * @param cookies map all cookies
      * @return header string for cookies.
      */
     private String buildCookieHeader(MultiValueMap<String, String> cookies) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -646,7 +646,7 @@ public class ApiClient {
      * Build cookie header. Keeps a single value per cookie (as per <a href="https://tools.ietf.org/html/rfc6265#section-5.3">
      * RFC6265 section 5.3</a>).
      *
-     * @param cookies merged map of all cookies
+     * @param cookies map all cookies
      * @return header string for cookies.
      */
     private String buildCookieHeader(MultiValueMap<String, String> cookies) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -642,14 +642,20 @@ public class ApiClient {
         }
     }
 
+    /**
+     * Build cookie header. Keeps a single value per cookie (as per <a href="https://tools.ietf.org/html/rfc6265#section-5.3">
+     * RFC6265 section 5.3</a>).
+     *
+     * @param cookies merged map of all cookies
+     * @return header string for cookies.
+     */
     private String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
-            for (String value : entry.getValue()) {
-                cookieValue.append(String.format("%s%s=%s", delimiter, entry.getKey(), entry.getValue()));
-                delimiter = "; ";
-            }
+            final String value = entry.getValue().get(entry.getValue().size() - 1);
+            cookieValue.append(String.format("%s%s=%s", delimiter, entry.getKey(), value));
+            delimiter = "; ";
         }
         return cookieValue.toString();
     }


### PR DESCRIPTION
Some of the java clients (jersey2 and resttemplate) were not sending the defaultCookies.

I added the defaultCookies implementation for jersey2 and validated that they are being included in the request in debugger (unfortunately it is hard to test outside of J2EE).

Resttemplate now adds the last cookie value (as per RFC) to the header instead of the toString value of the list. `Cookie: foo=bar` instead of `Cookie: foo=[bar]`.

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
