### PR TITLE
[MySQL] snake_case table and column names

### DIFF
--- a/docs/generators/mysql-schema.md
+++ b/docs/generators/mysql-schema.md
@@ -7,3 +7,4 @@ sidebar_label: mysql-schema
 | ------ | ----------- | ------ | ------- |
 |defaultDatabaseName|Default database name for all MySQL queries| ||
 |jsonDataTypeEnabled|Use special JSON MySQL data type for complex model properties. Requires MySQL version 5.7.8. Generates TEXT data type when disabled| |true|
+|identifierNamingConvention|Naming convention of MySQL identifiers(table names and column names). This is not related to database name which is defined by defaultDatabaseName option|<dl><dt>**original**</dt><dd>Do not transform original names</dd><dt>**snake_case**</dt><dd>Use snake_case names</dd><dl>|original|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/MysqlSchemaCodegen.java
@@ -226,10 +226,17 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             Map<String, Object> mo = (Map<String, Object>) _mo;
             CodegenModel model = (CodegenModel) mo.get("model");
             String modelName = model.getName();
+            String tableName = this.toTableName(modelName);
             String modelDescription = model.getDescription();
             Map<String, Object> modelVendorExtensions = model.getVendorExtensions();
             Map<String, Object> mysqlSchema = new HashMap<String, Object>();
             Map<String, Object> tableDefinition = new HashMap<String, Object>();
+
+            if (this.getIdentifierNamingConvention().equals("snake_case") && !modelName.equals(tableName)) {
+                // add original name in table comment
+                String commentExtra = "Original model name - " + modelName + ".";
+                modelDescription = (modelDescription == null || modelDescription.isEmpty()) ? commentExtra : modelDescription + ". " + commentExtra;
+            }
 
             if (modelVendorExtensions.containsKey(CODEGEN_VENDOR_EXTENSION_KEY)) {
                 // user already specified schema values
@@ -238,7 +245,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             } else {
                 modelVendorExtensions.put(CODEGEN_VENDOR_EXTENSION_KEY, mysqlSchema);
                 mysqlSchema.put("tableDefinition", tableDefinition);
-                tableDefinition.put("tblName", toTableName(modelName));
+                tableDefinition.put("tblName", tableName);
                 tableDefinition.put("tblComment", modelDescription);
             }
         }
@@ -289,6 +296,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
         Map<String, Object> columnDefinition = new HashMap<String, Object>();
         ArrayList columnDataTypeArguments = new ArrayList();
         String baseName = property.getBaseName();
+        String colName = this.toColumnName(baseName);
         String dataType = property.getDataType();
         String dataFormat = property.getDataFormat();
         String description = property.getDescription();
@@ -308,9 +316,15 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
+        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+            // add original name in column comment
+            String commentExtra = "Original param name - " + baseName + ".";
+            description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
+        }
+
         vendorExtensions.put(CODEGEN_VENDOR_EXTENSION_KEY, mysqlSchema);
         mysqlSchema.put("columnDefinition", columnDefinition);
-        columnDefinition.put("colName", toColumnName(baseName));
+        columnDefinition.put("colName", colName);
 
         if (Boolean.TRUE.equals(isEnum)) {
             Map<String, Object> allowableValues = property.getAllowableValues();
@@ -370,6 +384,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
         Map<String, Object> columnDefinition = new HashMap<String, Object>();
         ArrayList columnDataTypeArguments = new ArrayList();
         String baseName = property.getBaseName();
+        String colName = this.toColumnName(baseName);
         String dataType = property.getDataType();
         String dataFormat = property.getDataFormat();
         String description = property.getDescription();
@@ -388,9 +403,15 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
+        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+            // add original name in column comment
+            String commentExtra = "Original param name - " + baseName + ".";
+            description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
+        }
+
         vendorExtensions.put(CODEGEN_VENDOR_EXTENSION_KEY, mysqlSchema);
         mysqlSchema.put("columnDefinition", columnDefinition);
-        columnDefinition.put("colName", toColumnName(baseName));
+        columnDefinition.put("colName", colName);
 
         if (Boolean.TRUE.equals(isEnum)) {
             Map<String, Object> allowableValues = property.getAllowableValues();
@@ -449,6 +470,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
         Map<String, Object> columnDefinition = new HashMap<String, Object>();
         ArrayList columnDataTypeArguments = new ArrayList();
         String baseName = property.getBaseName();
+        String colName = this.toColumnName(baseName);
         String description = property.getDescription();
         String defaultValue = property.getDefaultValue();
         Boolean required = property.getRequired();
@@ -459,9 +481,15 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
+        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+            // add original name in column comment
+            String commentExtra = "Original param name - " + baseName + ".";
+            description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
+        }
+
         vendorExtensions.put(CODEGEN_VENDOR_EXTENSION_KEY, mysqlSchema);
         mysqlSchema.put("columnDefinition", columnDefinition);
-        columnDefinition.put("colName", toColumnName(baseName));
+        columnDefinition.put("colName", colName);
         columnDefinition.put("colDataType", "TINYINT");
         columnDefinition.put("colDataTypeArguments", columnDataTypeArguments);
         columnDataTypeArguments.add(toCodegenMysqlDataTypeArgument(1, false));
@@ -495,6 +523,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
         Map<String, Object> columnDefinition = new HashMap<String, Object>();
         ArrayList columnDataTypeArguments = new ArrayList();
         String baseName = property.getBaseName();
+        String colName = this.toColumnName(baseName);
         String dataType = property.getDataType();
         String dataFormat = property.getDataFormat();
         String description = property.getDescription();
@@ -510,9 +539,15 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
+        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+            // add original name in column comment
+            String commentExtra = "Original param name - " + baseName + ".";
+            description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
+        }
+
         vendorExtensions.put(CODEGEN_VENDOR_EXTENSION_KEY, mysqlSchema);
         mysqlSchema.put("columnDefinition", columnDefinition);
-        columnDefinition.put("colName", toColumnName(baseName));
+        columnDefinition.put("colName", colName);
 
         if (Boolean.TRUE.equals(isEnum)) {
             Map<String, Object> allowableValues = property.getAllowableValues();
@@ -566,6 +601,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
         Map<String, Object> mysqlSchema = new HashMap<String, Object>();
         Map<String, Object> columnDefinition = new HashMap<String, Object>();
         String baseName = property.getBaseName();
+        String colName = this.toColumnName(baseName);
         String dataType = property.getDataType();
         Boolean required = property.getRequired();
         String description = property.getDescription();
@@ -577,9 +613,15 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
+        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+            // add original name in column comment
+            String commentExtra = "Original param name - " + baseName + ".";
+            description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
+        }
+
         vendorExtensions.put(CODEGEN_VENDOR_EXTENSION_KEY, mysqlSchema);
         mysqlSchema.put("columnDefinition", columnDefinition);
-        columnDefinition.put("colName", toColumnName(baseName));
+        columnDefinition.put("colName", colName);
         columnDefinition.put("colDataType", dataType);
 
         if (Boolean.TRUE.equals(required)) {
@@ -610,6 +652,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
         Map<String, Object> mysqlSchema = new HashMap<String, Object>();
         Map<String, Object> columnDefinition = new HashMap<String, Object>();
         String baseName = property.getBaseName();
+        String colName = this.toColumnName(baseName);
         String dataType = property.getDataType();
         Boolean required = property.getRequired();
         String description = property.getDescription();
@@ -621,9 +664,15 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
+        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+            // add original name in column comment
+            String commentExtra = "Original param name - " + baseName + ".";
+            description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
+        }
+
         vendorExtensions.put(CODEGEN_VENDOR_EXTENSION_KEY, mysqlSchema);
         mysqlSchema.put("columnDefinition", columnDefinition);
-        columnDefinition.put("colName", toColumnName(baseName));
+        columnDefinition.put("colName", colName);
         columnDefinition.put("colDataType", dataType);
         if (Boolean.FALSE.equals(getJsonDataTypeEnabled())) {
             columnDefinition.put("colDataType", "TEXT");
@@ -658,6 +707,7 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
         Map<String, Object> mysqlSchema = new HashMap<String, Object>();
         Map<String, Object> columnDefinition = new HashMap<String, Object>();
         String baseName = property.getBaseName();
+        String colName = this.toColumnName(baseName);
         Boolean required = property.getRequired();
         String description = property.getDescription();
         String defaultValue = property.getDefaultValue();
@@ -668,9 +718,15 @@ public class MysqlSchemaCodegen extends DefaultCodegen implements CodegenConfig 
             return;
         }
 
+        if (this.getIdentifierNamingConvention().equals("snake_case") && !baseName.equals(colName)) {
+            // add original name in column comment
+            String commentExtra = "Original param name - " + baseName + ".";
+            description = (description == null || description.isEmpty()) ? commentExtra : description + ". " + commentExtra;
+        }
+
         vendorExtensions.put(CODEGEN_VENDOR_EXTENSION_KEY, mysqlSchema);
         mysqlSchema.put("columnDefinition", columnDefinition);
-        columnDefinition.put("colName", toColumnName(baseName));
+        columnDefinition.put("colName", colName);
         columnDefinition.put("colDataType", "TEXT");
 
         if (Boolean.TRUE.equals(required)) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/mysql/MysqlSchemaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/mysql/MysqlSchemaCodegenTest.java
@@ -274,4 +274,24 @@ public class MysqlSchemaCodegenTest {
         Assert.assertFalse(codegen.getJsonDataTypeEnabled());
     }
 
+    @Test
+    public void testSetIdentifierNamingConvention() {
+        final MysqlSchemaCodegen codegen = new MysqlSchemaCodegen();
+        Assert.assertSame("original", codegen.getIdentifierNamingConvention());
+        codegen.setIdentifierNamingConvention("invalidValue");
+        Assert.assertSame("original", codegen.getIdentifierNamingConvention());
+        codegen.setIdentifierNamingConvention("snake_case");
+        Assert.assertSame("snake_case", codegen.getIdentifierNamingConvention());
+        codegen.setIdentifierNamingConvention("anotherInvalid");
+        Assert.assertSame("snake_case", codegen.getIdentifierNamingConvention());
+    }
+
+    @Test
+    public void testGetIdentifierNamingConvention() {
+        final MysqlSchemaCodegen codegen = new MysqlSchemaCodegen();
+        Assert.assertSame("original", codegen.getIdentifierNamingConvention());
+        codegen.setIdentifierNamingConvention("snake_case");
+        Assert.assertSame("snake_case", codegen.getIdentifierNamingConvention());
+    }
+
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/mysql/MysqlSchemaOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/mysql/MysqlSchemaOptionsTest.java
@@ -45,6 +45,8 @@ public class MysqlSchemaOptionsTest extends AbstractOptionsTest {
             times = 1;
             clientCodegen.setJsonDataTypeEnabled(Boolean.valueOf(MysqlSchemaOptionsProvider.JSON_DATA_TYPE_ENABLED_VALUE));
             times = 1;
+            clientCodegen.setIdentifierNamingConvention(MysqlSchemaOptionsProvider.IDENTIFIER_NAMING_CONVENTION_VALUE);
+            times = 1;
         }};
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/MysqlSchemaOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/MysqlSchemaOptionsProvider.java
@@ -24,6 +24,7 @@ import java.util.Map;
 public class MysqlSchemaOptionsProvider implements OptionsProvider {
     public static final String DEFAULT_DATABASE_NAME_VALUE = "database_name";
     public static final String JSON_DATA_TYPE_ENABLED_VALUE = "false";
+    public static final String IDENTIFIER_NAMING_CONVENTION_VALUE = "snake_case";
 
     @Override
     public String getLanguage() {
@@ -35,6 +36,7 @@ public class MysqlSchemaOptionsProvider implements OptionsProvider {
         ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<String, String>();
         return builder.put(MysqlSchemaCodegen.DEFAULT_DATABASE_NAME, DEFAULT_DATABASE_NAME_VALUE)
             .put(MysqlSchemaCodegen.JSON_DATA_TYPE_ENABLED, JSON_DATA_TYPE_ENABLED_VALUE)
+            .put(MysqlSchemaCodegen.IDENTIFIER_NAMING_CONVENTION, IDENTIFIER_NAMING_CONVENTION_VALUE)
             .build();
     }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [ ] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

Output with `-p identifierNamingConvention=snake_case`
```sql
--
-- Table structure for table `file` generated from model 'File'
-- Must be named &#x60;File&#x60; for test.
--

CREATE TABLE IF NOT EXISTS `file` (
  `source_uri` TEXT DEFAULT NULL COMMENT 'Test capitalization. Original param name - sourceURI.'
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Must be named &#x60;File&#x60; for test.. Original model name - File.';
```

Closes #3503