### PR TITLE
[rust][client] avoid enum name conflict

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -569,6 +569,7 @@ public class RustClientCodegen extends DefaultCodegen implements CodegenConfig {
 
         // remove [] for array or map of enum
         enumName = enumName.replace("[]", "");
+        enumName = enumName + "Enum";
 
         if (enumName.matches("\\d.*")) { // starts with number
             return "_" + enumName;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) before.
- [x] Run the shell script(s) under `./bin/` (or Windows batch scripts under`.\bin\windows`) to update Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit, and these must match the expectations made by your contribution. You only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the code or mustache templates for a language (`{LANG}`) (e.g. php, ruby, python, etc).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.3.x`, `5.0.x`. Default: `master`.
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### PR description

The current implementation generates conflicting name for an enum and its containing schema.

```
openapi: 3.0.0

info:
  title: a
  version: 1.0.0
  description: ""

paths:
  /:
    get:
      responses:
        "200":
          description: ""
          content:
            application/json:
              schema:
                type: string
components:
  schemas:
    Behaviour:
      type: object
      properties:
        behaviour:
          type: string
          enum:
            - naughty
            - nice
      required:
        - behaviour

```


```
#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
pub struct Behaviour {
    #[serde(rename = "behaviour")]
    pub behaviour: Behaviour,
}

impl Behaviour {
    pub fn new(behaviour: Behaviour) -> Behaviour {
        Behaviour {
            behaviour,
        }
    }
}

/// 
#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
pub enum Behaviour {
    #[serde(rename = "naughty")]
    Naughty,
    #[serde(rename = "nice")]
    Nice,
}
```

versus
```
#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
pub struct Behaviour {
    #[serde(rename = "behaviour")]
    pub behaviour: BehaviourEnum,
}

impl Behaviour {
    pub fn new(behaviour: BehaviourEnum) -> Behaviour {
        Behaviour {
            behaviour,
        }
    }
}

/// 
#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
pub enum BehaviourEnum {
    #[serde(rename = "naughty")]
    Naughty,
    #[serde(rename = "nice")]
    Nice,
}
```

cc: @frol, @farcaller, @bjgill, @richardwhiuk


