### PR TITLE
[java] Update jackson_databind_nullable_version to 0.2.1

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -138,7 +138,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     jersey_version = "1.19.4"
     jodatime_version = "2.9.9"
     junit_version = "4.12"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -122,7 +122,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.10"
     {{#threetenbp}}
     jackson_threetenbp_version = "2.9.10"
     {{/threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -122,7 +122,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.10"
+    jackson_databind_nullable_version = "0.2.1"
     {{#threetenbp}}
     jackson_threetenbp_version = "2.9.10"
     {{/threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -315,7 +315,7 @@
         <feign-version>{{#useFeign10}}10.2.3{{/useFeign10}}{{^useFeign10}}9.7.0{{/useFeign10}}</feign-version>
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.9.10</jackson-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
         {{#threetenbp}}
         <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -122,7 +122,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     google_api_client_version = "1.23.0"
     jersey_common_version = "2.25.1"
     jodatime_version = "2.9.9"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/pom.mustache
@@ -308,7 +308,7 @@
         <jersey-common-version>2.25.1</jersey-common-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/joda}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -121,7 +121,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     {{#supportJava6}}
     jersey_version = "2.6"
     commons_io_version=2.5

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pom.mustache
@@ -362,7 +362,7 @@
         {{/supportJava6}}
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         {{#threetenbp}}
         <threetenbp-version>2.9.10</threetenbp-version>
         {{/threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pom.mustache
@@ -215,7 +215,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <jackson-version>2.9.9</jackson-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
     </properties>
 </project>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -101,7 +101,7 @@ ext {
 {{#jackson}}
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10"
-    jackson_databind_nullable_version = 0.2.0
+    jackson_databind_nullable_version = 0.2.1
 {{/jackson}}
 {{#gson}}
     gson_version = "2.8.5"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
@@ -325,7 +325,7 @@
         {{#jackson}}
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         {{#threetenbp}}
         <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>
         {{/threetenbp}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -121,7 +121,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     threetenbp_version = "2.9.10"
     resteasy_version = "3.1.3.Final"
     {{^java8}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/pom.mustache
@@ -296,7 +296,7 @@
         <resteasy-version>3.1.3.Final</resteasy-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <threetenbp-version>2.9.10</threetenbp-version>
         {{^java8}}
         <jodatime-version>2.9.9</jodatime-version>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -122,7 +122,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     spring_web_version = "4.3.9.RELEASE"
     jodatime_version = "2.9.9"
     junit_version = "4.12"

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -311,7 +311,7 @@
         <spring-web-version>4.3.9.RELEASE</spring-web-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/joda}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -133,7 +133,7 @@ ext {
     {{#play26}}
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     play_version = "2.6.7"
     {{/play26}}
     {{/usePlayWS}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/pom.mustache
@@ -388,7 +388,7 @@
         <jackson-version>2.9.10</jackson-version>
         <play-version>2.6.7</play-version>
         {{/play26}}
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         {{/usePlayWS}}
         <retrofit-version>2.5.0</retrofit-version>
         {{#useRxJava}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/pom.mustache
@@ -291,7 +291,7 @@
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind>2.9.10.1</jackson-databind>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
     </properties>
 </project>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pom.mustache
@@ -145,7 +145,7 @@
         <spring-web-version>5.0.8.RELEASE</spring-web-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
         <reactor-version>3.1.8.RELEASE</reactor-version>
         <reactor-netty-version>0.7.8.RELEASE</reactor-netty-version>

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -98,7 +98,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     jackson_threetenbp_version = "2.9.10"
     feign_version = "9.7.0"
     feign_form_version = "2.1.0"

--- a/samples/client/petstore/java/feign/pom.xml
+++ b/samples/client/petstore/java/feign/pom.xml
@@ -282,7 +282,7 @@
         <feign-version>9.7.0</feign-version>
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.9.10</jackson-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
         <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/feign10x/build.gradle
+++ b/samples/client/petstore/java/feign10x/build.gradle
@@ -98,7 +98,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     jackson_threetenbp_version = "2.9.10"
     feign_version = "10.2.3"
     feign_form_version = "2.1.0"

--- a/samples/client/petstore/java/feign10x/pom.xml
+++ b/samples/client/petstore/java/feign10x/pom.xml
@@ -282,7 +282,7 @@
         <feign-version>10.2.3</feign-version>
         <feign-form-version>2.1.0</feign-form-version>
         <jackson-version>2.9.10</jackson-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
         <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/google-api-client/build.gradle
+++ b/samples/client/petstore/java/google-api-client/build.gradle
@@ -98,7 +98,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     google_api_client_version = "1.23.0"
     jersey_common_version = "2.25.1"
     jodatime_version = "2.9.9"

--- a/samples/client/petstore/java/google-api-client/pom.xml
+++ b/samples/client/petstore/java/google-api-client/pom.xml
@@ -260,7 +260,7 @@
         <jersey-common-version>2.25.1</jersey-common-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/jersey1/build.gradle
+++ b/samples/client/petstore/java/jersey1/build.gradle
@@ -114,7 +114,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     jersey_version = "1.19.4"
     jodatime_version = "2.9.9"
     junit_version = "4.12"

--- a/samples/client/petstore/java/jersey2-java6/pom.xml
+++ b/samples/client/petstore/java/jersey2-java6/pom.xml
@@ -292,7 +292,7 @@
         <commons_lang3_version>3.6</commons_lang3_version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <threetenbp-version>2.9.10</threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -97,7 +97,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     jersey_version = "2.27"
     junit_version = "4.12"
 }

--- a/samples/client/petstore/java/jersey2-java8/pom.xml
+++ b/samples/client/petstore/java/jersey2-java8/pom.xml
@@ -279,7 +279,7 @@
         <jersey-version>2.27</jersey-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>
     </properties>

--- a/samples/client/petstore/java/jersey2/build.gradle
+++ b/samples/client/petstore/java/jersey2/build.gradle
@@ -97,7 +97,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     jersey_version = "2.27"
     junit_version = "4.12"
     threetenbp_version = "2.9.10"

--- a/samples/client/petstore/java/jersey2/pom.xml
+++ b/samples/client/petstore/java/jersey2/pom.xml
@@ -285,7 +285,7 @@
         <jersey-version>2.27</jersey-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <threetenbp-version>2.9.10</threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/native/pom.xml
+++ b/samples/client/petstore/java/native/pom.xml
@@ -208,7 +208,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <jackson-version>2.9.9</jackson-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/resteasy/build.gradle
+++ b/samples/client/petstore/java/resteasy/build.gradle
@@ -97,7 +97,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     threetenbp_version = "2.9.10"
     resteasy_version = "3.1.3.Final"
     jodatime_version = "2.9.9"

--- a/samples/client/petstore/java/resteasy/pom.xml
+++ b/samples/client/petstore/java/resteasy/pom.xml
@@ -245,7 +245,7 @@
         <resteasy-version>3.1.3.Final</resteasy-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <threetenbp-version>2.9.10</threetenbp-version>
         <jodatime-version>2.9.9</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -98,7 +98,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     spring_web_version = "4.3.9.RELEASE"
     jodatime_version = "2.9.9"
     junit_version = "4.12"

--- a/samples/client/petstore/java/resttemplate-withXml/pom.xml
+++ b/samples/client/petstore/java/resttemplate-withXml/pom.xml
@@ -269,7 +269,7 @@
         <spring-web-version>4.3.9.RELEASE</spring-web-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -98,7 +98,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     spring_web_version = "4.3.9.RELEASE"
     jodatime_version = "2.9.9"
     junit_version = "4.12"

--- a/samples/client/petstore/java/resttemplate/pom.xml
+++ b/samples/client/petstore/java/resttemplate/pom.xml
@@ -261,7 +261,7 @@
         <spring-web-version>4.3.9.RELEASE</spring-web-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <jackson-threetenbp-version>2.9.10</jackson-threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/retrofit2-play24/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play24/pom.xml
@@ -282,7 +282,7 @@
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
         <jackson-version>2.6.6</jackson-version>
         <play-version>2.4.11</play-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <retrofit-version>2.5.0</retrofit-version>
         <oltu-version>1.0.1</oltu-version>
         <junit-version>4.12</junit-version>

--- a/samples/client/petstore/java/retrofit2-play25/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play25/pom.xml
@@ -287,7 +287,7 @@
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
         <jackson-version>2.9.10</jackson-version>
         <play-version>2.5.15</play-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <retrofit-version>2.5.0</retrofit-version>
         <threetenbp-version>1.4.0</threetenbp-version>
         <oltu-version>1.0.1</oltu-version>

--- a/samples/client/petstore/java/retrofit2-play26/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play26/build.gradle
@@ -99,7 +99,7 @@ ext {
     retrofit_version = "2.3.0"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     play_version = "2.6.7"
     swagger_annotations_version = "1.5.22"
     junit_version = "4.12"

--- a/samples/client/petstore/java/retrofit2-play26/pom.xml
+++ b/samples/client/petstore/java/retrofit2-play26/pom.xml
@@ -292,7 +292,7 @@
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
         <jackson-version>2.9.10</jackson-version>
         <play-version>2.6.7</play-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <retrofit-version>2.5.0</retrofit-version>
         <threetenbp-version>1.4.0</threetenbp-version>
         <oltu-version>1.0.1</oltu-version>

--- a/samples/client/petstore/java/vertx/pom.xml
+++ b/samples/client/petstore/java/vertx/pom.xml
@@ -268,7 +268,7 @@
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind>2.9.10.1</jackson-databind>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -114,7 +114,7 @@ ext {
     swagger_annotations_version = "1.5.22"
     jackson_version = "2.9.10"
     jackson_databind_version = "2.9.10.1"
-    jackson_databind_nullable_version = "0.2.0"
+    jackson_databind_nullable_version = "0.2.1"
     jersey_version = "1.19.4"
     jodatime_version = "2.9.9"
     junit_version = "4.12"

--- a/samples/client/petstore/java/webclient/pom.xml
+++ b/samples/client/petstore/java/webclient/pom.xml
@@ -124,7 +124,7 @@
         <spring-web-version>5.0.8.RELEASE</spring-web-version>
         <jackson-version>2.9.10</jackson-version>
         <jackson-databind-version>2.9.10.1</jackson-databind-version>
-        <jackson-databind-nullable-version>0.2.0</jackson-databind-nullable-version>
+        <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <junit-version>4.12</junit-version>
         <reactor-version>3.1.8.RELEASE</reactor-version>
         <reactor-netty-version>0.7.8.RELEASE</reactor-netty-version>


### PR DESCRIPTION
Version [0.2.1](https://github.com/OpenAPITools/jackson-databind-nullable/releases/tag/jackson-databind-nullable-0.2.1) of `jackson-databind-nullable` was released, this PR update the templates to use the new version in the generated projects.

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [ ] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
