### PR TITLE
[C-libcurl] Fix build error when a struct includes a pointer pointing to itself

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-header.mustache
@@ -72,7 +72,7 @@ typedef struct {{classname}}_t {
     {{datatype}}_e {{name}}; //enum model
     {{/isEnum}}
     {{^isEnum}}
-    {{datatype}}_t *{{name}}; //model
+    struct {{datatype}}_t *{{name}}; //model
     {{/isEnum}}
     {{/isModel}}
     {{#isUuid}}


### PR DESCRIPTION
[C-libcurl] Fix build error when a struct includes a pointer pointing to itself

After a C client is generated by the C-libcurl OpenAPI-generator,  a struct may include a pointer pointing to itself,  e.g.

```c
typedef struct v1_json_schema_props_t {
    ...
    v1_json_schema_props_t *not;  
    ...
} v1_json_schema_props_t;
```  

C compiler cannot recoginze v1_json_schema_props_t *not; so the building will fail.

We need change the template code, let the generated code like below:

```c
typedef struct v1_json_schema_props_t {
    ...
    struct v1_json_schema_props_t *not; //model
    ...
} v1_json_schema_props_t;

```


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [X] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [X] File the PR against the [master](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [X] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

@wing328 @zhemant